### PR TITLE
release-debian: Remove PCP build dependencies while pcp is not in testing

### DIFF
--- a/release/release-debian
+++ b/release/release-debian
@@ -121,6 +121,11 @@ EOF
         dpkg-source --extract $DSC $distribution
         sed -i "s/$TAG-0/$TAG-0~$distribution/" $distribution/debian/changelog
         sed -i "s/experimental/$distribution/" $distribution/debian/changelog
+        # Hack: Remove PCP build dependencies while pcp is not in testing
+        # (https://tracker.debian.org/pcp)
+        if [ "$distribution" = unstable ]; then
+            sed -i '/libpcp.*-dev/d' $distribution/debian/control
+        fi
         dpkg-source --build $distribution
         )
 

--- a/release/release-ubuntu-ppa
+++ b/release/release-ubuntu-ppa
@@ -4,7 +4,7 @@
 #
 # HACK: This script is very Cockpit specific
 #
-# Depends on a source package built by release-debian.
+# Depends on a source package built by release-dsc
 #
 # Arguments are described here. Most arguments have an equivalent envvar.
 #


### PR DESCRIPTION
pcp has release-critical bugs and fell out of testing, see https://tracker.debian.org/pkg/pcp. Drop the pcp build dependencies when building for unstable so that the package can be used on testing/stretch.
    
This requires https://github.com/cockpit-project/cockpit/pull/5726 so that the package actually builds without these build dependencies.
