### PR TITLE
learn: Add a expose Route for testing

### DIFF
--- a/learn/README.md
+++ b/learn/README.md
@@ -60,6 +60,17 @@ with curl should work:
 
     $ kubectl run -it test --image=docker.io/cockpit/learn --restart=Never -- sh
 
+Alternatively you can expose the service temporarily. By doing the following:
+
+    $ kubectl create -f learn/cockpit-expose.yaml
+    $ kubectl describe route cockpit-expose
+    $ COCKPIT_LEARN_SERVICE_HOST=...
+    $ COCKPIT_LEARN_SERVICE_PORT=80
+
+    ... commands below ...
+
+    $ kubectl delete route cockpit-expose
+
 One uploads the data to the service by placing it in the `/train/` HTTP path:
 
     $ curl --progress-bar --fail --upload-file learn/test-example.jsonl.gz \

--- a/learn/cockpit-expose.yaml
+++ b/learn/cockpit-expose.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: List
+items:
+- kind: Route
+  apiVersion: v1
+  metadata:
+    name: cockpit-expose
+  spec:
+    to:
+      kind: Service
+      name: cockpit-learn
+    port:
+      targetPort: 8080


### PR DESCRIPTION
This is to be used temporarily to interact with the learn
service. However it's not meant for long term usage since
there's no authentication on the service.