### PR TITLE
webhook: Check payload for no-test label

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -39,7 +39,7 @@ RUN dnf -y update && \
     sed -i 's/%{npm-version:.*}/0/' /tmp/cockpit.spec && \
     dnf -y builddep /tmp/cockpit.spec && \
     dnf clean all && \
-    pip3 install pika # python3-pika RPM doesn't support SNI extension for TLS, which is needed for SSL auth with RabbitMQ on OpenShift
+    pip3 install 'pika<0.14.0' # python3-pika RPM doesn't support SNI extension for TLS, which is needed for SSL auth with RabbitMQ on OpenShift
 
 COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/
 

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -110,6 +110,10 @@ class ReleaseHandler(github_handler.GithubHandler):
         if action not in ['opened', 'synchronize']:
             logging.info("action not in ['opened', 'synchronize'], skipping testing")
             return None
+        # tests-scan also checks the labels, but apparently /issues/#/labels is not synchronous right at PR creation
+        if any([l['name'] == 'no-test' for l in request['pull_request'].get('labels', [])]):
+            logging.info("PR has no-test label, skipping testing")
+            return None
 
         cmd = ['bots/tests-scan', '--pull-number', str(number), '--amqp', 'amqp.cockpit.svc.cluster.local:5671']
         # the cockpit repo itself is treated as a special case in tests-scan, in


### PR DESCRIPTION
Tests-scan also checks the labels, but apparently /issues/#/labels is
not synchronous right at PR creation. This caused interactively created
PRs with the label to still get all test requests.