### PR TITLE
tests: Install chromium-headless

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,6 +7,7 @@ RUN dnf -y update && \
         bind-utils \
         bodhi-client \
         bzip2 \
+        chromium-headless \
         copr-cli \
         curl \
         expect \


### PR DESCRIPTION
This allows us to experiment with moving Cockpit tests from PhantomJS to
the Chrome Debugging Protocol, using headless Chromium
(https://github.com/cockpit-project/cockpit/pull/8069)

----

Note that there has not yet been a final decision between Electron and Chromium, but unlike electron it is impractical to pull in Chromium via NPM.  There are no pre-built chromium-headless packages on NPM, and https://www.npmjs.com/package/chromium is the full version which requires X and its libraries (which we don't have in the tests container).

Thus it might be that we revert this again soon, but this unblocks https://github.com/cockpit-project/cockpit/pull/8069