### PR TITLE
release: Don't put tabs into .spec files

### DIFF
--- a/release/release-srpm
+++ b/release/release-srpm
@@ -191,7 +191,7 @@ prepare()
     trace "Updating spec file"
 
     printf "# This spec file has been automatically updated\n" >> $specfile
-    printf "Version:\t$TAG\nRelease:\t$RELEASE%%{?dist}\n" >> $specfile
+    printf "Version:        $TAG\nRelease:        $RELEASE%%{?dist}\n" >> $specfile
 
     # Start the changelog appropriately
     printf "%%changelog\n" >> $logfile


### PR DESCRIPTION
This causes rpmlint warnings:

    cockpit-composer.src:4: W: mixed-use-of-spaces-and-tabs (spaces: line 4, tab: line 2)

Keep the alignment for a 17-character first column, as we use in cockpit
and welder-web.