### PR TITLE
Update containers to Fedora 26, optimize layering

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:25
+FROM fedora:26
 MAINTAINER "Stef Walter" <stefw@redhat.com>
 
 RUN dnf -y update && \

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,8 +1,7 @@
 FROM cockpit/infra-base
 MAINTAINER "Stef Walter" <stefw@redhat.com>
 
-RUN dnf -y update
-RUN dnf -y install nginx
+RUN dnf -y update && dnf -y install nginx && dnf clean all
 
 RUN mkdir -p /usr/local/bin && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
@@ -17,8 +16,7 @@ ADD nginx.conf /etc/nginx/
 VOLUME /secrets
 VOLUME /cache
 
-EXPOSE 80
-EXPOSE 443
+EXPOSE 80 443
 STOPSIGNAL SIGQUIT
 CMD /usr/sbin/nginx -g "daemon off;"
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,8 @@
 FROM cockpit/infra-base
 MAINTAINER "Stef Walter" <stefw@redhat.com>
 
+ADD https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec /tmp/cockpit.spec
+
 RUN dnf -y update && \
     dnf -y install \
         american-fuzzy-lop \
@@ -44,11 +46,9 @@ RUN dnf -y update && \
         sudo \
         tar \
         virt-install \
-        zanata-client \
-        && \
-    npm -g install phantomjs-prebuilt
-ADD https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec /tmp/cockpit.spec
-RUN dnf -y builddep /tmp/cockpit.spec && dnf clean all
+        zanata-client && \
+        dnf -y builddep /tmp/cockpit.spec && dnf clean all
+RUN npm -g install phantomjs-prebuilt
 
 RUN mkdir -p /usr/local/bin /home/user /build /secrets /cache/images /cache/github /build/libvirt/qemu
 ADD cockpit-tests install-service /usr/local/bin/
@@ -79,13 +79,12 @@ RUN touch /etc/modprobe.d/kvm-amd.conf && touch /etc/modprobe.d/kvm-intel.conf
 # Continue to work with a host defined cockpit1 network if necessary
 RUN chmod -v u+s /usr/libexec/qemu-bridge-helper && echo 'allow cockpit1' >> /etc/qemu/bridge.conf
 
-ENV LIBGUESTFS_BACKEND direct
-ENV XDG_CACHE_HOME /build
-ENV TMPDIR /tmp
-ENV TEMP /tmp
-ENV TEMPDIR /tmp
-ENV TEST_DATA /build
-ENV TEST_PUBLISH=
+ENV LIBGUESTFS_BACKEND=direct \
+    XDG_CACHE_HOME=/build \
+    TMPDIR=/tmp \
+    TEMPDIR=/tmp \
+    TEST_DATA=/build \
+    TEST_PUBLISH=
 
 VOLUME /secrets
 VOLUME /cache


### PR DESCRIPTION
Now that Fedora 27 is released, Fedora 25 will be EOL really soon. Update our containers to Fedora 26.

While I was at it, I also optimized the tests container's layering to save half a Gigabyte.

I locally ran a build and test/verify/run-tests successfully.

TODO:

 - [x] rebuild and verify release container (also take PR #146 into account)
 - [x] rebuild and verify images container
 - [x] roll out new images and tests containers to OpenShift