### PR TITLE
release: Support spec files with pre-filled Version:

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -72,13 +72,13 @@ this:
 
 ## Spec file requirements
 
-For a spec file to work with the scripts, it should be setup like this:
+For a spec file to work with `release-srpm`, it should have `Version: 0`.
+If your build system already puts the target release version into `Version:`,
+call `release-srpm` with the `-V` option instead, otherwise it will assume that
+this version was already released in a previous srpm and bump the `Release:`.
 
-    Version: 0
-
-And not have any content after the following line:
-
-    %changelog
+The spec file must not have any content after `%changelog`. It will generate a
+changelog from the git tag description.
 
 ## Preparing secrets
 

--- a/release/release-srpm
+++ b/release/release-srpm
@@ -20,6 +20,7 @@
 # -q         RELEASE_QUIET=1        Make output more quiet
 # -s spec    RELEASE_SPEC=spec      Path to spec file
 # -t tag     RELEASE_TAG=tag        Tag to use for SRPM version and log
+# -V         RELEASE_SPECVER=1      Spec file already has released Version: instead of 0
 # -v         RELEASE_VERBOSE=1      Make output more verbose
 #
 
@@ -30,6 +31,7 @@ QUIET=${RELEASE_QUIET:-0}
 VERBOSE=${RELEASE_VERBOSE:-0}
 SOURCE=${RELEASE_SOURCE:-}
 SPEC=${RELEASE_SPEC:-}
+SPECVER=${RELEASE_SPECVER:-0}
 SRPM=${RELEASE_SRPM:-}
 TAG=${RELEASE_TAG:-}
 TARBALL=${RELEASE_TARBALL:-}
@@ -130,7 +132,7 @@ calc_release()
 {
     # Asks rpm to print out the Release line of a spec file, without its 'dist' part
     rpm -q --specfile --queryformat '%{VERSION} %{RELEASE}\n' --undefine dist "$2" | while read ver rel; do
-        if [ "$ver" = "$1" -a "$rel" -gt 0 ]; then
+        if [ "$SPECVER" = 0 ] && [ "$ver" = "$1" -a "$rel" -gt 0 ]; then
             expr "$rel" \+ 1
         else
             echo "1" # different version restart release
@@ -261,7 +263,7 @@ prepare()
     rm -rf $workdir
 }
 
-while getopts "f:qs:t:vp" opt; do
+while getopts "f:qs:t:vVp" opt; do
     case "$opt" in
     f)
         TARBALL="$OPTARG"
@@ -275,6 +277,9 @@ while getopts "f:qs:t:vp" opt; do
         ;;
     s)
         SPEC="$OPTARG"
+        ;;
+    V)
+        SPECVER=1
         ;;
     t)
         TAG="$OPTARG"


### PR DESCRIPTION
starter-kit based projects do release tarballs with spec files that
already have a correct `Version:` instead of `0`. This makes them more
self-contained and able to build working (s)rpms without the help of
cockpituous.

Support this mode with a new `release-srpm -V` option. By default,
release-srpm would generate a spec file with `Release: 2` as it assumes
that `XXX-1` was already released. `-V` tells it that the `Version:` is
already correct and it should leave the `Release:` at 1.