### PR TITLE
webhook: Use tests-scan --pull-data option

### DIFF
--- a/tasks/webhook
+++ b/tasks/webhook
@@ -6,6 +6,7 @@ import subprocess
 import shutil
 import http.server
 import pipes
+import json
 
 import github_handler
 
@@ -110,12 +111,8 @@ class ReleaseHandler(github_handler.GithubHandler):
         if action not in ['opened', 'synchronize']:
             logging.info("action not in ['opened', 'synchronize'], skipping testing")
             return None
-        # tests-scan also checks the labels, but apparently /issues/#/labels is not synchronous right at PR creation
-        if any([l['name'] == 'no-test' for l in request['pull_request'].get('labels', [])]):
-            logging.info("PR has no-test label, skipping testing")
-            return None
 
-        cmd = ['bots/tests-scan', '--pull-number', str(number), '--amqp', 'amqp.cockpit.svc.cluster.local:5671']
+        cmd = ['bots/tests-scan', '--pull-data', json.dumps(request['pull_request']), '--amqp', 'amqp.cockpit.svc.cluster.local:5671']
         # the cockpit repo itself is treated as a special case in tests-scan, in
         # order to avoid complexity avoid supplying the repo option for now
         if repo != 'cockpit-project/cockpit':


### PR DESCRIPTION
GitHub webhooks suffer from a race condition: When getting a PR event,
calling the API about that very PR often delivers outdated results.  But
the webhook event already gets the entire `pull_request` object as part
of its payload, so let's just use that instead of querying it from the
API again.

https://github.com/cockpit-project/cockpit/pull/11556 introduced a new
`--pull-data` option to tests-scan, so pass the data to it.

This also finally obsoletes checking for the no-test label, so revert
commit f7918f6af.

Fixes https://github.com/cockpit-project/cockpit/issues/11554

 - [x] requires https://github.com/cockpit-project/cockpit/pull/11556
 - [x] test: https://github.com/cockpit-project/cockpit/issues/11558