### PR TITLE
tests: Add 12 hour timeout for any task

### DIFF
--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -70,8 +70,8 @@ for i in $(seq 1 30); do
     line="$(task)"
     if [ -n "$line" ]; then
 
-        # Execute the task in question
-        if /bin/sh -c "cd cockpit/; set -ex; $line"; then
+        # Execute the task in question: 12 hours max
+        if /usr/bin/timeout 12h /bin/sh -c "cd cockpit/; set -ex; $line"; then
             continue
         fi
     fi


### PR DESCRIPTION
Various tasks have timeouts of their own such as running tests
or building images. But if any task hangs for more than 12 hours
we kill it.

We do want to allow for tasks that take a long time such as
machine learning tasks, but they should be broken up to take
significantly less than half a day.