### PR TITLE
images: Expose http on standard port 80

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -26,4 +26,4 @@ CMD /usr/sbin/nginx -g "daemon off;"
 LABEL INSTALL /usr/bin/docker run -ti --rm --privileged --volume=/:/host:rw --user=root IMAGE /bin/bash -c \"/usr/sbin/chroot /host /bin/sh -s < /usr/local/bin/install-service\"
 
 # Run a simple interactive instance of the tests container
-LABEL RUN /usr/bin/docker run -ti --rm --publish=8090:80 --publish=8493:443 --volume=/var/lib/cockpit-tests/secrets:/secrets:ro --volume=/var/cache/cockpit-tests:/cache:rw IMAGE /bin/bash -i
+LABEL RUN /usr/bin/docker run -ti --rm --publish=80:80 --publish=8493:443 --volume=/var/lib/cockpit-tests/secrets:/secrets:ro --volume=/var/cache/cockpit-tests:/cache:rw IMAGE /bin/bash -i


### PR DESCRIPTION
Cockpit expects to talk to cockpit-11 on the standard HTTP port [1], and
apparently the created cockpit-tests.service had been manually changed
for that until the reinstall. As we don't need port 80 for anything
else, change the port in the Dockerfile instead of changing REDHAT_PING,
to keep the recent behaviour.

[1] https://github.com/cockpit-project/cockpit/blob/master/bots/tests-scan#L58