### PR TITLE
tasks: Update manual docker mode

### DIFF
--- a/tasks/README.md
+++ b/tasks/README.md
@@ -53,15 +53,14 @@ Make sure docker and atomic are installed and running:
 
 You may want to customize things like the operating system to test or number of jobs:
 
-    $ sudo mkdir -p /etc/systemd/system/cockpit-tasks.service.d
-    $ sudo sh -c 'printf "[Service]\nEnvironment=TEST_JOBS=8\n" > /etc/systemd/system/cockpit-tasks.service.d/jobs.conf'
-    $ sudo sh -c 'printf "[Service]\nEnvironment=TEST_CACHE=/mnt/nfs/share/cache\n" > /etc/systemd/system/cockpit-tasks.service.d/cache.conf'
+    $ sudo mkdir -p /etc/systemd/system/cockpit-tasks@.service.d
+    $ sudo sh -c 'printf "[Service]\nEnvironment=TEST_JOBS=4\n" > /etc/systemd/system/cockpit-tasks@.service.d/jobs.conf'
+    $ sudo sh -c 'printf "[Service]\nEnvironment=TEST_CACHE=/mnt/nfs/share/cache\n" > /etc/systemd/system/cockpit-tasks@.service.d/cache.conf'
     $ sudo systemctl daemon-reload
 
-And now you can start the service:
+And now you can restart the service:
 
-    $ sudo systemctl start cockpit-tasks
-    $ sudo systemctl enable cockpit-tasks
+    $ sudo systemctl restart cockpit-tasks@*
 
 To generate the certificates needed for cross-cluster amqp auth follow this
 guide:
@@ -72,8 +71,8 @@ guide:
 
 Some helpful commands:
 
-    # journalctl -fu cockpit-tasks
-    # systemctl stop cockpit-tasks
+    # journalctl -fu cockpit-tasks@*
+    # systemctl stop cockpit-tasks@*
 
 ## Updates
 

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -2,28 +2,31 @@
 
 set -eufx
 
-SECRETS=/var/lib/cockpit-secrets/tasks
+SECRETS=/var/lib/cockpit-secrets
 CACHE=/var/cache/cockpit-tasks
+INSTANCES=3
 
 mkdir -p $SECRETS $CACHE
 chown -R 1111:1111 $SECRETS $CACHE
 
-cat <<EOF > /etc/systemd/system/cockpit-tasks.service
+systemctl stop 'cockpit-tasks@*.service'
+
+cat <<EOF > /etc/systemd/system/cockpit-tasks@.service
 [Unit]
-Description=Cockpit Verify
+Description=Cockpit Tasks %i
 Requires=docker.service
 After=docker.service
 
 [Service]
-Environment="TEST_JOBS=4"
+Environment="TEST_JOBS=8"
 Environment="TEST_CACHE=$CACHE"
 Environment="TEST_SECRETS=$SECRETS"
-Environment="TEST_PUBLISH=sink"
+Environment="TEST_PUBLISH=sink-infracloud"
 Restart=always
 RestartSec=60
-ExecStartPre=-/usr/bin/docker rm -f cockpit-tasks
-ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-tasks --volume=\$TEST_CACHE:/cache:rw --volume=\$TEST_SECRETS:/secrets:ro --uts=host --shm-size=500m --privileged --env=TEST_OS=\"\$TEST_OS\" --env=TEST_JOBS=\"\$TEST_JOBS\" --env=TEST_PUBLISH=\"\$TEST_PUBLISH\" cockpit/tasks"
-ExecStop=/usr/bin/docker rm -f cockpit-tasks
+ExecStartPre=-/usr/bin/docker rm -f cockpit-tasks-%i
+ExecStart=/usr/bin/docker run --name=cockpit-tasks-%i --volume=\${TEST_CACHE}:/cache:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro --shm-size=1024m --user=1111 --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 cockpit/tasks
+ExecStop=/usr/bin/docker rm -f cockpit-tasks-%i
 
 [Install]
 WantedBy=multi-user.target
@@ -35,3 +38,5 @@ echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' > /etc/udev/rules.d/80-kvm.rules
 echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
 echo "options kvm-amd nested=1" > /etc/modprobe.d/kvm-amd.conf
 ( rmmod kvm-intel && modprobe kvm-intel ) || ( rmmod kvm-amd && modprobe kvm-amd )
+
+for i in `seq $INSTANCES`; do systemctl enable --now cockpit-tasks@$i; done


### PR DESCRIPTION
- Pass the webhook secrets as a volume
- Pass our CentOS-CI AMQP server
- Switch to our current sink
- Drop obsolete --privileged and --uts options, our containers run fine
  unprivileged
- Set default TEST_JOBS to 8, which is right for our beefy machines
- Use a systemd template unit, and run three instances on every host