### PR TITLE
release: No longer build Fedora 24 releases in Koji

### DIFF
--- a/release/major-cockpit-release
+++ b/release/major-cockpit-release
@@ -17,7 +17,6 @@ job release-srpm
 
 # Do fedora builds for the tag, using tarball
 job release-koji -k master
-job release-koji f24
 job release-koji f25
 
 # Upload release to github, using tarball


### PR DESCRIPTION
It's been a while since we've pushed into Fedora 24. There's no reason to do Fedora 24 releases in Koji any more.
    
We still do Fedora 24 releases in COPR.
