### PR TITLE
release: Don't force ssh TTY

### DIFF
--- a/release/release-runner
+++ b/release/release-runner
@@ -217,5 +217,5 @@ else
         else
             printf '\n{ "message": "Release failed: %s", "irc": { "channel": "#cockpit" } }' "$RELEASE_TAG"
         fi
-    ) | stdbuf -oL -eL ssh -tt "$SINK" -- python sink release-$RELEASE_TAG
+    ) | stdbuf -oL -eL ssh "$SINK" -- python sink release-$RELEASE_TAG
 fi


### PR DESCRIPTION
This causes eternal hangs, as an EOF on stdin is then not sufficient any
more to shut down ssh.  This can easily be demonstrated with

   echo whoami | ssh -tt somehost

This was introduced in commit 3f2c177abfff for release-debian. But this
has been gone for a  while, and there is no real justification to do
that -- nothing in our release scripts ought to need a PTY, and if there
is anything that should be wrapped in `script` or similar.