### PR TITLE
push-container: Fix choosing podman / docker

### DIFF
--- a/push-container
+++ b/push-container
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 IMAGE=$1
-DOCKER=$(which podman docker 2>/dev/null || true)
+DOCKER=$(which podman docker 2>/dev/null | head -n1)
 ID=$($DOCKER images -q $IMAGE:latest | head -n1)
 
 TAGS=$($DOCKER images --format "table {{.Tag}}\t{{.ID}}" $IMAGE | grep $ID | awk '{print $1}')


### PR DESCRIPTION
This was broken when both were installed.