### PR TITLE
release-debian: Drop cockpit specific PCP hack

### DIFF
--- a/release/release-debian
+++ b/release/release-debian
@@ -121,10 +121,11 @@ EOF
         dpkg-source --extract $DSC $distribution
         sed -i "s/$TAG-0/$TAG-0~$distribution/" $distribution/debian/changelog
         sed -i "s/experimental/$distribution/" $distribution/debian/changelog
-        # Hack: Remove PCP build dependencies while pcp is not in testing
-        # (https://tracker.debian.org/pcp)
-        if [ "$distribution" = unstable ]; then
-            sed -i '/libpcp.*-dev/d' $distribution/debian/control
+        # Some Debian/Ubuntu releases might not have all our build dependencies
+        # or may want to disable particular features. If present, this script
+        # will in-place modify the packaging for the given release.
+        if [ -x $distribution/debian/adjust-for-release ]; then
+            $distribution/debian/adjust-for-release $distribution
         fi
         dpkg-source --build $distribution
         )


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/6055 introduces a
generic "debian/adjust-for-release" script which does the PCP build
dependency mangling. Call this if present instead of hardcoding cockpit
specifics.

Fixes #6055

~~This is blocked on landing https://github.com/cockpit-project/cockpit/pull/6055 first.~~ (landed)