### PR TITLE
Dockerfiles: Remove yum remnants

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -55,7 +55,7 @@ throttleit \
 tough-cookie \
 yauzl \
     && \
-    yum-builddep -y /tmp/cockpit.spec && \
+    dnf -y builddep /tmp/cockpit.spec && \
     dnf clean all
 
 RUN mkdir -p /usr/local/bin /home/user /build/rpmbuild

--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -41,10 +41,9 @@ RUN dnf -y update && \
         sudo \
         tar \
         virt-install \
-        yum-utils \
         && \
     npm -g install phantomjs-prebuilt && \
-    yum-builddep -y /tmp/cockpit.spec && \
+    dnf -y builddep /tmp/cockpit.spec && \
     dnf clean all
 
 RUN mkdir -p /usr/local/bin /home/user /build


### PR DESCRIPTION
We use Fedora 24+ images and use of yum there is deprecated. In our
other scripts we can still use yum to maintain compatibility with
yum-based distros.