### PR TITLE
release: Red Hat OpenShift 2 cloud is gone

### DIFF
--- a/release/release-debian
+++ b/release/release-debian
@@ -152,9 +152,6 @@ commit()
 
     rsync --delete -a -e ssh $WORKDIR/_repo/./ "$REPOSITORY"
 
-    # HACK: for now to support TLS
-    rsync --delete -a -e ssh $WORKDIR/_repo/./ repo-cockpitproject.rhcloud.com:app-root/repo/debian/
-
     rm -rf $WORKDIR
 )
 


### PR DESCRIPTION
Drop the rsync of Debian repo to it, as otherwise release-debian fails
now.

The repository is still available at
https://fedorapeople.org/groups/cockpit/debian/

----

Log from today's failed release: https://fedorapeople.org/groups/cockpit/logs/release-152/log
`release-debian` is the last one in the list, so everything else completed and this wasn't actual fatal.

In the near future the current form of release-debian should stop, as our custom repo is not very relevant any more (nor is Debian 8). On the side I'll work on automating most parts of the release to Debian unstable, then we can replace release-debian with that.