### PR TITLE
Drop unnecessary volumes

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
 COPY install-service /usr/local/bin/
 COPY nginx.conf /etc/nginx/
 
-VOLUME /secrets /cache
+VOLUME /cache
 
 EXPOSE 8080 8443
 STOPSIGNAL SIGQUIT

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -50,6 +50,5 @@ ENV NODE_PATH=/usr/bin/node.real LANG=C.UTF-8
 RUN mv /usr/bin/node /usr/bin/node.real
 ADD node-stdio-wrapper /usr/bin/node
 
-VOLUME /run/secrets/release
 WORKDIR /build
 ENTRYPOINT ["/usr/local/bin/release-runner"]

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -74,7 +74,7 @@ ENV LANG=C.UTF-8 \
     TEST_DATA=/build \
     TEST_PUBLISH=
 
-VOLUME /secrets /cache /tmp /run/secrets/webhook
+VOLUME /cache
 
 USER user
 WORKDIR /build


### PR DESCRIPTION
docker creates anonymous, but persistent volumes for all `VOLUME` paths
that don't get an explicit one with `--volume`. These slowly pile up and
lead to `ENOSPC` errors on the hosts.

This mostly affects tasks' /tmp, but it also makes little sense to
create external anonymous volumes for the secrets when they don't get
specified (for manual usage).