### PR TITLE
sink: Make all uploaded files readable

### DIFF
--- a/sink/sink
+++ b/sink/sink
@@ -616,6 +616,7 @@ def main():
         ret = tar.wait()
         if ret:
             raise subprocess.CalledProcessError(ret, "tar")
+        subprocess.check_call(["chmod", "--recursive", "ugo+r", "."])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Make sure that all uploaded/attached files are readable once the
sink is done with them. These are published, and should be world
readable.