### PR TITLE
release-runner: Fix -t option

### DIFF
--- a/release/release-runner
+++ b/release/release-runner
@@ -134,7 +134,7 @@ runner()
     fi
 }
 
-while getopts "l:nqr:tvxz" opt; do
+while getopts "l:nqr:t:vxz" opt; do
     case "$opt" in
     l)
         SINK="$OPTARG"


### PR DESCRIPTION
Declare -t option to have an argument, otherwise it fails with

    release/release-runner: line 153: OPTARG: unbound variable