### PR TITLE
release: Clone specified repository instead of cockpit

### DIFF
--- a/release/README
+++ b/release/README
@@ -21,7 +21,7 @@ This is the container for the Cockpit release runner.
 
 First get the container:
 
-    # docker pull cockpit/infra-release
+    # docker pull cockpit/release
 
 Setup a 'cockpit' user:
 
@@ -66,6 +66,6 @@ Some helpful commands:
 To update, just pull the new container and restart the cockpit-verify service.
 It will restart automatically when it finds a pause in the verification work.
 
-    # docker pull cockpit/infra-release
+    # docker pull cockpit/release
     # systemctl restart cockpit-release
 

--- a/release/release-runner
+++ b/release/release-runner
@@ -182,7 +182,7 @@ if [ -n "$REPO" ]; then
     if [ -d ".git" ]; then
         git fetch origin
     else
-        git clone https://github.com/cockpit-project/cockpit .
+        git clone "$REPO" .
     fi
     if [ -z "$RELEASE_TAG" -a -d ".git" ]; then
         RELEASE_TAG=$(git describe --match='[0-9]*' --abbrev=0 origin/master || true)


### PR DESCRIPTION
This allows release-runner to work for projects other than cockpit.
    
release/cockpit-release.service already passes in that repository
through `-r`, so for cockpit this works exactly as before.
