### PR TITLE
release: Adjust to moved Cockpit release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ release-cockpit: docker-running
 		--volume=/home/cockpit/release:/build:rw \
 		--volume=$(CURDIR)/release:/usr/local/bin \
 		docker.io/cockpit/release \
-		-r https://github.com/cockpit-project/cockpit /build/bots/major-cockpit-release
+		-r https://github.com/cockpit-project/cockpit /build/tools/cockpituous-release
 
 release-container: docker-running
 	docker build -t docker.io/cockpit/release:$(TAG) release

--- a/release/README.md
+++ b/release/README.md
@@ -40,7 +40,7 @@ Fedora, COPR, Ubuntu PPA, etc.) the release should be done.
 These delivery scripts are run by [release-runner](./release-runner) in such a
 way that they all prepare their steps, and then commit them after everything
 has been prepared. See the delivery scripts of
-[cockpit](https://github.com/cockpit-project/cockpit/blob/master/bots/major-cockpit-release)
+[cockpit](https://github.com/cockpit-project/cockpit/blob/master/tools/cockpituous-release)
 and
 [welder-web](https://github.com/weldr/welder-web/blob/master/utils/cockpituous-release)
 as examples.
@@ -154,7 +154,7 @@ Add a webhook to your GitHub project on the Settings → Webhooks page of your p
 
  * Set a Payload URL like
 
-       http://release-cockpit.apps.ci.centos.org/bots/major-cockpit-release
+       http://release-cockpit.apps.ci.centos.org/tools/cockpituous-release
 
    using the URL of the deployed route, and the path to the release script of
    the corresponding project's git tree (the git repository URL will be taken

--- a/release/release-runner
+++ b/release/release-runner
@@ -17,7 +17,7 @@
 #
 # -n                                Dry run, stop before publishing changes
 # -q         RELEASE_QUIET=1        Make output more quiet
-# -r                                Do major release from this repo. Clone it
+# -r                                Do release from this repo. Clone it,
 #                                   lookup latest tag, and run script
 #                                   checking out of tag
 # -v         RELEASE_VERBOSE=1      Make output more verbose


### PR DESCRIPTION
Cockpit's cockpituous release script was moved into tools [1], so adjust
the documentation accordingly.

[1] https://github.com/cockpit-project/cockpit/pull/9914

 - [x] Land https://github.com/cockpit-project/cockpit/pull/9914