### PR TITLE
release: Allow use of strings like EL7 with the release-bodhi script

### DIFF
--- a/release/release-bodhi
+++ b/release/release-bodhi
@@ -78,7 +78,7 @@ prepare()
 commit()
 (
     local number fednvr
-    if test "$FEDORA" != "${FEDORA%el*}" ; then
+    if test "$FEDORA" != "${FEDORA%el*}" -o "$FEDORA" != "${FEDORA%*EL*}"; then
         number=$(echo $FEDORA | tr -d '[A-Z][a-z]')
         fednvr="${NVR/%fc*/el$number}"
     else


### PR DESCRIPTION
These are targetted at the EPEL Fedora repository.