### PR TITLE
release: Fix container build

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
 ADD https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec /tmp/cockpit.spec
 
+# whois-mkpasswd conflicts with expect and we don't need it
 RUN dnf -y update && \
+    dnf -y remove whois-mkpasswd && \
     dnf -y install \
 bind-utils \
 bodhi-client \


### PR DESCRIPTION
Recently, the container build started to fail with

    Problem: problem with installed package whois-mkpasswd-5.4.1-1.fc28.x86_64
    - package whois-mkpasswd-5.4.1-1.fc28.x86_64 conflicts with expect provided by expect-5.45.4-1.fc28.x86_64

We don't need mkpasswd, so remove it first.