### PR TITLE
sink: Remove badge support from sink

### DIFF
--- a/sink/sink
+++ b/sink/sink
@@ -15,34 +15,9 @@ PruneInterval: 0
 Server: chat.freenode.net:6667
 Login: %(user)sbot %(user)sbot %(user)sbot
 Nick: %(user)sbot
-
-[Badges]
-Location: ~/public_html/status/
 """
 
 TOKEN = "~/.config/github-token"
-
-BADGE_TEMPLATE = u"""\
-<svg xmlns="http://www.w3.org/2000/svg" width="220" height="20">
-  <linearGradient id="b" x2="0" y2="100%">
-    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
-    <stop offset="1" stop-opacity=".1"/>
-  </linearGradient>
-  <mask id="a">
-    <rect width="220" height="20" rx="3" fill="#fff"/>
-  </mask>
-  <g mask="url(#a)">
-    <path fill="#555" d="M0 0h150v20H0z"/>
-    <path fill="{color}" d="M150 0h70v20h-70z"/>
-  </g>
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="75" y="15" fill="#010101" fill-opacity=".3">{description}</text>
-    <text x="75" y="14">{description}</text>
-    <text x="185" y="15" fill="#010101" fill-opacity=".3">{status}</text>
-    <text x="185" y="14">{status}</text>
-  </g>
-</svg>
-"""
 
 import argparse
 import errno
@@ -289,32 +264,6 @@ def write_new(path, content):
     with open(path, 'wb') as f:
         f.write(content)
 
-class Badger(object):
-    def __init__(self, config):
-        self.location = os.path.expanduser(config.get("Badges", "Location"))
-        self.template = BADGE_TEMPLATE
-        self.colors = { 'passed': '#44cc11',
-                        'failed': '#e05d44' }
-        if not os.path.exists(self.location):
-            os.makedirs(self.location)
-
-    def push(self, data):
-        if 'badge' in data and 'name' in data['badge']:
-            badge = data['badge']
-            name = badge['name']
-            description = badge.get('description', "unknown")
-            status = badge.get('status', 'unknown')
-            status_text = badge.get('status-text', status)
-            if status in self.colors:
-                color = self.colors[status]
-            else:
-                color = '#9f9f9f'
-            content = self.template.format(description=description, status=status_text, color=color)
-            write_new(os.path.join(self.location, name + ".svg"),
-                      content)
-            write_new(os.path.join(self.location, name + ".html"),
-                      '<html><head><meta http-equiv="refresh" content="0; {url}"></head></html>'.format(url=data['link']))
-
 class Extras(object):
     def __init__(self, config):
         pass
@@ -326,7 +275,7 @@ class Extras(object):
 
 class Status(object):
     def __init__(self, config, identifier):
-        self.reporters = [ GitHubClassic(config), GitHub(config), Irc(config), Badger(config), Extras(config) ]
+        self.reporters = [ GitHubClassic(config), GitHub(config), Irc(config), Extras(config) ]
         self.link = config.get("Sink", "Url").replace('@@', identifier)
         self.data = None
 
@@ -373,8 +322,6 @@ class Status(object):
                 if "github" in data and "status" in data["github"]:
                     data["github"]["status"]["state"] = "error"
                     data["github"]["status"]["description"] = "Aborted without status"
-                    if "badge" in data:
-                        data["badge"]["status"] = "error"
         self.push(data, log)
         with open("status", "w") as fp:
             clean_data = data


### PR DESCRIPTION
This is a workaround for the fact that there was no service hosting
image badges for specific github statuses. We no longer use this.

If anyone ever does need this again, the correct way to solve this
is to host a service that looks up the GitHub status for master
and produces an image based on it.