### PR TITLE
tests: Keep the containers and pods running longer

### DIFF
--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -62,6 +62,6 @@ while true; do
     fi
     iteration=$(( (iteration+1) % 25 ))
     if ! cockpit/test/github-task "$@"; then
-        exit
+        sleep 60
     fi
 done


### PR DESCRIPTION
This has side effects with keeping the /build directory
cached properly as well as things like the github rate-limit
caching.

We need to work on caching further later, and this should be
viewed as an interim fix. Perhaps later we will cycle every
100 runs or so.