### PR TITLE
webhook: Increase receive buffer size

### DIFF
--- a/tasks/webhook
+++ b/tasks/webhook
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import socket
 import subprocess
 import shutil
 import http.server
@@ -190,4 +191,11 @@ subprocess.check_call(PASSWD_ENTRY_SCRIPT, shell=True)
 os.environ['HOME'] = HOME_DIR
 
 setup()
-http.server.HTTPServer(('', 8080), ReleaseHandler).serve_forever()
+server = http.server.HTTPServer(('', 8080), ReleaseHandler)
+
+# increase default receive buffer (which is 128 KiB), so that we don't lose
+# burst requests; each request is ~ 30 kB due to the large JSON POST payload
+server.socket.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 2**20)
+logging.info("Setting socket receive buffer size to %u",
+             server.socket.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF))
+server.serve_forever()


### PR DESCRIPTION
GitHub's POST requests are pretty big (~ 30 kB) due to the large JSON
blob. Processing a new pull request takes ~ 5 seconds due to tests-scan,
so we are currently prone to lose requests to "Connection refused".

Increase the default buffer size to fit more pending requests.