### PR TITLE
learn: Add simple limit to amount of training data

### DIFF
--- a/learn/cluster.py
+++ b/learn/cluster.py
@@ -184,7 +184,7 @@ class Model():
         self.features = None
 
     # Perform the unsupervised clustering
-    def train(self, items):
+    def train(self, items, limit=None):
         self.clusters = { }
         self.noise = [ ]
 
@@ -192,10 +192,10 @@ class Model():
 
         # Extract the features we want to use for clustering from the items
         self.extractor = extractor.Extractor()
-        self.features = self.extractor.fit_transform(items)
+        self.features = self.extractor.fit_transform(items, limit=limit)
 
         if self.verbose:
-            sys.stderr.write("{0}: Items to train\n".format(len(self.features)))
+            sys.stderr.write("{0}: Items to cluster\n".format(len(self.features)))
 
         jobs = os.cpu_count() or -1
         start = time.perf_counter()

--- a/learn/extractor.py
+++ b/learn/extractor.py
@@ -131,7 +131,7 @@ class Extractor():
         tokenized = tokenized or map(Extractor.tokenize, items)
         self.extract.fit(tokenized)
 
-    def transform(self, items, tokenized=None):
+    def transform(self, items, tokenized=None, limit=None):
         tokenized = list(tokenized or map(Extractor.tokenize, items))
         results = [ ]
         for index, item in enumerate(items):
@@ -158,12 +158,14 @@ class Extractor():
                 merged,                   # FEATURE_MERGED
                 timestamp                 # FEATURE_TIMESTAMP
             ))
+        if limit:
+            results = results[-limit:]
         return results
 
-    def fit_transform(self, items):
+    def fit_transform(self, items, limit=None):
         tokenized = list(map(Extractor.tokenize, items))
         self.fit(items, tokenized)
-        return self.transform(items, tokenized)
+        return self.transform(items, tokenized, limit=limit)
 
     def stop_tokens(self):
         return self.extract.stop_words_

--- a/learn/train-tests
+++ b/learn/train-tests
@@ -33,6 +33,9 @@ import cluster
 import data
 import tempfile
 
+DEFAULT_LIMIT = 15000
+DEFAULT_DIRECTORY = "."
+
 class Tee():
     def __init__(self, log, std):
         self.log = log
@@ -47,7 +50,7 @@ class Tee():
         self.log.close(*args)
         self.log.close(*args)
 
-def run(filename_or_fp, directory=".", since=None, verbose=False, name="input", batch=False, **kwargs):
+def run(filename_or_fp, directory=".", limit=None, verbose=False, name="input", batch=False, **kwargs):
     base = tempfile.mkdtemp(prefix='model-', dir=directory)
     log = open(os.path.join(base, "log"), "w")
 
@@ -57,8 +60,8 @@ def run(filename_or_fp, directory=".", since=None, verbose=False, name="input", 
         if verbose:
             sys.stderr.write("{0}\n".format(name))
 
-        items = loader(filename_or_fp, since, verbose)
-        train(items, base, verbose)
+        items = data.load(filename_or_fp, only=data.failures, verbose=verbose)
+        train(items, base, limit, verbose)
 
         # Atomically replace the data
         active = os.path.join(directory, "active")
@@ -88,24 +91,9 @@ def run(filename_or_fp, directory=".", since=None, verbose=False, name="input", 
 
     return result
 
-# Load jsonl style data into items, or if no file specified
-# then just run tests-data to retrieve live data
-def loader(fp, since, verbose):
-    after = None
-    if since:
-        after = time.strftime("%Y-%m-%d", time.gmtime(time.time() - (86400 * since)))
-
-    def only(item):
-        if not data.failures(item):
-            return False
-        date = item.get("date", "")
-        return not after or date > after
-
-    return list(data.load(fp, only=only, verbose=verbose))
-
-def train(items, directory, verbose):
+def train(items, directory, limit, verbose):
     model = cluster.Model(verbose=verbose)
-    model.train(items)
+    model.train(items, limit=limit)
 
     model.dump(directory)
     return cluster.save(directory, model)
@@ -114,9 +102,9 @@ def main(function):
     parser = argparse.ArgumentParser(description="Learn from testing data")
     parser.add_argument("-v", "--verbose", action="store_true",
             help="Verbose output")
-    parser.add_argument("-s", "--since", nargs='?',
-            help="Number of days of data to learn from")
-    parser.add_argument("-d", "--directory", default=os.environ.get("TEST_DATA") or ".",
+    parser.add_argument("-l", "--limit", default=os.environ.get("TEST_LIMIT", DEFAULT_LIMIT), type=int,
+            help="Number of failures to learn from")
+    parser.add_argument("-d", "--directory", default=os.environ.get("TEST_DATA", DEFAULT_DIRECTORY),
             help="Directory to store cluster data in")
     parser.add_argument("-b", "--batch", action="store_true",
             help="Wait for, process, and delete the input files")
@@ -126,7 +114,7 @@ def main(function):
 
     task = {
         "verbose": opts.verbose,
-        "since": opts.since,
+        "limit": opts.limit,
         "directory": opts.directory,
         "batch": opts.batch,
     }


### PR DESCRIPTION
The current DBSCAN model tries to do a full matrix of all
distances in the training data. Lets just limit to the most
recent N data items. Otherwise the size of the model
and runtime becomes unwieldly.

Hopefully we can eventually migrate to a more efficient
clustering algorithm or implementation.

 * [x] https://github.com/cockpit-project/cockpit/pull/10276