### PR TITLE
tasks: Add secrets symlink for lorax-test-env

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -58,6 +58,7 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
     ln -snf /secrets/rhel-login /home/user/.rhel/login && \
     ln -snf /secrets/rhel-password /home/user/.rhel/pass && \
     ln -snf /secrets/zanata.ini /home/user/.config/zanata.ini && \
+    ln -snf /secrets/lorax-test-env.sh /home/user/.config/lorax-test-env && \
     ln -snf /run/secrets/webhook/.config--github-token /home/user/.config/github-token && \
     chmod g=u /etc/passwd && \
     chmod -R ugo+w /build /secrets /cache /home/user


### PR DESCRIPTION
This has the cloud credentials for running lorax'es cloud image tests.