### PR TITLE
tests: Clean the tree after resetting

### DIFF
--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -66,6 +66,7 @@ function task() {
 for i in $(seq 1 30); do
     git -C cockpit fetch origin
     git -C cockpit reset --hard origin/master
+    git -C cockpit clean -dxff
 
     line="$(task)"
     if [ -n "$line" ]; then


### PR DESCRIPTION
This will guarantee that we don't have any built leftovers from previous
runs. This becomes even more important when testing third-party modules.