### PR TITLE
Various improvements to release container

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -48,7 +48,7 @@ ENV NODE_PATH /usr/bin/node.real
 RUN mv /usr/bin/node /usr/bin/node.real
 ADD node-stdio-wrapper /usr/bin/node
 
-VOLUME /home/user /build
+VOLUME /home/user /build /run/secrets/release /run/secrets/webhook
 WORKDIR /build
 USER user
 ENTRYPOINT ["/usr/local/bin/release-runner"]

--- a/release/README.md
+++ b/release/README.md
@@ -124,7 +124,7 @@ webhook, see below.
 To remove the deployment:
 
     oc delete -f release/cockpit-release.yaml
-    oc delete secrets cockpit-release-secrets
+    oc delete secrets cockpit-release-secrets cockpit-release-webhook-secrets
 
 ## Manual operation and Troubleshooting
 

--- a/release/build-secrets
+++ b/release/build-secrets
@@ -1,16 +1,34 @@
 #!/bin/sh
-# Run this in a home directory with all credentials; write OpenShift secrets
-# volume JSON definition to stdout
+# Run this in a home directory with all credentials; write OpenShift secret
+# volumes YAML definitions to stdout
 # https://docs.openshift.com/container-platform/3.9/dev_guide/secrets.html
 set -eu
 
-printf '{ "apiVersion": "v1", "kind": "Secret", "metadata": { "name": "cockpit-release-secrets" }, "data": {\n'
+cat <<EOF
+---
+apiVersion: v1
+kind: List
+items:
+EOF
 
-first=yes
-cd ~
-for f in $(find .ssh .gnupg .config .pki .fedora* .gitconfig -type f); do
-    [ -n "$first" ] || printf ',\n'
-    printf '\t"%s": "%s"' "$(echo $f | sed "s!/!--!g")" "$(base64 --wrap=0 $f)"
-    first=''
+# release secrets
+cat <<EOF
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: cockpit-release-secrets
+  data:
+EOF
+for f in $(find .ssh .gnupg .config .pki .fedora* .gitconfig -type f ! -name github-webhook-token); do
+    printf '    %s: %s\n' "$(echo $f | sed "s!/!--!g")" "$(base64 --wrap=0 $f)"
 done
-printf '\n} }\n'
+
+# webhook secrets
+cat <<EOF
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: cockpit-release-webhook-secrets
+  data:
+    .config--github-webhook-token: $(base64 --wrap=0 .config/github-webhook-token)
+EOF

--- a/release/cockpit-release.yaml
+++ b/release/cockpit-release.yaml
@@ -17,13 +17,19 @@ items:
             protocol: TCP
         command: [ "webhook" ]
         volumeMounts:
-        - name: secrets
+        - name: release-secrets
           mountPath: /run/secrets/release
           readOnly: true
+        - name: webhook-secrets
+          mountPath: /run/secrets/webhook
+          readOnly: true
     volumes:
-    - name: secrets
+    - name: release-secrets
       secret:
         secretName: cockpit-release-secrets
+    - name: webhook-secrets
+      secret:
+        secretName: cockpit-release-webhook-secrets
 
 - kind: Service
   apiVersion: v1

--- a/release/cockpit-release.yaml
+++ b/release/cockpit-release.yaml
@@ -2,34 +2,41 @@
 apiVersion: v1
 kind: List
 items:
-- kind: Pod
+- kind: ReplicationController
   apiVersion: v1
   metadata:
     name: release
-    labels:
-      infra: cockpit-release
   spec:
-    containers:
-      - name: release
-        image: cockpit/release
-        ports:
-          - containerPort: 8080
-            protocol: TCP
-        command: [ "webhook" ]
-        volumeMounts:
+    replicas: 1
+    selector:
+      infra: cockpit-release
+    template:
+      metadata:
+        name: release
+        labels:
+          infra: cockpit-release
+      spec:
+        containers:
+          - name: release
+            image: cockpit/release
+            ports:
+              - containerPort: 8080
+                protocol: TCP
+            command: [ "webhook" ]
+            volumeMounts:
+            - name: release-secrets
+              mountPath: /run/secrets/release
+              readOnly: true
+            - name: webhook-secrets
+              mountPath: /run/secrets/webhook
+              readOnly: true
+        volumes:
         - name: release-secrets
-          mountPath: /run/secrets/release
-          readOnly: true
+          secret:
+            secretName: cockpit-release-secrets
         - name: webhook-secrets
