### PR TITLE
release: Don't clean dsc source package

### DIFF
--- a/release/release-dsc
+++ b/release/release-dsc
@@ -106,7 +106,7 @@ prepare()
     sed -i -e '/Package: cockpit-test-assets/,/^$/d' $WORKDIR/build/debian/control
 
     # Perform the actual build
-    ( cd $WORKDIR/build && debuild -S )
+    ( cd $WORKDIR/build && debuild -S -nc -d)
 
     trace "Copying Debian source build"
 


### PR DESCRIPTION
With the addition of the dh-systemd build dependency we cannot run the
clean target under Fedora any more, as dh-systemd is not packaged and
debhelper is too old (dh_systemd got merged in 10.1 only). However,
there is no need for it -- we create a clean source anyway, so there is
nothing to clean. So skip cleaning (-nc), and also use -d to skip the
build dependency check to avoid some noise.