### PR TITLE
tests: Make sure we run on Centos CI nodes that expose /dev/kvm

### DIFF
--- a/tests/cockpit-tasks-centosci.yaml
+++ b/tests/cockpit-tasks-centosci.yaml
@@ -50,3 +50,5 @@ items:
             medium: Memory
         - name: tmp
           emptyDir: {}
+        nodeSelector:
+          oci_kvm_hook: allowed


### PR DESCRIPTION
This was lost in translation between my original PoC and bouncing it between Sanne and me.

Right now it seems to work anyway, as apparently oci-kvm-hook got deployed everywhere. But let's be explicit about it anyway.