### PR TITLE
sink: Improve error for state collisions

### DIFF
--- a/sink/sink
+++ b/sink/sink
@@ -109,7 +109,8 @@ def contains(expect, result, debug=True):
                     found += 1
             if found == 0:
                 if debug:
-                    sys.stderr.write("Expected " + json.dumps(exp) + " but not present\n")
+                    sys.stderr.write("Expected " + json.dumps(exp) + " but not present in " +
+                                     json.dumps(result) + "\n")
                 return False
             elif found > 1:
                 if debug:


### PR DESCRIPTION
Right now it just says

    Expected [expected data] but not present

Also show what the actual state is, so that we can debug what's going
wrong with collision detection.