### PR TITLE
tests: Add 'image-stores' file to the container secrets

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -57,6 +57,7 @@ RUN printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpi
     mkdir -p /home/user/.config /home/user/.ssh && \
     ln -snf /secrets/ssh-config /home/user/.ssh/config && \
     ln -snf /secrets/github-token /home/user/.config/github-token && \
+    ln -snf /secrets/image-stores /home/user/.config/image-stores && \
     git clone https://github.com/cockpit-project/cockpit /build/cockpit && \
     cd /build/cockpit && npm install && \
     chown -R user /build /secrets /images /home/user

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,6 +20,7 @@ The container has optional mounts:
  * ```/secrets```: A directory containing at least the following files
    * ```ssh-config```: SSH configuration file
    * ```github-token```: A file containing a GitHub token to post results
+   * ```image-stores```: Non default locations to try downloading images from
  * ```/images```: A volume to store downloaded image files
 
 The mounts normally default to ```/var/lib/cockpit-tests/secrets``` and


### PR DESCRIPTION
This is a file that may contain non-public URLs of where to
download non-public images.