### PR TITLE
release: Add welder-web-release.service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ release-push: docker-running
 	base/push-container docker.io/cockpit/release
 
 release-install:
-	cp release/releasetrigger.socket release/releasetrigger@.service release/cockpit-release.service /etc/systemd/system/
+	cp release/releasetrigger.socket release/releasetrigger@.service release/cockpit-release.service release/welder-web-release.service /etc/systemd/system/
 	systemctl daemon-reload
 	systemctl enable --now releasetrigger.socket
 

--- a/release/welder-web-release.service
+++ b/release/welder-web-release.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=welder-web Release Runner
+Requires=docker.service
+After=docker.service
+
+[Service]
+StartLimitInterval=1day
+StartLimitBurst=3
+Environment="RELEASE_SINK=fedorapeople.org"
+ExecStartPre=-/usr/bin/docker rm -f welder-web-release
+ExecStart=/bin/sh -xc "/usr/bin/docker run --name=welder-web-release --privileged --volume=/home/cockpit:/home/user:rw --volume=/home/cockpit/welder-web-release:/build:rw --env=RELEASE_SINK=\"$RELEASE_SINK\" cockpit/release -r https://github.com/weldr/welder-web.git /build/utils/cockpituous-release"
+ExecStop=/usr/bin/docker rm -f welder-web-release


### PR DESCRIPTION
This is fairly similar to cockpit-release.service, but configures the
git repository and cockpituous script path for welder-web.