### PR TITLE
tests: Make the sleep while waiting longer

### DIFF
--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -59,7 +59,8 @@ function task() {
     ) | sed -e 's/#.*$//' -e '/^$/d' | sort -r | head -n 10 | shuf | head -n 1
 }
 
-for i in $(seq 1 60); do
+# Perform N tasks or waits, then restart
+for i in $(seq 1 30); do
     git -C cockpit fetch origin
     git -C cockpit reset --hard origin/master
 
@@ -72,5 +73,6 @@ for i in $(seq 1 60); do
         fi
     fi
 
-    sleep 60
+    # Nothing to do, or failure, wait between 1 and 10 minutes
+    sleep $(shuf -i 60-600 -n 1)
 done


### PR DESCRIPTION
Make the sleep while waiting longer, roughly the same order of
magnitude to how long it takes to run a test suite.

And perform less tasks in a batch before cycling the container.