### PR TITLE
images: Serve files under /logs/ as text/plain

### DIFF
--- a/images/nginx.conf
+++ b/images/nginx.conf
@@ -34,6 +34,8 @@ http {
 
         location / {
             autoindex on;
+
+            location /logs/ { default_type text/plain; }
         }
     }
 
@@ -66,6 +68,8 @@ http {
 
             dav_methods PUT DELETE;
             dav_access user:rw all:r;
+
+            location /logs/ { default_type text/plain; }
         }
     }
 }


### PR DESCRIPTION
Sometimes a cockpit/images container is used as a log sink as well,
and then we want files like "log", "status", and
"TestStorage-blah.FAIL.log" to be served as text/plain.