### PR TITLE
release: Ensure dnf knows builddep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ release-container: docker-running
 	docker commit --change='ENTRYPOINT ["/usr/local/bin/release-runner"]' \
 		cockpit-release-stage cockpit/infra-release:$(TAG)
 	docker tag cockpit/infra-release:$(TAG) cockpit/infra-release:latest
+	docker rmi cockpit/infra-release:staged
 	docker rm -f cockpit-release-stage
 	@true
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER "Stef Walter" <stefw@redhat.com>
 RUN dnf -y update && \
     dnf -y install \
         bzip2 \
+        findutils \
         git \
         gnupg \
         nc \

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -54,6 +54,7 @@ tough-cookie \
 yauzl \
     && \
     dnf -y install --enablerepo=updates-testing fedpkg koji copr-cli && \
+    dnf -y install 'dnf-command(builddep)' && \
     dnf -y builddep /tmp/cockpit.spec && \
     dnf clean all
 

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -26,6 +26,7 @@ psmisc \
 python \
 python-irclib \
 reprepro \
+rpm-build \
 which \
 yum-utils \
     && \


### PR DESCRIPTION
We need that plugin to install the cockpit build dependencies.