### PR TITLE
sink: Add script to clean up old logs

### DIFF
--- a/sink/clean-logs.sh
+++ b/sink/clean-logs.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# clean up obsolete logs on our sink
+
+set -ec
+cd /srv/groups/cockpit/logs
+
+# remove all logs older than two months
+# keep logs for external projects for now, until we get them into machine learning
+# ironically, the external projects have "-cockpit-" in the name (from a test
+# like cockpit/rhel-7-6/chrome@weldr/welder-web), while cockpit's own tests are
+# called "verify", "selenium", and "container"; this also catches logs from
+# image rebuilds, test learning, etc.
+find -mindepth 1 -maxdepth 1 -type d -mtime +60 ! -name '*-cockpit-*' -print -exec rm -rf {} \;
+
+# remove auxiliary files (screenshots, core files etc.) older than one month;
+# for machine learning we just need "log" and "status"
+find -type f -mtime +30 ! -name log ! -name log.html ! -name status -print -delete
+
+# core dumps and journals are really big, only keep the last two weeks
+find \( -path '*.core*' -o -name '*-FAIL.log' \) -mtime +14 -delete


### PR DESCRIPTION
Our sinks accumulate an impressive amount of log data (roughly 70 GB in
the last month on fedorapeople.org). These are prone to hit the quota
limit or ENOSPC.

Add a script which cleans up obsolete ones. This takes into account that
we don't yet do machine learning on non-Cockpit tests, so keep all of
these external project logs around. These don't have any artifacts like
core dumps etc. right now, so they don't take up much space anyway.