### PR TITLE
release-koji: corrected the way patches are being added

### DIFF
--- a/release/release-koji
+++ b/release/release-koji
@@ -73,6 +73,13 @@ spec_variables()
     rpm -q --specfile --queryformat="[%{$1}\n]" --undefine dist "$2"
 }
 
+# Get all patches from spec file
+#  $1: The spec file
+spec_patches()
+{
+    cat $1|grep ^Patch|cut -d ':' -f 2|sed "s/^[ \t]*//"
+}
+
 # Get the specified variable name from a source rpm
 #  $1: The name of the variable
 #  $2: The source rpm file
@@ -152,7 +159,7 @@ prepare()
         set -f
 
         # Add in all the new patches
-        spec_variables PATCH $spec | while read patch; do
+        spec_patches $spec | while read patch; do
             git -C $WORKDIR add -f $patch
         done
 

--- a/release/release-koji
+++ b/release/release-koji
@@ -80,6 +80,13 @@ spec_patches()
     cat $1|grep ^Patch|cut -d ':' -f 2|sed "s/^[ \t]*//"
 }
 
+# Get all patches from spec file
+#  $1: The spec file
+spec_sources()
+{
+    cat $1|grep ^Source|cut -d ':' -f 2|sed "s/^[ \t]*//"|grep -v ^"ftp://"|grep -v ^"http://"
+}
+
 # Get the specified variable name from a source rpm
 #  $1: The name of the variable
 #  $2: The source rpm file
@@ -161,6 +168,11 @@ prepare()
         # Add in all the new patches
         spec_patches $spec | while read patch; do
             git -C $WORKDIR add -f $patch
+        done
+
+	# Add in all additional files
+        spec_sources $spec | while read source; do
+            test -f "$WORKDIR/$source" && git -C $WORKDIR add -f $source
         done
 
         # The release number in old notes


### PR DESCRIPTION
Previously 'rpm -q --specfile --queryformat' was used, but this
command does not list the patches in the spec file. The current
approach uses cut and sed.