### PR TITLE
tasks: Fix `make tasks-shell`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ release-push:
 
 tasks-shell:
 	$(DOCKER) run -ti --rm \
-		--privileged --uts=host \
+		--shm-size=1024m \
 		--volume=$(CURDIR)/tasks:/usr/local/bin \
 		--volume=$(TASK_SECRETS):/secrets:ro \
 		--volume=$(WEBHOOK_SECRETS):/run/webhook/secrets:ro \


### PR DESCRIPTION
Add missing --shm-size, as docker defaults to 64MB which is too small
for chromium. Drop the obsolete --privileged and --uts options.

This brings this command in sync with tasks/install-service and the
OpenShift deployments.