### PR TITLE
tests: Install full chromium and Xvfb

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -46,8 +46,9 @@ RUN dnf -y update && \
         sudo \
         tar \
         virt-install \
+        xorg-x11-server-Xvfb \
         zanata-client && \
-    dnf -y install chromium-headless --enablerepo=updates-testing && \
+    dnf -y install chromium --enablerepo=updates-testing && \
     npm -g install phantomjs-prebuilt && \
     curl -s -o /tmp/cockpit.spec https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec && \
     dnf -y builddep /tmp/cockpit.spec && \


### PR DESCRIPTION
Headless Chrome does not handle requests for client SSL certificates
(https://bugs.chromium.org/p/chromium/issues/detail?id=757181) and there
is no known workaround. These are issued by OpenShift's OAuth during
Cockpit's container tests. Install the full chrome and Xvfb for the
time being so that we can run the container tests under "full" chrome.
(Other tests can continue to use `--headless`).