### PR TITLE
release-source: Don't generate patches for non-tarball commits

### DIFF
--- a/release/release-source
+++ b/release/release-source
@@ -200,6 +200,11 @@ prepare()
                 --strip-components=1 -xzf - < $repodir/_build/release-patched.tar.gz
             git -C $stagedir add -f .
 
+            # If nothing added above, then just skip
+            if git -C $stagedir diff-index --exit-code --quiet HEAD --; then
+                continue
+            fi
+
             # Transfer key information to new stage commit
             author="$(git -C $repodir show $commit --pretty='%an <%ae>' --no-patch)"
             date="$(git -C $repodir show $commit --pretty='%ad' --no-patch)"


### PR DESCRIPTION
In release-source we generate patches for every git commit
after the tag. However some commits don't affect the tarball
and therefore should be skipped and not generate patches
for the tarball.