### PR TITLE
tests: Document right rule for KVM usage

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -103,6 +103,7 @@ Some helpful commands:
 The tests need ```/dev/kvm``` to be accessible to non-root users on each node:
 
     $ sudo chmod 666 /dev/kvm
+    $ printf 'KERNEL=="kvm", GROUP="kvm", MODE="0666"\n' | sudo tee /etc/udev/rules.d/80-kvm.rules
 
 Some tests need nested virtualization enabled:
 

--- a/tests/install-service
+++ b/tests/install-service
@@ -30,6 +30,7 @@ EOF
 
 systemctl daemon-reload
 
+echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' > /etc/udev/rules.d/80-kvm.rules
 echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
 echo "options kvm-amd nested=1" > /etc/modprobe.d/kvm-amd.conf
 ( rmmod kvm-intel && modprobe kvm-intel ) || ( rmmod kvm-amd && modprobe kvm-amd )


### PR DESCRIPTION
This is exactly the same rule that qemu-system-x86 puts in
place when it installs.