### PR TITLE
tests: Fix container to work with unprivileged users

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -62,7 +62,6 @@ RUN mkdir -p /usr/local/bin /home/user /build /secrets /cache/images /cache/gith
     printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpituous\n' >/home/user/.gitconfig && \
     ln -s /cache/images /build/images && \
     ln -s /cache/images /build/virt-builder && \
-    ln -s /cache/images /build/libvirt/qemu/log && \
     ln -s /cache/github /build/github && \
     ln -s /tmp /build/tmp && \
     mkdir -p /home/user/.config /home/user/.ssh /home/user/.rhel && \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -79,9 +79,6 @@ RUN mkdir -p /usr/local/bin /home/user /build /secrets /cache/images /cache/gith
 # Prevent us from screwing around with KVM settings in the container
 RUN touch /etc/modprobe.d/kvm-amd.conf && touch /etc/modprobe.d/kvm-intel.conf
 
-# Continue to work with a host defined cockpit1 network if necessary
-RUN chmod -v u+s /usr/libexec/qemu-bridge-helper && echo 'allow cockpit1' >> /etc/qemu/bridge.conf
-
 ENV LIBGUESTFS_BACKEND=direct \
     XDG_CACHE_HOME=/build \
     TMPDIR=/tmp \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -73,13 +73,15 @@ RUN mkdir -p /usr/local/bin /home/user /build /secrets /cache/images /cache/gith
     ln -snf /secrets/zanata.ini /home/user/.config/zanata.ini && \
     git clone https://github.com/cockpit-project/cockpit /build/cockpit && \
     cd /build/cockpit && npm install && \
-    chown -R user /build /secrets /cache /home/user
+    chmod g=u /etc/passwd && \
+    chmod -R ugo+w /build /secrets /cache /home/user
 
 # Prevent us from screwing around with KVM settings in the container
 RUN touch /etc/modprobe.d/kvm-amd.conf && touch /etc/modprobe.d/kvm-intel.conf
 
 ENV LIBGUESTFS_BACKEND=direct \
     XDG_CACHE_HOME=/build \
+    HOME=/home/user \
     TMPDIR=/tmp \
     TEMPDIR=/tmp \
     TEST_DATA=/build \

--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -23,12 +23,6 @@ sudo chown user:user /cache /cache/github /cache/images
 # to write there, but only if a specific subtree exists here
 sudo -n mount -o bind /run /sys/devices/virtual/net/ || true
 
-# In case a network has leaked in from elsewhere
-if sudo -n ip address show dev cockpit1 >/dev/null 2>/dev/null; then
-	sudo -n ip link set cockpit1 down || true
-	sudo -n brctl delbr cockpit1 || true
-fi
-
 if [ ! -d cockpit ]; then
     sudo chown -R user .
     git clone https://github.com/cockpit-project/cockpit

--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -15,16 +15,22 @@ if [ $loop = "yes" ]; then
     set -x
 fi
 
-# Make sure directory is writable
-sudo mkdir -p /cache/github /cache/images
-sudo chown user:user /cache /cache/github /cache/images
+# ensure symlinks from /build/ are valid even when mounting /cache
+mkdir -p /cache/github /cache/images
 
 # HACK: /sys is read-only in containers. And libvirt tries
 # to write there, but only if a specific subtree exists here
-sudo -n mount -o bind /run /sys/devices/virtual/net/ || true
+if [ -d /sys/devices/virtual/net/lo ]; then
+    sudo -n mount -o bind /run /sys/devices/virtual/net/ || true
+fi
+
+# ensure we have a passwd entry for random UIDs
+# https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html
+if ! whoami && [ -w /etc/passwd ]; then
+    echo "user:x:$(id -u):0:random uid:${HOME:-/home/user}:/sbin/nologin" >> /etc/passwd
+fi
 
 if [ ! -d cockpit ]; then
-    sudo chown -R user .
     git clone https://github.com/cockpit-project/cockpit
 fi
 


### PR DESCRIPTION
In some restricted OpenShift environments pods get started with a random
UID:

 - Don't chown files and use sudo, use world-writable directories
   instead.
 - Explicitly set $HOME, as the random UID does not have a passwd entry.
 - Ensure we have a passwd entry for a random UID, so that ssh works.

All of that is backwards compatible with the current container version
on privileged OpenShift.

Based on patch by Stef Walter, with some simplifications and adding the 
passwd fix.