### PR TITLE
release: Add option to sit on failure

### DIFF
--- a/release/release-runner
+++ b/release/release-runner
@@ -24,6 +24,7 @@
 # -z         RELEASE_CHECK=1        Check access and configuration
 # -l         RELEASE_SINK=1         Host to sink logs to
 # -t         RELEASE_TAG=0.X        Tag to release
+# -s                                Keep running in infinite sleep when release fails
 #
 
 
@@ -41,10 +42,11 @@ FAIL=0
 DRYRUN=0
 JOBS=""
 REPO=""
+SUCCESS_FLAGFILE=
 
 usage()
 {
-    echo "usage: release-runner [-nqvz] [-r REPO] [-t TAG] SCRIPT" >&2
+    echo "usage: release-runner [-nqvzs] [-r REPO] [-t TAG] SCRIPT" >&2
     exit ${1:-2}
 }
 
@@ -167,7 +169,7 @@ runner()
     fi
 }
 
-while getopts "l:nqr:t:vxz" opt; do
+while getopts "l:nqr:t:vxzs" opt; do
     case "$opt" in
     l)
         SINK="$OPTARG"
@@ -192,6 +194,9 @@ while getopts "l:nqr:t:vxz" opt; do
     z)
         RELEASE_CHECK=1
         DRYRUN=1
+        ;;
+    s)
+        SUCCESS_FLAGFILE=$(mktemp -t success-XXXXXX)
         ;;
     -)
         break
@@ -249,8 +254,17 @@ else
         printf '{ "message": "Release running: %s", "irc": { "channel": "#cockpit" } }\n' "$RELEASE_TAG"
         if stdbuf -oL -eL "$0" "$@"; then
             printf '\n{ "message": "Release complete: %s", "irc": { "channel": "#cockpit" } }' "$RELEASE_TAG"
+            # absent flag file means success
+            [ -z "$SUCCESS_FLAGFILE" ] || rm "$SUCCESS_FLAGFILE"
         else
             printf '\n{ "message": "Release failed: %s", "irc": { "channel": "#cockpit" } }' "$RELEASE_TAG"
         fi
     ) | stdbuf -oL -eL ssh "$SINK" -- python sink "release-$(basename $REPO .git)-$RELEASE_TAG"
+fi
+
+# if we want to sit on failure, check if the flag file still exists (i. e. release failed)
+if [ -n "$SUCCESS_FLAGFILE" ] && [ -e "$SUCCESS_FLAGFILE" ]; then
+    rm "$SUCCESS_FLAGFILE"
+    echo "Sleeping indefinitely to debug release failure"
+    sleep infinity
 fi

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,9 +1,7 @@
 FROM fedora:28
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
-# whois-mkpasswd conflicts with expect and we don't need it
 RUN dnf -y update && \
-    dnf -y remove whois-mkpasswd && \
     dnf -y install \
         american-fuzzy-lop \
         chromium-headless \

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -28,7 +28,7 @@ spec:
         - name: release
           image: cockpit/release
           workingDir: /build
-          args: [ "-r", "%(git_repo)s", "-t", "%(tag)s", "%(script)s" ]
+          args: [ "-s", "-r", "%(git_repo)s", "-t", "%(tag)s", "%(script)s" ]
           volumeMounts:
           - name: secrets
             mountPath: /run/secrets/release


### PR DESCRIPTION
If a release fails, the release container stops and makes it hard to
debug the failure or finish the release manually. For that, introduce a
new `-s` (sit) option that will sleep indefinitely instead.

As with a sink the actual release-runner runs in a subprocess, we can't
just pass a variable to the parent; so let the child process remove a
temporary flag file on success.

Enable this option in the webhook.