### PR TITLE
Makefile: Fix pushing and tagging of containers

### DIFF
--- a/base/push-container
+++ b/base/push-container
@@ -7,7 +7,7 @@ if [ $(echo "$ID" | wc -w) -ne "1" ]; then
     echo "Expected exactly one image matching '$IMAGE:latest'"
 	exit 1
 fi
-TAGS=$(docker images --format "table {{.Tag}}\t{{.ID}}" | grep $ID | awk '{print $1}')
+TAGS=$(docker images --format "table {{.Tag}}\t{{.ID}}" $IMAGE | grep $ID | awk '{print $1}')
 if [ $(echo "$TAGS" | wc -w) -ne "2" ]; then
 	echo "Expected exactly two tags for the image to push: latest and one other"
 	exit 1

--- a/release/cockpit-release.service
+++ b/release/cockpit-release.service
@@ -7,7 +7,7 @@ After=docker.service
 Environment="RELEASE_SINK=fedorapeople.org"
 Restart=always
 RestartSec=1800
-ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-release --privileged --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/release:/build:rw --env=RELEASE_SINK=\"$RELEASE_SINK\" cockpit/infra-release -r https://github.com/cockpit-project/cockpit /build/bots/major-cockpit-release
+ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-release --privileged --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/release:/build:rw --env=RELEASE_SINK=\"$RELEASE_SINK\" cockpit/release -r https://github.com/cockpit-project/cockpit /build/bots/major-cockpit-release"
 ExecStop=-/bin/sh -xc "/usr/bin/docker rm -f cockpit-release"
 
 [Install]


### PR DESCRIPTION
Fedora and RHEL are now more strict about what the default
registry is. Lets explicitly use docker.io here.

In addition there's a bit of renaming going on