### PR TITLE
sink: Create log directories in a collision free way

### DIFF
--- a/sink/sink
+++ b/sink/sink
@@ -303,6 +303,34 @@ class Buffer(object):
         result += os.read(self.fd, 1024)
         return result
 
+# Create the directory in a race free way
+def mkdir_and_chdir(base, identifier):
+    directory = os.path.abspath(os.path.join(base, identifier))
+
+    # 1. Create a temporary non-empty directory and get its handle
+    tempdir = tempfile.mkdtemp(prefix=identifier, dir=base)
+    os.close(os.open(os.path.join(tempdir, ".sink"), os.O_WRONLY | os.O_CREAT))
+    dirfd = os.open(tempdir, os.O_RDONLY)
+
+    # 2. Rename directory into place
+    while True:
+        try:
+            os.rename(tempdir, directory)
+            break
+        except OSError as ex:
+            # 3. If that raced, then move the target into our directory
+            if ex.errno != errno.EEXIST and ex.errno != errno.ENOTEMPTY:
+                raise
+            try:
+                os.rename(directory, tempfile.mkdtemp(prefix="backup.", dir=tempdir))
+            except OSError as ex:
+                if ex.errno != errno.ENOENT:
+                    raise
+
+    os.fchdir(dirfd)
+    os.fchmod(dirfd, 0o755)
+    os.close(dirfd)
+
 def main():
     parser = argparse.ArgumentParser(description="Sink logs from distributed processes")
     parser.add_argument("identifier", nargs=1)
@@ -323,19 +351,9 @@ def main():
     config.readfp(StringIO.StringIO(DEFAULTS))
     config.read([ os.path.expanduser("~/.config/sink") ])
 
-    # Create the right directory
+    # Create the directory and chdir
     logs = os.path.expanduser(config.get("Sink", "Logs"))
-    directory = os.path.join(logs, identifier)
-    if os.path.exists(directory):
-        files = os.listdir(directory)
-        dest = tempfile.mkdtemp(prefix='backup.', dir=directory)
-        os.chmod(dest, 0o755)
-        for filename in files:
-            if not filename.startswith("backup."):
-                shutil.move(os.path.join(directory, filename), dest)
-    else:
-        os.makedirs(directory)
-    os.chdir(directory)
+    mkdir_and_chdir(logs, identifier)
 
     # Initialize status reporters
     status = Status(config, identifier)


### PR DESCRIPTION
This means if two sinks start logging to a certain directory,
the earlier one will end up as a backup.XXXX directory, and won't
continue to log to the main directory or overwrite files there