### PR TITLE
systemd: Avoid container startup failure on stale Docker containers

### DIFF
--- a/images/install-service
+++ b/images/install-service
@@ -19,8 +19,9 @@ Environment="TEST_CACHE=$CACHE"
 Environment="TEST_SECRETS=$SECRETS"
 Restart=always
 RestartSec=60
+ExecStartPre=-/usr/bin/docker rm -f cockpit-images
 ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-images --publish=8090:80 --publish=8493:443 --volume=\$TEST_SECRETS:/secrets:ro --volume=\$TEST_CACHE:/cache:rw cockpit/images"
-ExecStop=-/bin/sh -xc "/usr/bin/docker rm -f cockpit-images"
+ExecStop=/usr/bin/docker rm -f cockpit-images
 
 [Install]
 WantedBy=multi-user.target

--- a/release/cockpit-release.service
+++ b/release/cockpit-release.service
@@ -7,8 +7,9 @@ After=docker.service
 Environment="RELEASE_SINK=fedorapeople.org"
 Restart=always
 RestartSec=1800
+ExecStartPre=-/usr/bin/docker rm -f cockpit-release
 ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-release --privileged --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/release:/build:rw --env=RELEASE_SINK=\"$RELEASE_SINK\" cockpit/release -r https://github.com/cockpit-project/cockpit /build/bots/major-cockpit-release"
-ExecStop=-/bin/sh -xc "/usr/bin/docker rm -f cockpit-release"
+ExecStop=/usr/bin/docker rm -f cockpit-release
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/install-service
+++ b/tests/install-service
@@ -21,8 +21,9 @@ Environment="TEST_SECRETS=$SECRETS"
 Environment="TEST_PUBLISH=sink"
 Restart=always
 RestartSec=60
+ExecStartPre=-/usr/bin/docker rm -f cockpit-tests
 ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-tests --volume=\$TEST_CACHE:/cache:rw --volume=\$TEST_SECRETS:/secrets:ro --uts=host --shm-size=500m --privileged --env=TEST_OS=\"\$TEST_OS\" --env=TEST_JOBS=\"\$TEST_JOBS\" --env=TEST_PUBLISH=\"\$TEST_PUBLISH\" cockpit/tests"
-ExecStop=-/bin/sh -xc "/usr/bin/docker rm -f cockpit-tests"
+ExecStop=/usr/bin/docker rm -f cockpit-tests
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Clean up a stale `cockpit-{tests,images,release}` at boot before
starting a new one, to avoid failed units and thus non-running image
containers after an unclean reboot.

---

This often happened on verifymachine4/5 and thus public image servers didn't exist until someone cleaned up manually. I tested and rolled out the changes there.