### PR TITLE
tests: Start to use non-privileged containers

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ or RHEL 7+.
 
 Use the following commands to run the tests container as a one off:
 
-    $ sudo yum -y install docker atomic
+    $ sudo yum -y install docker atomic oci-kvm-hook
     $ sudo systemctl start docker
     $ sudo atomic run cockpit/tests
 
@@ -81,18 +81,19 @@ It will restart automatically when it finds a pause in the verification work.
 
 The testing machines can run on Openshift cluster(s).
 
-Create a service account for use by the testing machines.  Currently the privileged SCC
-is used for scheduling the tests pod. This is because of the requirement to access
-```/dev/kvm```. Further work is necessary to remove this requirement.
+Create a service account for use by the testing machines. Make sure to have the
+```oci-kvm-hook``` package installed on all nodes.  This is because of the requirement
+to access ```/dev/kvm```. Further work is necessary to remove this requirement.
 
-    $ oc create -f tests/cockpit-tester-account.json
-    $ oc adm policy add-scc-to-user privileged -z tester
+    $ oc create -f tests/cockpituous-account.json
+    $ oc adm policy add-scc-to-user anyuid -z cockpituous
+    $ oc adm policy add-scc-to-user hostmount-anyuid -z cockpituous
 
 Now create all the remaining kubernetes objects. The secrets are created from the
 ```/var/lib/cockpit-tests/secrets``` directory as described above.
 
     $ sudo make tests-secrets | oc create -f -
-    $ oc create -f tests/cockpit-tests.json
+    $ oc create -f tests/cockpit-tasks.json
 
 ## Troubleshooting
 

--- a/tests/cockpit-tasks.json
+++ b/tests/cockpit-tasks.json
@@ -5,32 +5,25 @@
         {
             "kind": "ReplicationController",
             "metadata": {
-                "name": "cockpit-tests",
-                "annotations": {
-                    "openshift.io/scc": "privileged"
-                }
+                "name": "cockpit-tasks"
             },
             "spec": {
                 "replicas": 1,
                 "selector": {
-                    "infra": "cockpit-tests"
+                    "infra": "cockpit-tasks"
                 },
                 "template": {
                     "metadata": {
                         "labels": {
-                            "infra": "cockpit-tests"
-                        },
-                        "annotations": {
-                            "openshift.io/scc": "privileged"
+                            "infra": "cockpit-tasks"
                         }
                     },
                     "spec": {
                         "containers": [
                             {
-                                "name": "cockpit-tests",
+                                "name": "cockpit-tasks",
                                 "image": "docker.io/cockpit/tests",
                                 "securityContext": {
-                                    "privileged": true,
                                     "runAsUser": 1111,
                                     "hostNetwork": false
                                 },
@@ -107,7 +100,7 @@
                                 "emptyDir": { }
                             }
                         ],
-                        "serviceAccountName": "tester"
+                        "serviceAccountName": "cockpituous"
                     }
                 }
             }
@@ -120,7 +113,7 @@
             "spec": {
                 "clusterIP": "None",
                 "selector": {
-                    "infra": "cockpit-tests"
+                    "infra": "cockpit-tasks"
                 },
                 "ports": [
                     {

--- a/tests/cockpituous-account.json
+++ b/tests/cockpituous-account.json
@@ -6,7 +6,7 @@
             "kind": "ServiceAccount",
             "apiVersion": "v1",
             "metadata": {
-                "name": "tester"
+                "name": "cockpituous"
             }
         }
     ]


### PR DESCRIPTION
This enables use of non-privileged containers for running the tests
and bot tasks.

Certain older branches will still need to use privileged containers
because they expect to use a cockpit1 bridged host network. However
those cases can be handled by non-Openshift containers run via the command

    $ sudo atomic run cockpit/tests

I'd like to eventually rename the usage of 'tests' to 'tasks' in this
repo. This pull request starts that but doesn't finish it.