### PR TITLE
tests: Use separate SHM tmpfs volume

### DIFF
--- a/tests/cockpit-tasks.json
+++ b/tests/cockpit-tasks.json
@@ -102,8 +102,8 @@
                             },
                             {
                                 "name": "shm",
-                                "hostPath": {
-                                    "path": "/dev/shm"
+                                "emptyDir": {
+                                    "medium": "Memory"
                                 }
                             },
                             {


### PR DESCRIPTION
Commit 7506c4 used a bind mount from the host's /dev/shm/ into the
container's /dev/shm to increase shared memory size. This causes SELinux
violations:

    avc:  denied  { write } for  pid=59335 comm="Chrome_IOThread" name="/" dev="tmpfs" ino=13316 scontext=system_u:system_r:svirt_lxc_net_t:s0:c2,c8 tcontext=system_u:object_r:tmpfs_t:s0 tclass=dir

which break chromium. So define the shm volume as standalone tmpfs
instead.