### PR TITLE
tasks: Add wget

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -35,6 +35,7 @@ RUN dnf -y update && \
         sudo \
         tar \
         virt-install \
+        wget \
         zanata-client && \
     curl -s -o /tmp/cockpit.spec https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec && \
     sed -i 's/%{npm-version:.*}/0/' /tmp/cockpit.spec && \


### PR DESCRIPTION
It was previously pulled in through a dependency. Cockpit's
atomic.bootstrap uses that, and replacing it with curl is a bit
inconvenient.