### PR TITLE
tasks: Revert to Fedora 28

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:28
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
 # whois-mkpasswd conflicts with expect and we don't need it


### PR DESCRIPTION
There are too many cockpit test failures with Fedora 29 (e. g. qemu
monitor API), these need to be sorted out first.