### PR TITLE
release: Wait for copr build to finish

### DIFF
--- a/release/release-copr
+++ b/release/release-copr
@@ -100,7 +100,7 @@ prepare()
 
 commit()
 (
-    if ! copr-cli build --nowait $COPR "$URL"; then
+    if ! copr-cli build $COPR "$URL"; then
         if [ $CONTINUE -eq 0 ]; then
             exit 1
         fi


### PR DESCRIPTION
That way we can be sure the rpms will be available to
the docker images.