### PR TITLE
release-koji: fix git ls-tree invocation

### DIFF
--- a/release/release-koji
+++ b/release/release-koji
@@ -142,7 +142,7 @@ prepare()
 
         # Remove all the old patches
         # TODO: We would like to read this from the old spec file, but rpm comes back empty
-        git -C $WORKDIR ls-tree HEAD | grep '.patch$' | xargs --no-run-if-empty git -C $WORKDIR rm -f
+        git -C $WORKDIR ls-tree --name-only HEAD | grep '.patch$' | xargs --no-run-if-empty git -C $WORKDIR rm -f
 
         # Extract the source RPM
         set +f


### PR DESCRIPTION
git ls-tree prints multiple tabs by default, and the current
invocation assumed that only the file name is present. Ensure
that only the file name is present by appending --name-only.