### PR TITLE
tests: Increase SHM size

### DIFF
--- a/tests/cockpit-tasks.json
+++ b/tests/cockpit-tasks.json
@@ -49,6 +49,11 @@
                                         "readOnly": false
                                     },
                                     {
+                                        "name": "shm",
+                                        "mountPath": "/dev/shm",
+                                        "readonly": false
+                                    },
+                                    {
                                         "name": "tmp",
                                         "mountPath": "/tmp",
                                         "readonly": false
@@ -93,6 +98,12 @@
                                 "name": "cache",
                                 "hostPath": {
                                     "path": "/var/cache/cockpit-tests"
+                                }
+                            },
+                            {
+                                "name": "shm",
+                                "hostPath": {
+                                    "path": "/dev/shm"
                                 }
                             },
                             {

--- a/tests/install-service
+++ b/tests/install-service
@@ -21,7 +21,7 @@ Environment="TEST_SECRETS=$SECRETS"
 Environment="TEST_PUBLISH=sink"
 Restart=always
 RestartSec=60
-ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-tests --volume=\$TEST_CACHE:/cache:rw --volume=\$TEST_SECRETS:/secrets:ro --uts=host --privileged --env=TEST_OS=\"\$TEST_OS\" --env=TEST_JOBS=\"\$TEST_JOBS\" --env=TEST_PUBLISH=\"\$TEST_PUBLISH\" cockpit/tests"
+ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-tests --volume=\$TEST_CACHE:/cache:rw --volume=\$TEST_SECRETS:/secrets:ro --uts=host --shm-size=500m --privileged --env=TEST_OS=\"\$TEST_OS\" --env=TEST_JOBS=\"\$TEST_JOBS\" --env=TEST_PUBLISH=\"\$TEST_PUBLISH\" cockpit/tests"
 ExecStop=-/bin/sh -xc "/usr/bin/docker rm -f cockpit-tests"
 
 [Install]


### PR DESCRIPTION
Docker containers only get a 64 MB /dev/shm by default, which cannot be
increased through OpenShift [1]. The recommendation is to use volumes
instead, so just use the host's /dev/shm. This will enable us to use
chromium-headless or electron in our tests docker containers, which use
shared memory to exchange data between processes. Some of these, like
HTML dumps or screenshots are rather big, and multiple parallel
processes often exceed the 64 MB limit.

For the standalone cockpit-tests.service, bump the SHM size to 500MB.

[1] https://docs.openshift.com/container-platform/3.6/dev_guide/shared_memory.html