### PR TITLE
tests: Document doing modprobe /dev/kvm on boot

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -104,6 +104,8 @@ Some helpful commands:
 
 The tests need ```/dev/kvm``` to be accessible to non-root users on each node:
 
+    $ sudo modprobe kvm
+    $ printf 'kvm\n' | sudo tee /etc/modules-load.d/kvm.conf
     $ sudo chmod 666 /dev/kvm
     $ printf 'KERNEL=="kvm", GROUP="kvm", MODE="0666"\n' | sudo tee /etc/udev/rules.d/80-kvm.rules
 


### PR DESCRIPTION
Unless libvirt is used on the Openshift host, the kvm module
is often not loaded by itself.