### PR TITLE
release: Stop pushing Fedora 25 builds into Bodhi

### DIFF
--- a/release/major-cockpit-release
+++ b/release/major-cockpit-release
@@ -31,7 +31,6 @@ job release-dockerhub cockpit-project/cockpit-container
 job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 
 # Push out a Bodhi update
-job release-bodhi F25
 job release-bodhi F26
 
 # Upload documentation


### PR DESCRIPTION
We consider the latest cockpit release on Fedora 25 to be stable.