### PR TITLE
tasks: Mount webhook secrets into tasks container

### DIFF
--- a/tasks/cockpit-tasks-bos.yaml
+++ b/tasks/cockpit-tasks-bos.yaml
@@ -30,6 +30,9 @@ items:
           - name: secrets
             mountPath: "/secrets"
             readOnly: true
+          - name: webhook-secrets
+            mountPath: /run/secrets/webhook
+            readOnly: true
           - name: cache
             mountPath: "/cache"
           - name: shm
@@ -53,6 +56,9 @@ items:
         - name: secrets
           secret:
             secretName: cockpit-tasks-secrets
+        - name: webhook-secrets
+          secret:
+            secretName: webhook-secrets
         - name: cache
           hostPath:
             path: "/var/cache/cockpit-tasks"

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -27,6 +27,9 @@ items:
           - name: secrets
             mountPath: "/secrets"
             readOnly: true
+          - name: webhook-secrets
+            mountPath: /run/secrets/webhook
+            readOnly: true
           - name: cache
             mountPath: "/cache"
           - name: images
@@ -40,6 +43,9 @@ items:
         - name: secrets
           secret:
             secretName: cockpit-tasks-secrets
+        - name: webhook-secrets
+          secret:
+            secretName: webhook-secrets
         - name: cache
           emptyDir: {}
         - name: images


### PR DESCRIPTION
The GitHub token has moved to the webhook secrets a while ago, and
the copy got dropped from the tasks secrets.