### PR TITLE
tests: Install latest chromium-headless from updates-testing

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,7 +7,6 @@ RUN dnf -y update && \
         bind-utils \
         bodhi-client \
         bzip2 \
-        chromium-headless \
         copr-cli \
         curl \
         expect \
@@ -45,6 +44,7 @@ RUN dnf -y update && \
         tar \
         virt-install \
         zanata-client && \
+    dnf -y install chromium-headless --enablerepo=updates-testing && \
     npm -g install phantomjs-prebuilt && \
     curl -s -o /tmp/cockpit.spec https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec && \
     dnf -y builddep /tmp/cockpit.spec && \


### PR DESCRIPTION
Current chromium 61 has a bug in `Network.setCookie()` which is hard to
work around and fixed in 62. Install chromium-headless from
updates-testing, which gets current upstream versions much more timely.