### PR TITLE
verify: Don't specify default number of jobs in Dockerfile

### DIFF
--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -33,4 +33,4 @@ VOLUME /build
 USER user
 WORKDIR /build
 ENTRYPOINT ["/usr/local/bin/cockpit-verify"]
-CMD ["--publish=fedorapeople.org", "--verbose", "--jobs=${TEST_JOBS:-`nproc`}"]
+CMD ["--publish=fedorapeople.org", "--verbose"]

--- a/verify/cockpit-verify.service
+++ b/verify/cockpit-verify.service
@@ -5,9 +5,10 @@ After=docker.service libvirtd.service
 
 [Service]
 Environment="TEST_OS=fedora-testing fedora-atomic"
+Environment="TEST_JOBS=4"
 Restart=always
 RestartSec=60
-ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-verify --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/verify:/build:rw --net=host --pid=host --privileged --env=TEST_OS=\"$TEST_OS\" cockpit/infra-verify"
+ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-verify --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/verify:/build:rw --net=host --pid=host --privileged --env=TEST_OS=\"$TEST_OS\" --env=TEST_JOBS=\"$TEST_JOBS\" cockpit/infra-verify"
 ExecStop=-/bin/sh -xc "/usr/bin/docker rm -f cockpit-verify"
 
 [Install]


### PR DESCRIPTION
We set an environment variable in the systemd service file that
runs the container instead. This way the environment and the
test code itself can decide how many jobs to run in parallel,
without changing the container.