### PR TITLE
tests: Add Red Hat subscription credentials to testers

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -56,10 +56,12 @@ RUN printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpi
     ln -s /cache/images /build/virt-builder && \
     ln -s /cache/github /build/github && \
     ln -s /tmp /build/tmp && \
-    mkdir -p /home/user/.config /home/user/.ssh && \
+    mkdir -p /home/user/.config /home/user/.ssh /home/user/.rhel && \
     ln -snf /secrets/ssh-config /home/user/.ssh/config && \
     ln -snf /secrets/github-token /home/user/.config/github-token && \
     ln -snf /secrets/image-stores /home/user/.config/image-stores && \
+    ln -snf /secrets/rhel-login /home/user/.rhel/login && \
+    ln -snf /secrets/rhel-password /home/user/.rhel/pass && \
     git clone https://github.com/cockpit-project/cockpit /build/cockpit && \
     cd /build/cockpit && npm install && \
     chown -R user /build /secrets /cache /home/user

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,8 @@ The container has optional mounts:
    * ```ssh-config```: SSH configuration file containing a 'sink' host
    * ```github-token```: A file containing a GitHub token to post results
    * ```image-stores```: Non default locations to try downloading images from
+   * ```rhel-login```: Red Hat subscription credential login (optional)
+   * ```rhel-password```: Red Hat subscription credential password (optional)
  * ```/cache```: A directory for reusable cached data such as downloaded image files
 
 The mounts normally default to ```/var/lib/cockpit-tests/secrets``` and


### PR DESCRIPTION
Depends on:

 * [x] #132 
 * [x] https://github.com/cockpit-project/cockpit/pull/6734