### PR TITLE
verify: Fetch the current origin/master before starting

### DIFF
--- a/verify/cockpit-verify
+++ b/verify/cockpit-verify
@@ -19,7 +19,8 @@ echo "Starting testing of $TEST_OS"
 while true; do
     fail=0
     for os in $TEST_OS; do
-        git -C cockpit reset --hard origin/master
+        git -C cockpit fetch origin master
+        git -C cockpit reset --hard FETCH_HEAD
         if ! TEST_OS=$os cockpit/test/check-verify --install --rebase "$@"; then
             fail=1
         fi

--- a/verify/cockpit-verify
+++ b/verify/cockpit-verify
@@ -19,8 +19,8 @@ echo "Starting testing of $TEST_OS"
 while true; do
     fail=0
     for os in $TEST_OS; do
-	    git -C cockpit reset --hard origin/master
-	    if ! TEST_OS=$os cockpit/test/check-verify --install --rebase "$@"; then
+        git -C cockpit reset --hard origin/master
+        if ! TEST_OS=$os cockpit/test/check-verify --install --rebase "$@"; then
             fail=1
         fi
     done


### PR DESCRIPTION
Normally, check-verify updates our local repo, but if it doesn't
because it is buggy, we would get stuck with that buggy master.