### PR TITLE
verify: Default number of jobs to env variable or nproc

### DIFF
--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -33,4 +33,4 @@ VOLUME /build
 USER user
 WORKDIR /build
 ENTRYPOINT ["/usr/local/bin/cockpit-verify"]
-CMD ["--publish=fedorapeople.org", "--verbose", "--jobs=4"]
+CMD ["--publish=fedorapeople.org", "--verbose", "--jobs=${TEST_JOBS:-`nproc`}"]


### PR DESCRIPTION
Hardcoding to 4 excludes weaker test runners and doesn't fully utilize
powerful machines.
To override nproc, set TEST_JOBS on the runner.