### PR TITLE
release-bodhi: Move to fedora password

### DIFF
--- a/release/README
+++ b/release/README
@@ -36,10 +36,10 @@ update github status:
     /home/cockpit/.ssh/id_rsa.pub
     /home/cockpit/.ssh/known_hosts
     /home/cockpit/.config/bodhi-user
-    /home/cockpit/.config/bodhi-password
     /home/cockpit/.config/copr
     /home/cockpit/.config/github-token
     /home/cockpit/.config/github-whitelist
+    /home/cockpit/.fedora-password
     /home/cockpit/.fedora.cert
     /home/cockpit/.fedora-server-ca.cert
     /home/cockpit/.gitconfig

--- a/release/release-bodhi
+++ b/release/release-bodhi
@@ -53,9 +53,9 @@ check()
         exit 2
     fi
 
-    PASSWORD="$(cat ~/.config/bodhi-password)"
+    PASSWORD="$(cat ~/.fedora-password)"
     if [ -z "$PASSWORD" ]; then
-        message "no valid ~/.config/bodhi-password found"
+        message "no valid ~/.fedora-password found"
         exit 2
     fi
 }


### PR DESCRIPTION
bodhi changed recently to now ask for the Fedora (kinit) passsword, and
the bodhi specific password is not being used any more.  See
https://bugzilla.redhat.com/show_bug.cgi?id=1449045 for details.

Note that this needs the latest python-fedora from updates.

----

The previous 140 release attempt [failed due to this](https://fedorapeople.org/groups/cockpit/logs/release-140/log), and I re-ran the lost steps manually, which finally created a [bodhi update for 140](https://bodhi.fedoraproject.org/updates/cockpit-140-1.fc26). I stopped the release container for the time being, as we need to rebuild it.