### PR TITLE
release: Enforce success on Fedora 26, drop Fedora 25

### DIFF
--- a/release/major-cockpit-release
+++ b/release/major-cockpit-release
@@ -17,8 +17,7 @@ job release-srpm
 
 # Do fedora builds for the tag, using tarball
 job release-koji -k master
-job release-koji f25
-job release-koji -k f26
+job release-koji f26
 
 # Upload release to github, using tarball
 job release-github


### PR DESCRIPTION
We don't regularly release to Fedora 25 any more, so drop koji build.
    
Stop allowing failures on Fedora 26 as that is now our primary target.
See https://github.com/cockpit-project/cockpit/pull/6602