### PR TITLE
tests: Install cypress.io dependencies

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -22,7 +22,7 @@ RUN dnf -y update && \
         grubby \
         hardlink \
         jq \
-        kernel \
+        kernel-headers \
         koji \
         krb5-workstation \
         libguestfs-tools \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -16,10 +16,12 @@ RUN dnf -y update && \
         freetype \
         gcc \
         gcc-c++ \
+        GConf2 \
         gettext \
         git \
         gnupg \
         grubby \
+        gtk2 \
         hardlink \
         jq \
         kernel-headers \
@@ -31,6 +33,7 @@ RUN dnf -y update && \
         libvirt-client \
         libvirt-python \
         libvirt-python3 \
+        libXScrnSaver \
         mock \
         nc \
         net-tools \
@@ -50,6 +53,7 @@ RUN dnf -y update && \
         sudo \
         tar \
         virt-install \
+        xorg-x11-server-Xvfb \
         zanata-client && \
     curl -s -o /tmp/cockpit.spec https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec && \
     sed -i 's/%{npm-version:.*}/0/' /tmp/cockpit.spec && \


### PR DESCRIPTION
This allows the container to run cypress.io tests. It's not currently
clear if and how much we are going to use it, but we at least want to
experiment with it and offer it as an alternative for external Cockpit
projects.

--- 

See https://github.com/cockpit-project/starter-kit/pull/50

Also a second commit to toss out the unnecessary kernel package.