### PR TITLE
tests: Add cleanup hacks for container networking

### DIFF
--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -26,6 +26,16 @@ if [ -n "$TMPDIR" ]; then
     ln -snf $TMPDIR/libvirt /tmp/libvirt
 fi
 
+# HACK: /sys is read-only in containers. And libvirt tries
+# to write there, but only if a specific subtree exists here
+sudo -n mount -o bind /run /sys/devices/virtual/net/ || true
+
+# In case a network has leaked in from elsewhere
+if sudo -n ip address show dev cockpit1 >/dev/null 2>/dev/null; then
+	sudo -n ip link set cockpit1 down || true
+	sudo -n brctl delbr cockpit1 || true
+fi
+
 if [ ! -d cockpit ]; then
     sudo chown -R user /build
     git clone https://github.com/cockpit-project/cockpit


### PR DESCRIPTION
The first hack is because we don't want to see this error message
when libvirt tries to write bridge related stuff:

    error: Unable to set bridge cockpit1 forward_delay: Read-only file system

Secondly, when run in Kubernetes the Pod can outlast the Container and
so this network may have leaked in from elsewhere. Lets double
check and remove it using brctl.

Neither of these hacks work in the tasks code because it may be
executing older branches which do not account for these things.