### PR TITLE
images: Disable HTTP/2 on the images Web Server

### DIFF
--- a/images/nginx.conf
+++ b/images/nginx.conf
@@ -38,8 +38,8 @@ http {
     }
 
     server {
-        listen       443 ssl http2 default_server;
-        listen       [::]:443 ssl http2 default_server;
+        listen       443 ssl default_server;
+        listen       [::]:443 ssl default_server;
         server_name  cockpit-tests;
         root         /cache/images;
 


### PR DESCRIPTION
This resulted in massive slow downs for several users.

https://github.com/cockpit-project/cockpit/issues/6571