### PR TITLE
tasks: Drop obsolete libvirt hack

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -18,12 +18,6 @@ fi
 # ensure symlinks from /build/ are valid even when mounting /cache
 mkdir -p /cache/github /cache/images
 
-# HACK: /sys is read-only in containers. And libvirt tries
-# to write there, but only if a specific subtree exists here
-if [ -d /sys/devices/virtual/net/lo ]; then
-    sudo -n mount -o bind /run /sys/devices/virtual/net/ || true
-fi
-
 # ensure we have a passwd entry for random UIDs
 # https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html
 if ! whoami && [ -w /etc/passwd ]; then


### PR DESCRIPTION
This hasn't worked for a long time, as our containers cannot run sudo.
VMs work fine, so this is obsolete.