### PR TITLE
tests: Add a volume to container for tmp

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -45,7 +45,7 @@ RUN dnf -y update && \
 ADD https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec /tmp/cockpit.spec
 RUN dnf -y builddep /tmp/cockpit.spec && dnf clean all
 
-RUN mkdir -p /usr/local/bin /home/user /build /build/tmp /secrets /cache/images /cache/github
+RUN mkdir -p /usr/local/bin /home/user /build /secrets /cache/images /cache/github
 ADD cockpit-tests install-service /usr/local/bin/
 
 RUN usermod -a -G mock user
@@ -55,6 +55,7 @@ RUN printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpi
     ln -s /cache/images /build/images && \
     ln -s /cache/images /build/virt-builder && \
     ln -s /cache/github /build/github && \
+    ln -s /tmp /build/tmp && \
     mkdir -p /home/user/.config /home/user/.ssh && \
     ln -snf /secrets/ssh-config /home/user/.ssh/config && \
     ln -snf /secrets/github-token /home/user/.config/github-token && \
@@ -71,14 +72,15 @@ RUN chmod -v u+s /usr/libexec/qemu-bridge-helper && echo 'allow cockpit1' >> /et
 
 ENV LIBGUESTFS_BACKEND direct
 ENV XDG_CACHE_HOME /build
-ENV TMPDIR /build/tmp
-ENV TEMP /build/tmp
-ENV TEMPDIR /build/tmp
+ENV TMPDIR /tmp
+ENV TEMP /tmp
+ENV TEMPDIR /tmp
 ENV TEST_DATA /build
 ENV TEST_PUBLISH=
 
 VOLUME /secrets
 VOLUME /cache
+VOLUME /tmp
 
 USER user
 WORKDIR /build

--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -19,13 +19,6 @@ fi
 sudo mkdir -p /cache/github /cache/images
 sudo chown user:user /cache /cache/github /cache/images
 
-if [ -n "$TMPDIR" ]; then
-    mkdir -p "$TMPDIR"
-    mkdir -p $TMPDIR/libvirt
-    rm -rf /tmp/libvirt
-    ln -snf $TMPDIR/libvirt /tmp/libvirt
-fi
-
 # HACK: /sys is read-only in containers. And libvirt tries
 # to write there, but only if a specific subtree exists here
 sudo -n mount -o bind /run /sys/devices/virtual/net/ || true
@@ -37,7 +30,7 @@ if sudo -n ip address show dev cockpit1 >/dev/null 2>/dev/null; then
 fi
 
 if [ ! -d cockpit ]; then
-    sudo chown -R user /build
+    sudo chown -R user .
     git clone https://github.com/cockpit-project/cockpit
 fi
 

--- a/tests/cockpit-tests.json
+++ b/tests/cockpit-tests.json
@@ -54,6 +54,11 @@
                                         "name": "cache",
                                         "mountPath": "/cache",
                                         "readOnly": false
+                                    },
+                                    {
+                                        "name": "tmp",
+                                        "mountPath": "/tmp",
+                                        "readonly": false
                                     }
                                 ]
                             },
@@ -96,6 +101,10 @@
                                 "hostPath": {
                                     "path": "/var/cache/cockpit-tests"
                                 }
+                            },
+                            {
+                                "name": "tmp",
+                                "emptyDir": { }
                             }
                         ],
                         "serviceAccountName": "tester"


### PR DESCRIPTION
Add a scratch empty volume to a container for the /tmp directory
and start to do the builds and running of VMs there.