### PR TITLE
base: Set Unicode locale

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -17,3 +17,5 @@ RUN dnf -y update && \
     dnf clean all
 RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
     mkdir -p /home/user/.ssh && mkdir -p /usr/local/bin
+
+ENV LANG=C.UTF-8


### PR DESCRIPTION
We often process non-ASCII strings in our tests and logs.  Set a proper
Unicode locale to avoid Unicode{En,De}codeErrors.

---

We currently get a lot of failed test runs that just crash in the middle; [example](https://fedorapeople.org/groups/cockpit/logs/pull-9551-20180701-204949-872c225a-verify-fedora-i386/log):
```
Traceback (most recent call last):
  File "/build/cockpit/bots/../test/verify/run-tests", line 66, in <module>
    sys.exit(main())
  File "/build/cockpit/bots/../test/verify/run-tests", line 63, in main
    return run(opts)
  File "/build/cockpit/bots/../test/verify/run-tests", line 43, in run
    return testlib.test_main(options=opts, suite=suite)
  File "/build/cockpit/test/common/testlib.py", line 1251, in test_main
    ret = runner.run(suite)
  File "/build/cockpit/test/common/testlib.py", line 1098, in run
    join_some(self.jobs - 1)
  File "/build/cockpit/test/common/testlib.py", line 1091, in join_some
    failed, retry = self.filterOutput(test, failed, output)
  File "/build/cockpit/test/common/testlib.py", line 1160, in filterOutput
    (changed, unused) = proc.communicate(output)
  File "/usr/lib64/python2.7/subprocess.py", line 483, in communicate
    return self._communicate(input)
  File "/usr/lib64/python2.7/subprocess.py", line 1124, in _communicate
    stdout, stderr = self._communicate_with_poll(input)
  File "/usr/lib64/python2.7/subprocess.py", line 1188, in _communicate_with_poll
    input_offset += os.write(fd, chunk)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2026' in position 2613: ordinal not in range(128)
```