### PR TITLE
images: Fix container to work on OpenShift, and add deployment resources

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -17,7 +17,7 @@ COPY nginx.conf /etc/nginx/
 
 VOLUME /secrets /cache
 
-EXPOSE 80 443
+EXPOSE 8080 8443
 STOPSIGNAL SIGQUIT
 CMD /usr/sbin/nginx -g "daemon off;"
 
@@ -25,4 +25,4 @@ CMD /usr/sbin/nginx -g "daemon off;"
 LABEL INSTALL /usr/bin/docker run -ti --rm --privileged --volume=/:/host:rw --user=root IMAGE /bin/bash -c \"/usr/sbin/chroot /host /bin/sh -s < /usr/local/bin/install-service\"
 
 # Run a simple interactive instance of the tests container
-LABEL RUN /usr/bin/docker run -ti --rm --publish=80:80 --publish=8493:443 --volume=/var/lib/cockpit-tests/secrets:/secrets:ro --volume=/var/cache/cockpit-tests:/cache:rw IMAGE /bin/bash -i
+LABEL RUN /usr/bin/docker run -ti --rm --publish=80:8080 --publish=8493:8443 --volume=/var/lib/cockpit-tests/secrets:/secrets:ro --volume=/var/cache/cockpit-tests:/cache:rw IMAGE /bin/bash -i

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,29 @@
+# Cockpit image server
+
+This is an image store for hosting VMs for Cockpit integration tests.
+
+# Deploying on a host
+
+Secrets need to be set up in the same way as for the
+[tests container](../tests/README.md). This container particularly needs the CA
+and server SSL certificates and the `htpasswd` file for authenticating users
+that are allowed to upload.
+
+    $ sudo docker pull cockpit/images
+    $ sudo atomic install cockpit/tests
+    $ sudo systemctl start cockpit-tests
+
+# Deploying on OpenShift
+
+Again, secrets need to be set up in the same way as for the OpenShift
+deployment for [tests](../tests/README.md), in particular the
+`cockpit-tests-secrets` secret volume.
+
+This needs a large persistent volume to hold the images. Create a claim for it
+with
+
+    oc create -f images/images-claim.yaml
+
+then wait until it gets provisioned, and create the remaining objects with
+
+    oc create -f images/cockpit-images.yaml

--- a/images/cockpit-images.yaml
+++ b/images/cockpit-images.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: List
+items:
+- kind: Pod
+  apiVersion: v1
+  metadata:
+    name: images
+    labels:
+      infra: cockpit-images
+  spec:
+    containers:
+      - name: images
+        image: cockpit/images
+        ports:
+          - containerPort: 8080
+            protocol: TCP
+        ports:
+          - containerPort: 8443
+            protocol: TCP
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
+        - name: images
+          mountPath: /cache/images
+        - name: httpd-log
+          mountPath: /var/log/nginx
+        - name: httpd-state
+          mountPath: /var/lib/nginx
+        - name: httpd-state-tmp
+          mountPath: /var/lib/nginx/tmp
+    volumes:
+    - name: images
+      persistentVolumeClaim:
+        claimName: cockpit-images
+    - name: secrets
+      secret:
+        secretName: cockpit-tests-secrets
+    - name: httpd-log
+      emptyDir:
+        medium: Memory
+    - name: httpd-state
+      emptyDir:
+        medium: Memory
+    - name: httpd-state-tmp
+      emptyDir:
+        medium: Memory
+
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: cockpit-images
+  spec:
+    clusterIP: None
+    selector:
+      infra: cockpit-images
+    ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 8443
+      protocol: TCP
+
+- kind: Route
+  apiVersion: v1
+  metadata:
+    name: images
+  spec:
+    to:
+      kind: Service
+      name: cockpit-images
+    port:
+      targetPort: 8443
+    tls:
+      termination: passthrough

--- a/images/images-claim.yaml
+++ b/images/images-claim.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cockpit-images
+  namespace: cockpit
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi

--- a/images/install-service
+++ b/images/install-service
@@ -20,7 +20,7 @@ Environment="TEST_SECRETS=$SECRETS"
 Restart=always
 RestartSec=60
 ExecStartPre=-/usr/bin/docker rm -f cockpit-images
-ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-images --publish=8090:80 --publish=8493:443 --volume=\$TEST_SECRETS:/secrets:ro --volume=\$TEST_CACHE:/cache:rw cockpit/images"
+ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-images --publish=8090:8080 --publish=8493:8443 --volume=\$TEST_SECRETS:/secrets:ro --volume=\$TEST_CACHE:/cache:rw cockpit/images"
 ExecStop=/usr/bin/docker rm -f cockpit-images
 
 [Install]

--- a/images/nginx.conf
+++ b/images/nginx.conf
@@ -1,7 +1,7 @@
 user user;
 worker_processes 1;
 error_log /var/log/nginx/error.log;
-pid /run/nginx.pid;
+pid /dev/null;
 
 # Load dynamic modules. See /usr/share/nginx/README.dynamic.
 include /usr/share/nginx/modules/*.conf;
@@ -27,8 +27,8 @@ http {
     default_type        application/octet-stream;
 
     server {
-        listen       80 default_server;
-        listen       [::]:80 default_server;
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
         server_name  cockpit-tests;
         root         /cache/images;
 
@@ -38,8 +38,8 @@ http {
     }
 
     server {
-        listen       443 ssl default_server;
-        listen       [::]:443 ssl default_server;
+        listen       8443 ssl default_server;
+        listen       [::]:8443 ssl default_server;
         server_name  cockpit-tests;
         root         /cache/images;
 

--- a/tests/cockpit-tasks.json
+++ b/tests/cockpit-tasks.json
@@ -65,11 +65,11 @@
                                 "image": "docker.io/cockpit/images",
                                 "ports": [
                                     {
-                                        "containerPort": 80,
+                                        "containerPort": 8080,
                                         "protocol": "TCP"
                                     },
                                     {
-                                        "containerPort": 443,
+                                        "containerPort": 8443,
                                         "protocol": "TCP"
                                     }
                                 ],
@@ -130,11 +130,13 @@
                     {
                         "name": "http",
                         "port": 80,
+                        "targetPort": 8080,
                         "protocol": "TCP"
                     },
                     {
                         "name": "https",
                         "port": 443,
+                        "targetPort": 8443,
                         "protocol": "TCP"
                     }
                 ]


### PR DESCRIPTION
I rebuilt the container with this changes, rolled it out onto both CentOS CI *and* our existing image stores on verifymachine4/5 (to demonstrate backwards compatibility). The new image store is here: https://images-cockpit.apps.ci.centos.org/

This needs some fixes to Cockpit's image-{upload,download}, in https://github.com/cockpit-project/cockpit/pull/9321 .