### PR TITLE
release: Remove strange characters from Git tags

### DIFF
--- a/release/release-github
+++ b/release/release-github
@@ -68,7 +68,7 @@ message()
 json_escape()
 {
     # Escape quotes, backslashes and new lines
-    sed -e 's/[\\"]/\\\0/g' -e 's/$/\\n/g'
+    sed -e 's/[\\"]/\\\0/g' -e 's/$/\\n/g' | tr -cd '[[:print:][:space:]]'
 }
 
 trim_contents()


### PR DESCRIPTION
If there's strange characters in the tag then the posting to
github falls over. So remove them.