### PR TITLE
release-srpm: Resolve tarball symlinks early

### DIFF
--- a/release/release-srpm
+++ b/release/release-srpm
@@ -153,6 +153,9 @@ prepare()
 {
     local specfile logfile count workdir
 
+    # Resolve the tarball to real file if a symlink
+    TARBALL=$(realpath "$TARBALL")
+
     # The version number comes from the tag or tarball
     if [ -z "$TAG" ]; then
         TAG=$(tarball_version $TARBALL)
@@ -176,9 +179,6 @@ prepare()
     logfile=$workdir/changelog
 
     trace "Updating spec file"
-
-    # Resolve the tarball to real file if a symlink
-    TARBALL=$(realpath "$TARBALL")
 
     printf "# This spec file has been automatically updated\n" >> $specfile
     printf "Version:\t$TAG\nRelease:\t$RELEASE%%{?dist}\n" >> $specfile


### PR DESCRIPTION
For tarballs that are symlinks to an actual tarball, we resolve
those before trying to perhaps trying to parse a tag from them.