### PR TITLE
tasks: Increase root fs size

### DIFF
--- a/tasks/install-service
+++ b/tasks/install-service
@@ -30,7 +30,7 @@ ExecStartPre=-/usr/bin/docker rm -f cockpit-tasks-%i
 ExecStartPre=/usr/bin/docker pull cockpit/tasks
 ExecStartPre=-/usr/bin/docker network rm cockpit-tasks-%i
 ExecStartPre=/usr/bin/docker network create --driver bridge cockpit-tasks-%i
-ExecStart=/usr/bin/docker run --name=cockpit-tasks-%i --hostname=%i-%H --network=cockpit-tasks-%i --volume=\${TEST_CACHE}:/cache:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro --shm-size=1024m --user=1111 --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 cockpit/tasks
+ExecStart=/usr/bin/docker run --name=cockpit-tasks-%i --hostname=%i-%H --network=cockpit-tasks-%i --storage-opt size=50G --volume=\${TEST_CACHE}:/cache:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro --shm-size=1024m --user=1111 --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 cockpit/tasks
 ExecStop=/usr/bin/docker rm -f cockpit-tasks-%i
 ExecStop=/usr/bin/docker network rm cockpit-tasks-%i
 


### PR DESCRIPTION
Commit ab56ed3a08 dropped the automatic volume for /tmp. This caused
weldr/lorax tests to run out of space, as they need lots of temporary
space. Configure the container to have 50 GB root fs space instead of
the default 10 GB.

This is simpler than re-introducing a /tmp volume and having to clean it
up manually.