### PR TITLE
verify: Set TMPDIR to /build/tmp inside the container

### DIFF
--- a/verify/cockpit-verify.service
+++ b/verify/cockpit-verify.service
@@ -7,7 +7,7 @@ After=docker.service libvirtd.service
 Environment="TEST_OS=fedora-testing fedora-atomic"
 Restart=always
 RestartSec=60
-ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-verify --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/verify:/build:rw --net=host --pid=host --privileged --env=TEST_OS=\"$TEST_OS\" cockpit/infra-verify"
+ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-verify --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/verify:/build:rw --net=host --pid=host --privileged --env=TEST_OS=\"$TEST_OS\" --env=TMPDIR=/build/tmp cockpit/infra-verify"
 ExecStop=-/bin/sh -xc "/usr/bin/docker rm -f cockpit-verify"
 
 [Install]


### PR DESCRIPTION
So that tools/make-srpm has enough space.

Fixes #10