### PR TITLE
tests: Make deployable in restricted Openshift SCC

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -74,7 +74,7 @@ RUN mkdir -p /usr/local/bin /home/user /build /secrets /cache/images /cache/gith
     ln -snf /secrets/zanata.ini /home/user/.config/zanata.ini && \
     git clone https://github.com/cockpit-project/cockpit /build/cockpit && \
     cd /build/cockpit && npm install && \
-    chown -R user /build /secrets /cache /home/user
+    chmod -R ugo+w /build /secrets /cache /home/user
 
 # Prevent us from screwing around with KVM settings in the container
 RUN touch /etc/modprobe.d/kvm-amd.conf && touch /etc/modprobe.d/kvm-intel.conf
@@ -87,7 +87,8 @@ ENV LIBGUESTFS_BACKEND=direct \
     TMPDIR=/tmp \
     TEMPDIR=/tmp \
     TEST_DATA=/build \
-    TEST_PUBLISH=
+    TEST_PUBLISH= \
+    HOME=/home/user
 
 VOLUME /secrets /cache /tmp
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -83,7 +83,19 @@ The testing machines can run on Openshift cluster(s).
 
 Create a service account for use by the testing machines. Make sure to have the
 ```oci-kvm-hook``` package installed on all nodes.  This is because of the requirement
-to access ```/dev/kvm```. Further work is necessary to remove this requirement.
+to access ```/dev/kvm```.
+
+This creates all the remaining kubernetes objects. The secrets are created from the
+```/var/lib/cockpit-tests/secrets``` directory as described above.
+
+    $ sudo make tests-secrets | oc create -f -
+    $ oc create -f tests/cockpit-tasks-restricted.json
+
+## High Density Openshift Deployment
+
+In order to deploy on Openshift at high density, shared host mounts between pods
+are necessary. To do this we need to have additional privileges, and the Openshift
+setup is different:
 
     $ oc create -f tests/cockpituous-account.json
     $ oc adm policy add-scc-to-user anyuid -z cockpituous

--- a/tests/cockpit-tasks-restricted.json
+++ b/tests/cockpit-tasks-restricted.json
@@ -1,0 +1,146 @@
+{
+    "apiVersion": "v1",
+    "kind": "List",
+    "items": [
+        {
+            "kind": "ReplicationController",
+            "metadata": {
+                "name": "cockpit-tasks"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "infra": "cockpit-tasks"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "infra": "cockpit-tasks"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "cockpit-tasks",
+                                "image": "docker.io/cockpit/tests:2018-03-08",
+                                "env": [
+                                    {
+                                        "name": "TEST_JOBS",
+                                        "value": "8"
+                                    },
+                                    {
+                                        "name": "TEST_PUBLISH",
+                                        "value": "sink"
+                                    }
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "name": "secrets",
+                                        "mountPath": "/secrets",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "name": "cache",
+                                        "mountPath": "/cache",
+                                        "readOnly": false
+                                    },
+                                    {
+                                        "name": "shm",
+                                        "mountPath": "/dev/shm",
+                                        "readonly": false
+                                    },
+                                    {
+                                        "name": "tmp",
+                                        "mountPath": "/tmp",
+                                        "readonly": false
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "cockpit-images",
+                                "image": "docker.io/cockpit/images",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 443,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "name": "secrets",
+                                        "mountPath": "/secrets",
+                                        "readOnly": true
+                                    },
+                                    {
+                                        "name": "cache",
+                                        "mountPath": "/cache",
+                                        "readOnly": false
+                                    },
+                                    {
+                                        "name": "hack-hide-virtual-net",
+                                        "mountPath": "/sys/devices/virtual/net/",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "secrets",
+                                "secret": {
+                                    "secretName": "cockpit-tests-secrets"
+                                }
+                            },
+                            {
+                                "name": "cache",
+                                "emptyDir": { }
+                            },
+                            {
+                                "name": "shm",
+                                "emptyDir": {
+                                    "medium": "Memory"
+                                }
+                            },
+                            {
+                                "name": "tmp",
+                                "emptyDir": { }
+                            },
+                            {
+                                "name": "hack-hide-virtual-net",
+                                "emptyDir": { }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "kind": "Service",
+            "metadata": {
+                "name": "cockpit-images"
+            },
+            "spec": {
+                "clusterIP": "None",
+                "selector": {
+                    "infra": "cockpit-tasks"
+                },
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 80,
+                        "protocol": "TCP"
+                    },
+                    {
+                        "name": "https",
+                        "port": 443,
+                        "protocol": "TCP"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -16,21 +16,21 @@ if [ $loop = "yes" ]; then
 fi
 
 # Make sure directory is writable
-sudo mkdir -p /cache/github /cache/images
-sudo chown user:user /cache /cache/github /cache/images
+mkdir -p /cache/github /cache/images
 
 # HACK: /sys is read-only in containers. And libvirt tries
 # to write there, but only if a specific subtree exists here
-sudo -n mount -o bind /run /sys/devices/virtual/net/ || true
+if [ -d /sys/devices/virtual/net/lo ]; then
+    sudo -n mount -o bind /run /sys/devices/virtual/net/ || true
+fi
 
 # In case a network has leaked in from elsewhere
-if sudo -n ip address show dev cockpit1 >/dev/null 2>/dev/null; then
+if ip address show dev cockpit1 >/dev/null 2>/dev/null; then
 	sudo -n ip link set cockpit1 down || true
 	sudo -n brctl delbr cockpit1 || true
 fi
 
 if [ ! -d cockpit ]; then
-    sudo chown -R user .
     git clone https://github.com/cockpit-project/cockpit
 fi
 
@@ -63,7 +63,8 @@ function task() {
 }
 
 # Perform N tasks or waits, then restart
-for i in $(seq 1 30); do
+TASKS=300
+for i in $(seq 1 $TASKS); do
     git -C cockpit fetch origin
     git -C cockpit reset --hard origin/master
     git -C cockpit clean -dxff


### PR DESCRIPTION
Many Openshift clusters don't give us anything but the restricted
SCC, which doesn't allow host mounts. We typically use host mounts
to acheive high density of bots, but when these are not available
we have to fall back to other methods.

Includes:

 * A new pod definition for the restricted SCC case
 * Don't use sudo when unpredictable Openshift UIDs are used
 * Setup $HOME directory properly with unpredictable UIDs
 * Give access to the right files with unpredicable UIDs