### PR TITLE
release-srpm: Fix parsing version/tag from tarball

### DIFF
--- a/release/release-srpm
+++ b/release/release-srpm
@@ -145,7 +145,7 @@ spec_srpm()
 #  $1: The tarball path
 tarball_version()
 {
-    echo "$1" | sed -ne 's/.*-\([0-9.]\+\)\..*/\1/p'
+    echo "$1" | sed -ne 's/.*-\([0-9.]\+\)\.[^0-9].*/\1/p'
 }
 
 # Build the source RPM


### PR DESCRIPTION
When -t or $RELEASE_TAG is not specified we parse the version
number from teh tarball. We should be greedy and parse until
the first non-numeric character.