### PR TITLE
tests: Add troubleshooting info about ip6_tables

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -105,6 +105,11 @@ The tests need ```/dev/kvm``` to be accessible to non-root users on each node:
     $ sudo chmod 666 /dev/kvm
     $ printf 'KERNEL=="kvm", GROUP="kvm", MODE="0666"\n' | sudo tee /etc/udev/rules.d/80-kvm.rules
 
+Some of the older tests need ip6_tables to be loaded:
+
+    $ sudo modprobe ip6_tables
+    $ printf 'ip6_tables\n' | sudo tee /etc/modules-load.d/ip6_tables.conf
+
 Some tests need nested virtualization enabled:
 
     $ sudo -s


### PR DESCRIPTION
As we migrate way from vm-prep on master, this will become less
of an issue. But for now the libvirt bridged network in the container
needs this to be loaded.