-          mountPath: /run/secrets/webhook
-          readOnly: true
-    volumes:
-    - name: release-secrets
-      secret:
-        secretName: cockpit-release-secrets
-    - name: webhook-secrets
-      secret:
-        secretName: cockpit-release-webhook-secrets
+          secret:
+            secretName: cockpit-release-webhook-secrets
 
 - kind: Service
   apiVersion: v1

--- a/release/github_handler.py
+++ b/release/github_handler.py
@@ -1,0 +1,87 @@
+import os
+import hmac
+import logging
+import json
+import http.server
+
+__all__ = (
+    "GithubHandler",
+)
+
+class GithubHandler(http.server.BaseHTTPRequestHandler):
+    def check_sig(self, request):
+        '''Validate github signature of request.
+
+        See https://developer.github.com/webhooks/securing/
+        '''
+        # load key
+        keyfile = os.path.expanduser('~/.config/github-webhook-token')
+        try:
+            with open(keyfile, 'rb') as f:
+                key = f.read().strip()
+        except IOError as e:
+            logging.error('Failed to load GitHub key: %s', e)
+            return False
+
+        sig_sha1 = self.headers.get('X-Hub-Signature', '')
+        payload_sha1 = 'sha1=' + hmac.new(key, request, 'sha1').hexdigest()
+        if hmac.compare_digest(sig_sha1, payload_sha1):
+            return True
+        logging.error('GitHub signature mismatch! received: %s calculated: %s',
+                      sig_sha1, payload_sha1)
+        return False
+
+    def fail(self, reason, code=404):
+        logging.error(reason)
+        self.send_response(code)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(reason.encode())
+        self.wfile.write(b'\n')
+
+    def success(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(b'OK\n')
+
+    def do_POST(self):
+        content_length = int(self.headers.get('Content-Length', 0))
+        request = self.rfile.read(content_length)
+
+        if not self.check_sig(request):
+            self.send_response(403)
+            self.end_headers()
+            return
+
+        event = self.headers.get('X-GitHub-Event')
+
+        request = request.decode('UTF-8')
+        logging.debug('event: %s, path: %s', event, self.path)
+        logging.debug(request)
+
+        request = json.loads(request)
+
+        try:
+            request['repository']['clone_url']
+        except KeyError:
+            self.fail('Request misses repository clone_url')
+            return
+
+        if event == 'ping':
+            self.success()
+            return
+        err = self.handle_event(event, request)
+        if err:
+            self.fail(err[1], code=err[0])
+        else:
+            self.success()
+
+    def handle_event(self, event, request):
+        '''Handle GitHub event type "event"
+
+        "ping" is already handled internally.
+
+        Returns: None for success, or a (code, message) tuple on errors.
+        '''
+        raise NotImplementedError('must be implemented in subclasses')

--- a/release/webhook
+++ b/release/webhook
@@ -16,7 +16,8 @@ HOME_DIR = '/tmp/home'
 BUILD_DIR = os.path.join(HOME_DIR, 'build')
 # FIXME: make this a request parameter
 SINK = 'fedorapeople.org'
-SECRETS = '/run/secrets/release'
+RELEASE_SECRETS = '/run/secrets/release'
+WEBHOOK_SECRETS = '/run/secrets/webhook'
 
 
 def setup():
@@ -37,13 +38,14 @@ fi''' % HOME_DIR, shell=True)
     # install credentials from secrets volume; copy to avoid world-readable files
     # (which e. g. ssh complains about), and to make them owned by our random UID.
     old_umask = os.umask(0o77)
-    for f in os.listdir(SECRETS):
-        if f.startswith('..'):
-            continue  # secrets volume internal files
-        src = os.path.join(SECRETS, f)
-        dest = os.path.join(HOME_DIR, f.replace('--', '/'))
-        os.makedirs(os.path.dirname(dest), exist_ok=True)
-        shutil.copyfile(src, dest)
+    for volume in [RELEASE_SECRETS, WEBHOOK_SECRETS]:
+        for f in os.listdir(volume):
+            if f.startswith('..'):
+                continue  # secrets volume internal files
+            src = os.path.join(volume, f)
+            dest = os.path.join(HOME_DIR, f.replace('--', '/'))
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            shutil.copyfile(src, dest)
     os.umask(old_umask)
 
 

--- a/release/webhook
+++ b/release/webhook
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
 import os
-import hmac
 import logging
-import json
 import subprocess
 import shutil
 import http.server
+
+import github_handler
 
 project = None
 release_tag = None
@@ -47,91 +47,27 @@ fi''' % HOME_DIR, shell=True)
     os.umask(old_umask)
 
 
