### PR TITLE
release: Fix malformed email addresses in release-sprm

### DIFF
--- a/release/release-srpm
+++ b/release/release-srpm
@@ -98,11 +98,11 @@ tagemail=%(taggeremail)' "refs/tags/$1")
     if [ -z "$tagbody" -a -z "$tagauthor" ]; then
         tagdate=$(LC_ALL=C date '+%a %b %d %Y')
         tagauthor=$(git config --global user.name)
-        tagemail=$(git config --global user.email)
+        tagemail="<$(git config --global user.email)>"
         tagbody="- Update to upstream $TAG release"
     fi
 
-    printf "* %s %s <%s> - %s-%s\n" "$tagdate" "$tagauthor" "$tagemail" "$1" "$2"
+    printf "* %s %s %s - %s-%s\n" "$tagdate" "$tagauthor" "$tagemail" "$1" "$2"
 
     # Only include the main body if not a revision > 1
     if [ "$2" -eq 1 ]; then


### PR DESCRIPTION
git's --format='%(taggeremail)' already wraps the address in <>, so
don't do it again when creating the changelog. Drop it from the
changelog building and instead add it to the fallback when releasing a
source from non-git.

Fixes duplicate << >> wrapping in e. g.
http://pkgs.fedoraproject.org/cgit/rpms/cockpit.git/commit/?id=2caac4ddcb