### PR TITLE
tasks: Drop cockpit checkout and npm install

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -63,8 +63,6 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
     ln -snf /secrets/rhel-password /home/user/.rhel/pass && \
     ln -snf /secrets/zanata.ini /home/user/.config/zanata.ini && \
     ln -snf /run/secrets/webhook/.config--github-token /home/user/.config/github-token && \
-    git clone https://github.com/cockpit-project/cockpit /build/cockpit && \
-    cd /build/cockpit && npm install && \
     chmod g=u /etc/passwd && \
     chmod -R ugo+w /build /secrets /cache /home/user
 


### PR DESCRIPTION
The `npm install` was meant as pre-caching in the past, but it is moot
now: cockpit-tasks runs `git clean` as pretty much the first thing it
does. The webhook container entirely ignores this and does its own 
checkout. So let's save these > 400 MB from the docker image.

Also drop the checkout -- cockpit-tasks will do that, it doesn't take
long, and it's never going to be really useful as-is, as it quickly gets
out of date.