### PR TITLE
release: Enable automatic landing in bodhi

### DIFF
--- a/release/release-bodhi
+++ b/release/release-bodhi
@@ -87,7 +87,7 @@ commit()
     fi
 
     echo "$PASSWORD" | setsid -w -- bodhi updates new --type=enhancement --close-bugs --notes="$NOTES" \
-        --stable-karma=2 --unstable-karma=-1 --request=stable --user $USER  \
+        --stable-karma=2 --unstable-karma=-1 --autokarma --request=stable --user $USER  \
         ${fednvr}
 )
 


### PR DESCRIPTION
In the past two years there has never been a case where we had to recall
a Cockpit update, and pushing it to stable is an extra manual step that
one must remember. Let this happen automatically now.

Note that a bad update can still be blocked by a single -1.