### PR TITLE
tests: Properly reset HEAD of cockpit checkout

### DIFF
--- a/tests/cockpit-tests
+++ b/tests/cockpit-tests
@@ -65,8 +65,9 @@ function task() {
 # Perform N tasks or waits, then restart
 for i in $(seq 1 30); do
     git -C cockpit fetch origin
-    git -C cockpit reset --hard origin/master
+    git -C cockpit reset --hard
     git -C cockpit clean -dxff
+    git -C cockpit checkout origin/master
 
     line="$(task)"
     if [ -n "$line" ]; then


### PR DESCRIPTION
`git reset --hard origin/master` still leaves the current checkout in
"detached HEAD" state. This sometimes confuses git when testing a new
PR, it then tries to re-apply all commits of the entire history when
cockpit's tests-invoke tries to rebase a checked out PR onto current
master.

Do what we actually mean: First reset and clean up all changes from the
current checkout and then checkout the current origin/master.