### PR TITLE
tests: Install C/C++ compiler and jq

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -14,11 +14,14 @@ RUN dnf -y update && \
         fedpkg \
         fontconfig \
         freetype \
+        gcc \
+        gcc-c++ \
         gettext \
         git \
         gnupg \
         grubby \
         hardlink \
+        jq \
         kernel \
         koji \
         krb5-workstation \


### PR DESCRIPTION
This will be necessary for updating translations with zanata-js for
welder-web.

Fixes #197