### PR TITLE
release: Use a distribution specific basetgz for pbuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,17 @@ release-shell: docker-running
 		--volume=$(CURDIR)/release:/usr/local/bin \
 		--entrypoint=/bin/bash cockpit/infra-release
 
+TAG := cockpit/infra-release:$(shell date --iso-8601)
 release-container: docker-running
 	docker build -t cockpit/infra-release:staged release
 	docker rm -f cockpit-release-stage || true
 	docker run --privileged --name=cockpit-release-stage \
 		--entrypoint=/usr/local/bin/Dockerfile.sh cockpit/infra-release:staged
 	docker commit --change='ENTRYPOINT ["/usr/local/bin/release-runner"]' \
-		cockpit-release-stage cockpit/infra-release
+		cockpit-release-stage $(TAG)
+	docker tag $(TAG) cockpit/infra-release:latest
 	docker rm -f cockpit-release-stage
+	@true
 
 release-install: release-container
 	cp release/cockpit-release.service /etc/systemd/system/

--- a/release/Dockerfile.sh
+++ b/release/Dockerfile.sh
@@ -7,4 +7,5 @@ BUILD_DEPENDS="debhelper dh-autoreconf autoconf automake intltool libssh-dev lib
                libjson-glib-dev libpam0g-dev libpcp-import1-dev libpcp-pmda3-dev xsltproc xmlto docbook-xsl
                glib-networking nodejs-legacy npm openssh-client"
 
-sudo pbuilder create --distribution unstable --extrapackages "$BUILD_DEPENDS"
+sudo pbuilder create --distribution jessie --basetgz /var/cache/pbuilder/jessie.tgz --extrapackages "$BUILD_DEPENDS"
+sudo pbuilder create --distribution unstable --basetgz /var/cache/pbuilder/unstable.tgz --extrapackages "$BUILD_DEPENDS"

--- a/release/release-debian
+++ b/release/release-debian
@@ -59,7 +59,7 @@ changelog_lines()
 
 prepare()
 {
-    local installed
+    local installed basetgz
     local debversion="$TAG-0"
 
     trace "Creating Debian repository"
@@ -99,11 +99,11 @@ EOF
         reprepro -b $DEBIAN_REPO includedsc unstable cockpit_$debversion.dsc
 
         # build binary package
-        sudo pbuilder clean
-        sudo pbuilder update --configfile pbuilderrc --distribution unstable
-        sudo pbuilder build --configfile pbuilderrc \
-                            --hookdir /etc/pbuilder/hooks \
-                            cockpit_$debversion.dsc
+        basetgz=/var/cache/pbuilder/unstable.tgz
+        sudo pbuilder clean --distribution unstable --basetgz $basetgz
+        sudo pbuilder update --configfile pbuilderrc --distribution unstable --basetgz $basetgz
+        sudo pbuilder build --configfile pbuilderrc --distribution unstable --basetgz $basetgz \
+                            --hookdir /etc/pbuilder/hooks cockpit_$debversion.dsc
 
         reprepro -b $DEBIAN_REPO includedeb unstable /var/cache/pbuilder/result/*.deb
     else


### PR DESCRIPTION
Use a distribution specific basetgz as a pbuilder cache. This will be followed up by work on building on various distributions.
