### PR TITLE
Use an isolated network namespace in verify machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ verify-shell: docker-running
 		--volume /home/cockpit:/home/user \
 		--volume $(CURDIR)/verify:/usr/local/bin \
 		--volume=/home/cockpit/verify:/build:rw \
-		--net=host --pid=host --privileged --entrypoint=/bin/bash \
+		--entrypoint=/bin/bash \
         cockpit/infra-verify -i
 
 verify-container: docker-running

--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -47,13 +47,12 @@ RUN dnf -y update && \
     dnf clean all
 
 RUN mkdir -p /usr/local/bin /home/user /build
-ADD cockpit-verify /usr/local/bin/
+ADD cockpit-verify vm-prep network-cockpit.xml /usr/local/bin/
 
 RUN chown -R user /build /home/user
 RUN usermod -a -G mock user
 RUN echo 'user ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 RUN echo "config_opts['basedir'] = '/build/mock/'" >> /etc/mock/site-defaults.cfg
-RUN chmod -v u+s /usr/libexec/qemu-bridge-helper && echo 'allow cockpit1' >> /etc/qemu/bridge.conf
 
 # Prevent us from screwing around with KVM settings in the container
 RUN touch /etc/modprobe.d/kvm-amd.conf && touch /etc/modprobe.d/kvm-intel.conf

--- a/verify/README
+++ b/verify/README
@@ -21,11 +21,9 @@ First get the container:
 
 Some bits need to be configured outside the container:
 
-    # yum install libvirt libvirt-client qemu-system-x86
-    # wget https://raw.githubusercontent.com/cockpit-project/cockpit/master/test/vm-prep
-    # mkdir common
-    # wget -O ./common/network-cockpit.xml https://raw.githubusercontent.com/cockpit-project/cockpit/master/test/common/network-cockpit.xml
-    # sh vm-prep
+    # echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
+    # echo "options kvm-amd nested=1" > /etc/modprobe.d/kvm-amd.conf
+    # ( rmmod kvm-intel && modprobe kvm-intel ) || ( rmmod kvm-amd && modprobe kvm-amd )
 
 Setup a 'cockpit' user:
 

--- a/verify/cockpit-verify
+++ b/verify/cockpit-verify
@@ -14,6 +14,10 @@ if [ ! -d cockpit ]; then
     git clone https://github.com/cockpit-project/cockpit
 fi
 
+if ! ip address show dev cockpit1 >/dev/null 2>/dev/null; then
+    sudo /usr/local/bin/vm-prep
+fi
+
 if [ ! -d cockpit/node_modules ]; then
     ( cd cockpit && npm install )
 fi

--- a/verify/cockpit-verify.service
+++ b/verify/cockpit-verify.service
@@ -8,7 +8,7 @@ Environment="TEST_OS=fedora-testing fedora-atomic"
 Environment="TEST_JOBS=4"
 Restart=always
 RestartSec=60
-ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-verify --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/verify:/build:rw --net=host --pid=host --privileged --env=TEST_OS=\"$TEST_OS\" --env=TEST_JOBS=\"$TEST_JOBS\" cockpit/infra-verify"
+ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-verify --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/verify:/build:rw --uts=host --privileged --env=TEST_OS=\"$TEST_OS\" --env=TEST_JOBS=\"$TEST_JOBS\" cockpit/infra-verify"
 ExecStop=-/bin/sh -xc "/usr/bin/docker rm -f cockpit-verify"
 
 [Install]