-class GithubHandler(http.server.BaseHTTPRequestHandler):
-    def check_sig(self, request):
-        '''Validate github signature of request.
-
-        See https://developer.github.com/webhooks/securing/
-        '''
-        # load key
-        keyfile = os.path.join(HOME_DIR, '.config/github-webhook-token')
-        try:
-            with open(keyfile, 'rb') as f:
-                key = f.read().strip()
-        except IOError as e:
-            logging.error('Failed to load GitHub key: %s', e)
-            return False
-
-        sig_sha1 = self.headers.get('X-Hub-Signature', '')
-        payload_sha1 = 'sha1=' + hmac.new(key, request, 'sha1').hexdigest()
-        if hmac.compare_digest(sig_sha1, payload_sha1):
-            return True
-        logging.error('GitHub signature mismatch! received: %s calculated: %s',
-                      sig_sha1, payload_sha1)
-        return False
-
-    def fail(self, reason, code=404):
-        logging.error(reason)
-        self.send_response(code)
-        self.send_header('Content-type', 'text/plain')
-        self.end_headers()
-        self.wfile.write(reason.encode())
-        self.wfile.write(b'\n')
-
-    def success(self):
-        self.send_response(200)
-        self.send_header('Content-type', 'text/plain')
-        self.end_headers()
-        self.wfile.write(b'OK\n')
-
-    def do_POST(self):
+class ReleaseHandler(github_handler.GithubHandler):
+    def handle_event(self, event, request):
         global project, release_tag, release_script
 
-        content_length = int(self.headers.get('Content-Length', 0))
-        request = self.rfile.read(content_length)
-
-        if not self.check_sig(request):
-            self.send_response(403)
-            self.end_headers()
-            return
-
-        event = self.headers.get('X-GitHub-Event')
-
-        logging.debug('event: %s, path: %s', event, self.path)
-        logging.debug(request.decode())
-
-        request = json.loads(request)
-
-        try:
-            project = request['repository']['clone_url']
-        except KeyError:
-            self.fail('Request misses repository clone_url')
-            return
-
-        if event == 'ping':
-            self.success()
-            return
-        elif event != 'create':
-            self.fail('unsupported event ' + event)
-            return
+        if event != 'create':
+            return (501, 'unsupported event ' + event)
 
         ref_type = request.get('ref_type', '')
         if ref_type != 'tag':
-            self.fail('Ignoring ref_type %s, only doing releases on tags' % ref_type, code=501)
-            return
+            return (501, 'Ignoring ref_type %s, only doing releases on tags' % ref_type)
 
         try:
             release_tag = request['ref']
         except KeyError:
-            self.fail('Request is missing tag name in "ref" field')
-            return
+            return (400, 'Request is missing tag name in "ref" field')
 
         if self.path[0] != '/':
-            self.fail('Invalid path, should start with /: ' + self.path)
-            return
+            return (400, 'Invalid path, should start with /: ' + self.path)
 
+        project = request['repository']['clone_url']
         release_script = self.path[1:]
-        self.success()
 
 
 def release(project, tag, script):
@@ -139,7 +75,6 @@ def release(project, tag, script):
     shutil.rmtree(BUILD_DIR, ignore_errors=True)
     subprocess.check_call(['git', 'clone', project, BUILD_DIR])
     e = os.environ.copy()
-    e['HOME'] = HOME_DIR
     e['RELEASE_SINK'] = SINK
     subprocess.check_call(['/usr/local/bin/release-runner', '-r', project, '-t', tag, os.path.join(BUILD_DIR, script)],
                           cwd=BUILD_DIR, env=e)
@@ -151,8 +86,9 @@ def release(project, tag, script):
 
 logging.basicConfig(level=logging.DEBUG)  # INFO
 
+os.environ['HOME'] = HOME_DIR
 setup()
-httpd = http.server.HTTPServer(('', 8080), GithubHandler)
+httpd = http.server.HTTPServer(('', 8080), ReleaseHandler)
 
 # we can't do the long-running release() within the request, that blocks the client
 # run a loop, as kubernetes does not seem to have on-demand pod launching from a service


### PR DESCRIPTION
See individual commits.

I rebuilt and uploaded the cockpit/release container, deployed it on our CentOS CI, and tested it with a fake release of my https://github.com/martinpitt/cockpit-ostree fork. Version 177 was successfully released on [GitHub](https://github.com/martinpitt/cockpit-ostree/releases) and [COPR](https://copr.fedorainfracloud.org/coprs/martinpitt/welder-web/package/cockpit-ostree/), which proves that secrets and the general webhook/release process work.

Full release log: https://fedorapeople.org/groups/cockpit/logs/release-177/log