### PR TITLE
release-debian: also publish to ubuntu ppa

### DIFF
--- a/release/cockpit-script
+++ b/release/cockpit-script
@@ -29,5 +29,6 @@ job release-bodhi F24
 # Upload documentation
 job release-guide doc/guide/html cockpit-project/cockpit-project.github.io
 
-# Create and publish a Debian repository
+# Create and publish a Debian repository and Ubuntu PPA
 job release-debian
+job release-ubuntu-ppa

--- a/release/release-debian
+++ b/release/release-debian
@@ -85,8 +85,7 @@ Description: Apt repository for Cockpit
 SignWith: default
 EOF
 
-    installed=$(reprepro -b $DEBIAN_REPO --list-format='${Package}' listfilter unstable "Package(==cockpit),\$Version(==$TAG)")
-    if [ "x$installed" != "xcockpit" ]; then
+    if [ -z "$(reprepro --silent -b $DEBIAN_REPO listfilter unstable \$Version\(==$TAG\))" ]; then
 
         # build source package
         rm -rf debian-tmp; mkdir debian-tmp

--- a/release/release-ubuntu-ppa
+++ b/release/release-ubuntu-ppa
@@ -1,0 +1,120 @@
+#!/bin/bash -eu
+#
+# release-ubuntu-ppa
+#
+# A release script that publishes packages to an ubuntu ppa on launchpad.
+#
+# Depends on a source package built by release-debian.
+#
+# Arguments are described here. Most arguments have an equivalent envvar.
+#
+# -q         RELEASE_QUIET=1            Make output more quiet
+# -x         RELEASE_TRANSACTION=1      SIGSTOP before pushing the dist-git commit
+# -v         RELEASE_VERBOSE=1          Make output more verbose
+# -z         RELEASE_CHECK=1            Check credentials only
+#
+
+set -eu
+
+TRANSACTION=${RELEASE_TRANSACTION:-0}
+CHECK=${RELEASE_CHECK:-0}
+QUIET=${RELEASE_QUIET:-0}
+VERBOSE=${RELEASE_VERBOSE:-0}
+
+TAG=${RELEASE_TAG:-$(git describe --abbrev=0)}
+
+usage()
+{
+    echo "usage: release-ubuntu-ppa [-qvxz] [-t tag]" >&2
+    exit ${1-2}
+}
+
+trace()
+{
+    if [ $QUIET -eq 0 ]; then
+        echo "> $@" >&2
+    fi
+}
+
+message()
+{
+    echo "release-ubuntu-ppa: $@" >&2
+}
+
+check()
+{
+    sftp -o StrictHostKeyChecking=no -b - cockpit-project@ppa.launchpad.net <<EOF
+bye
+EOF
+}
+
+prepare()
+{
+    true
+}
+
+commit()
+(
+    trace "Publishing Ubuntu PPA"
+
+    # upload files manually as there's no dput on fedora
+    sftp -o StrictHostKeyChecking=no -b - cockpit-project@ppa.launchpad.net <<EOF
+put cockpit_${TAG}-0_source.changes ~cockpit-project/cockpit/ubuntu/xenial/cockpit_${TAG}-0_source.changes
+put cockpit_${TAG}-0.dsc            ~cockpit-project/cockpit/ubuntu/xenial/cockpit_${TAG}-0.dsc
+put cockpit_${TAG}-0.debian.tar.xz  ~cockpit-project/cockpit/ubuntu/xenial/cockpit_${TAG}-0.debian.tar.xz
+put cockpit_${TAG}.orig.tar.xz      ~cockpit-project/cockpit/ubuntu/xenial/cockpit_${TAG}.orig.tar.xz
+EOF
+)
+
+while getopts "t:qvxz" opt; do
+    case "$opt" in
+    t)
+        TAG="$OPTARG"
+        ;;
+    q)
+        QUIET=1
+        VERBOSE=0
+        ;;
+    v)
+        QUIET=0
+        VERBOSE=1
+        ;;
+    x)
+        TRANSACTION=1
+        ;;
+    z)
+        CHECK=1
+        ;;
+    -)
+        break
+        ;;
+    *)
+        usage
+        ;;
+    esac
+done
+
+shift $(expr $OPTIND - 1)
+
+if [ $# -ne 0 ]; then
+    usage
+fi
+
+if [ $CHECK -eq 1 ]; then
+    check "$1"
+    exit 0
+fi
+
+if [ -z "$TAG" ]; then
+    message "could not find a tag to release"
+    exit 2
+fi
+
+prepare
+
+if [ $TRANSACTION -eq 1 ]; then
+    kill -STOP $$
+fi
+
+commit
+


### PR DESCRIPTION
Publish debian source package to a [ppa on launchpad][1].

I've added the public ssh (for uploading packages via sftp) and pgp (for verifying the signed packages) keys to the launchpad user *cockpit-project*.

@stefwalter, please validate the pgp key by decrypting the email launchpad sent to cockpituous@gmail.com and following the link inside.

Launchpad will send an email every time new packages are uploaded to signal whether the upload was accepted. It will also notify about build failures.

[1]: https://launchpad.net/~cockpit-project/+archive/ubuntu/cockpit