--- a/verify/network-cockpit.xml
+++ b/verify/network-cockpit.xml
@@ -1,0 +1,33 @@
+<network ipv6='yes'>
+  <name>cockpit1</name>
+  <uuid>f3605fa4-0763-41ea-8143-49da3bf73263</uuid>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='cockpit1' stp='on' delay='0' />
+  <domain name='cockpit.lan'/>
+  <ip address='10.111.112.1' netmask='255.255.240.0'>
+    <dhcp xmlns:cockpit="urn:cockpit-project.org:cockpit">
+      <range start="10.111.112.2" end="10.111.127.254" />
+      <host mac='52:54:00:9e:00:F0' ip='10.111.112.100' name='f0.cockpit.lan' cockpit:image="ipa"/>
+      <host mac='52:54:00:9e:00:F1' ip='10.111.112.101' name='f1.cockpit.lan' cockpit:image="openshift"/>
+      <host mac='52:54:00:9e:00:F2' ip='10.111.112.102' name='f2.cockpit.lan' cockpit:test="check-networking"/>
+      <host mac='52:54:00:9e:00:F3' ip='10.111.112.103' name='f3.cockpit.lan' cockpit:test="check-shutdown-restart"/>
+      <host mac='52:54:00:9e:00:F4' ip='10.111.112.104' name='f4.cockpit.lan' cockpit:test="check-journal"/>
+      <host mac='52:54:00:9e:00:F5' ip='10.111.112.105' name='f5.cockpit.lan' cockpit:test="check-ostree"/>
+      <host mac='52:54:00:9e:00:F6' ip='10.111.112.106' name='f6.cockpit.lan' cockpit:test="unused"/>
+      <host mac='52:54:00:9e:00:F7' ip='10.111.112.107' name='f7.cockpit.lan' cockpit:test="unused"/>
+      <host mac='52:54:00:9e:00:F8' ip='10.111.112.108' name='f8.cockpit.lan' cockpit:test="unused"/>
+      <host mac='52:54:00:9e:00:F9' ip='10.111.112.109' name='f9.cockpit.lan' cockpit:test="unused"/>
+      <host mac='52:54:00:9e:00:FA' ip='10.111.112.110' name='fa.cockpit.lan' cockpit:test="unused"/>
+      <host mac='52:54:00:9e:00:FB' ip='10.111.112.111' name='fb.cockpit.lan' cockpit:test="unused"/>
+      <host mac='52:54:00:9e:00:FC' ip='10.111.112.112' name='fc.cockpit.lan' cockpit:test="unused"/>
+      <host mac='52:54:00:9e:00:FD' ip='10.111.112.113' name='fd.cockpit.lan' cockpit:test="unused"/>
+      <host mac='52:54:00:9e:00:FE' ip='10.111.112.114' name='fe.cockpit.lan' cockpit:test="unused"/>
+      <host mac='52:54:00:9e:00:FF' ip='10.111.112.115' name='ff.cockpit.lan' cockpit:test="unused"/>
+    </dhcp>
+  </ip>
+  <ip family="ipv6" address="fd00:111:112::1" prefix="64"/>
+</network>

--- a/verify/vm-prep
+++ b/verify/vm-prep
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2013 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+# The cockpit1 network is a legacy testing requirement. It goes away once
+# all maintained branches have moved away from using the cockpit1 bridge
+# for tests.
+
+VIRSH=/bin/virsh
+QEMU_BRIDGE_HELPER=/usr/libexec/qemu-bridge-helper
+
+BASE=$(dirname $0)
+SELF=vm-prep
+
+set -euf
+
+usage()
+{
+	echo >&2 "usage: $SELF [-u]"
+}
+
+warning()
+{
+	echo >&2 "$SELF: $@"
+}
+
+silent()
+{
+	"$@" > /dev/null 2> /dev/null
+	return $?
+}
+
+prepare()
+{
+	if ! virsh list >/dev/null 2>&1; then
+		if systemctl status >/dev/null 2>&1; then
+			systemctl start libvirtd
+		else
+			libvirtd -d
+			virtlogd -d
+		fi
+	fi
+
+	if silent $VIRSH net-info $NETWORK_NAME; then
+		$VIRSH net-destroy $NETWORK_NAME || true
+		$VIRSH net-undefine $NETWORK_NAME
+	fi
+
+	# HACK: NetworkManager races with dnsmasq-dhcp on bridge
+	# https://bugzilla.redhat.com/show_bug.cgi?id=1205081
+	cat > /etc/sysconfig/network-scripts/ifcfg-$NETWORK_NAME << EOF
+DEVICE=$NETWORK_NAME
+NM_CONTROLLED=no
+EOF
+
+    $VIRSH net-define $BASE/network-cockpit.xml
+	$VIRSH net-start $NETWORK_NAME
+
+	if [ ! -u $QEMU_BRIDGE_HELPER ]; then
+		chmod -v u+s $QEMU_BRIDGE_HELPER
+	fi
+
+	qemu_config_dirs=()
+  for d in /etc/qemu-kvm/ /etc/qemu; do
+      if test -f ${d}/bridge.conf; then
+          qemu_config_dirs+=(${d})
+      fi
+	done
+  if [ ${#qemu_config_dirs[@]} -eq 0 ]; then
+      warning "Could not find qemu config dir"
+	    exit 1
+  fi
+
+	rule="allow $NETWORK_NAME"
+  for qemu_config_dir in ${qemu_config_dirs[@]}; do
+      if ! silent grep -F $NETWORK_NAME ${qemu_config_dir}/bridge.conf; then
+        echo "$rule" >> ${qemu_config_dir}/bridge.conf
+      fi
+  done
+}
+
+args=$(getopt -o "uh" -l "help" -- "$@")
+eval set -- "$args"
+while [ $# -gt 0 ]; do
+	case $1 in
+	-h|--help)
+		usage
+		exit 0
+		;;
+	--)
+		shift
+		break
+		;;
+	esac
+	shift
+done
+
+if [ $# -ne 0 ]; then
+	usage
+	exit 2
+fi
+
+uid=$(id -u)
+if [ "$uid" != "0" ]; then
+	warning "this script must be run as root"
+	exit 1
+fi
+
+NETWORK_NAME=cockpit1
+prepare


### PR DESCRIPTION
This helps things be self-contained, reduces deployment
effort, but also helps us work with socket + mcast qemu networks.

It turns out on RHEL 7 socket + mcast in a container doesn't work
properly if sharing the host network namespace. At least on our
RHEL based verify machines it doesn't.