### PR TITLE
webhook: Update checkouts when merging no-test PRs

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,7 +1,9 @@
 FROM cockpit/infra-base
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
+# whois-mkpasswd conflicts with expect and we don't need it
 RUN dnf -y update && \
+    dnf -y remove whois-mkpasswd && \
     dnf -y install \
         american-fuzzy-lop \
         bind-utils \

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -103,9 +103,6 @@ class ReleaseHandler(github_handler.GithubHandler):
         merged = request['pull_request'].get('merged', False)
 
         logging.info('repo: %s; title: %s; number: %d; action: %s', repo, title, number, action)
-        if '[no-test]' in title:
-            logging.info("Found '[no-test]' in pull request title, skipping testing")
-            return None
         # see https://developer.github.com/v3/activity/events/types/#pullrequestevent for all actions
         if action == 'closed' and merged:
             logging.info("pull request was merged, ensuring cockpit checkout is latest master")
@@ -113,6 +110,9 @@ class ReleaseHandler(github_handler.GithubHandler):
             return None
         if action not in ['opened', 'synchronize']:
             logging.info("action not in ['opened', 'synchronize'], skipping testing")
+            return None
+        if '[no-test]' in title:
+            logging.info("Found '[no-test]' in pull request title, skipping testing")
             return None
 
         cmd = ['bots/tests-scan', '--pull-number', str(number), '--amqp', 'amqp.cockpit.svc.cluster.local:5671']


### PR DESCRIPTION
Do the "[no-test]" check later, to avoid short-circuiting the git
update.