### PR TITLE
Fix the 'make verify-shell' target to not use /opt path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ verify-shell: docker-running
 		--privileged \
 		--volume /home/cockpit:/home/user \
 		--volume $(CURDIR)/verify:/usr/local/bin \
-		--volume=/opt/verify:/build:rw \
+		--volume=/home/cockpit/verify:/build:rw \
 		--net=host --pid=host --privileged --entrypoint=/bin/bash \
         cockpit/infra-verify -i
 


### PR DESCRIPTION
This is a path specific to the system cockpituous was written on.