### PR TITLE
release: Replace release polling with GitHub trigger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ release-container: docker-running
 release-push: docker-running
 	base/push-container docker.io/cockpit/release
 
-release-install: release-container
-	cp release/cockpit-release.service /etc/systemd/system/
+release-install:
+	cp release/releasetrigger.socket release/releasetrigger@.service release/cockpit-release.service /etc/systemd/system/
 	systemctl daemon-reload
-	systemctl enable cockpit-release
+	systemctl enable --now releasetrigger.socket
 
 tests-shell: docker-running
 	docker run -ti --rm \

--- a/release/README
+++ b/release/README
@@ -15,13 +15,11 @@ been prepared.
 
 # Cockpit Release Runner
 
-This is the container for the Cockpit release runner.
+This is the container for the Cockpit release runner. It normally gets
+activated through a HTTP request: <http://host:8090/cockpit>. The "/cockpit"
+path specifies the systemd service name to start (<name>-release.service).
 
 ## How to deploy
-
-First get the container:
-
-    # docker pull cockpit/release
 
 Setup a 'cockpit' user:
 
@@ -45,27 +43,21 @@ update github status:
     /home/cockpit/.gitconfig
     /home/cockpit/.gnupg
 
-Get the service file. Edit it before installing it. Set the TEST_OS.
-Then install it and run it:
+Install the systemd services:
 
-    # wget https://raw.githubusercontent.com/cockpit-project/cockpituous/master/release/cockpit-release.service
-    # cp cockpit-release.service /etc/systemd/system/
-    # systemctl daemon-reload
-    # systemctl enable cockpit-release
-    # systemctl start cockpit-release
+    # git clone https://github.com/cockpit-project/cockpituous.git /tmp/cockpituous
+    # make -C /tmp/cockpituous release-install
+
+Add a webhook to your GitHub project that calls http://host:8090/cockpit on
+"create" events (and nothing else!); set this in "Let me select individual events".
 
 # Troubleshooting
 
-Some helpful commands:
+Follow the logs of a running release:
 
     # journalctl -fu cockpit-release
-    # systemctl stop cockpit-release
 
-# Updates
+Start the container manually (without a webhook):
 
-To update, just pull the new container and restart the cockpit-verify service.
-It will restart automatically when it finds a pause in the verification work.
-
-    # docker pull cockpit/release
-    # systemctl restart cockpit-release
+    # systemctl start cockpit-release
 

--- a/release/cockpit-release.service
+++ b/release/cockpit-release.service
@@ -5,11 +5,8 @@ After=docker.service
 
 [Service]
 Environment="RELEASE_SINK=fedorapeople.org"
-Restart=always
-RestartSec=1800
 ExecStartPre=-/usr/bin/docker rm -f cockpit-release
 ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-release --privileged --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/release:/build:rw --env=RELEASE_SINK=\"$RELEASE_SINK\" cockpit/release -r https://github.com/cockpit-project/cockpit /build/bots/major-cockpit-release"
 ExecStop=/usr/bin/docker rm -f cockpit-release
-
-[Install]
-WantedBy=multi-user.target
+StartLimitInterval=1day
+StartLimitBurst=3

--- a/release/releasetrigger.socket
+++ b/release/releasetrigger.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=GitHub WebHook release trigger
+
+[Socket]
+ListenStream=8090
+Backlog=1
+MaxConnections=1
+Accept=yes
+
+[Install]
+WantedBy=sockets.target

--- a/release/releasetrigger@.service
+++ b/release/releasetrigger@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=GitHub WebHook release trigger
+Requires=releasetrigger.socket
+After=network.target
+
+[Service]
+ExecStart=/bin/sh -ec 'read method path _ <&3; \
+    project=$$(echo "$${path#/}" | grep '^[[:alnum:]]*$'); \
+    unit="$${project}-release.service"; \
+    if systemctl cat "$$unit" >/dev/null 2>&1; then \
+        status="200 OK"; systemctl start --no-block "$$unit"; \
+    else \
+        status="404 Not Found"; \
+    fi; \
+    printf "HTTP/1.0 $$status\\nContent-Type: text/plain\\nContent-Length: 2\\n\\nOK\\n" >&3; sleep 1'


### PR DESCRIPTION
So far cockpit-release.service restarted itself every 30 minutes to
poll if a new release is pending. This is a waste most of the time, and
an annoying delay when a release actually happens.

Make this unit start via a HTTP request instead, so that it becomes
suitable as a GitHub "create" web hook, and generalize the mechanism to
work with more than just cockpit:

Add a releasetrigger.socket that listens on port 8090 and activates
releasetrigger@.service. This receives a HTTP request and uses the
path to select the project (sanitizing it to just alphanumeric
characters). If `<project>-release.service` exists, start that and
report success, otherwise report a 404.

There is no user input aside from the sanitized HTTP path, so at most a
remote can try to DoS. Mitigate this by limiting cockpit-release.service
to three starts a day, and if it is already running trying to start it
again is a no-op.

Drop the `make release-install` dependency to `release-container`. There
is no need to build a container image, we want to user the one from
dockerhub, as documented in README.

Update the documentation accordingly. Refer to `make release-install`
instead of replicating the setup commands.