### PR TITLE
release-debian: generate empty i386 Packages file

### DIFF
--- a/release/release-debian
+++ b/release/release-debian
@@ -82,7 +82,7 @@ EOF
 Origin: Cockpit
 Label: Cockpit
 Codename: unstable
-Architectures: source amd64
+Architectures: source amd64 i386
 Components: main
 Description: Apt repository for Cockpit
 SignWith: default
@@ -105,6 +105,9 @@ EOF
           debuild -S
         )
         reprepro -b $DEBIAN_REPO includedsc unstable cockpit_$debversion.dsc
+
+        # also export package listings for empty architectures
+        reprepro -b $DEBIAN_REPO export
 
         # build binary package
         sudo pbuilder clean


### PR DESCRIPTION
`apt-get update` tries to find package listings for all architectures on
multi-arch systems. (It probably shouldn't do that when the repository
only advertises one architecture.)

To work around this in the most common case of having i386 configured on
an amd64 system, generate an empty Packages file for i386.