### PR TITLE
tasks: Install libappstream-glib

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -27,6 +27,7 @@ RUN dnf -y update && \
         kernel-headers \
         koji \
         krb5-workstation \
+        libappstream-glib \
         libguestfs-tools \
         libguestfs-xfs \
         libvirt \


### PR DESCRIPTION
We need this for validating AppStream metadata, see
https://docs.fedoraproject.org/en-US/packaging-guidelines/AppData/#_app_data_validate_usage