### PR TITLE
Add sink OpenShift resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ containers: images-container release-container tests-container
 images-shell:
 	$(DOCKER) run -ti --rm --publish=8493:443 \
 		--volume=$(TASK_SECRETS):/secrets:ro \
-		--volume=$(TASK_CACHE):/cache:rw \
+		--volume=$(TASK_CACHE)/images:/cache/images:rw \
 		--entrypoint=/bin/bash \
         cockpit/images -i
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ containers: images-container release-container tests-container
 	@true
 
 images-shell:
-	$(DOCKER) run -ti --rm --publish=8493:443 \
+	$(DOCKER) run -ti --rm --publish 8080:8080 --publish=8493:8443 \
 		--volume=$(TASK_SECRETS):/secrets:ro \
 		--volume=$(TASK_CACHE)/images:/cache/images:rw \
 		--entrypoint=/bin/bash \

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -2,16 +2,26 @@ FROM fedora:latest
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
 RUN dnf -y update && \
-    dnf -y install nginx && \
-    dnf clean all
+    dnf -y install nginx openssh-server /usr/bin/python && \
+    dnf clean all && \
+    mkdir -p /home/user
+
+# can't use ../sink/sink with docker build
+ADD https://raw.githubusercontent.com/cockpit-project/cockpituous/master/sink/sink /home/user/sink
 
 RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
-    mkdir -p /home/user/.ssh && chown -R user /home/user && \
+    mkdir -p /home/user/.ssh && ln -sf /secrets/id_rsa.pub /home/user/.ssh/authorized_keys && \
+    mkdir -p /home/user/.config && ln -sf /run/secrets/webhook/.config/github-token /home/user/.config/github-token && \
+    ln -sf /run/config/sink /home/user/.config/sink && \
+    ssh-keygen -A && \
+    chmod -R ga+r /etc/ssh /home/user && \
     mkdir -p /usr/local/bin && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log && \
     rm -rf /usr/share/nginx/html && \
-    ln -snf /cache/images /usr/share/nginx/html
+    ln -snf /cache/images /usr/share/nginx/html && \
+    chmod a+x /home/user/sink && \
+    chmod g=u /etc/passwd
 
 COPY install-service /usr/local/bin/
 COPY nginx.conf /etc/nginx/

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -16,7 +16,7 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
 COPY install-service /usr/local/bin/
 COPY nginx.conf /etc/nginx/
 
-VOLUME /cache
+VOLUME /cache/images
 
 EXPOSE 8080 8443
 STOPSIGNAL SIGQUIT
@@ -26,4 +26,4 @@ CMD /usr/sbin/nginx -g "daemon off;"
 LABEL INSTALL /usr/bin/docker run -ti --rm --privileged --volume=/:/host:rw --user=root IMAGE /bin/bash -c \"/usr/sbin/chroot /host /bin/sh -s < /usr/local/bin/install-service\"
 
 # Run a simple interactive instance of the tasks container
-LABEL RUN /usr/bin/docker run -ti --rm --publish=80:8080 --publish=8493:8443 --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks:/cache:rw IMAGE /bin/bash -i
+LABEL RUN /usr/bin/docker run -ti --rm --publish=80:8080 --publish=8493:8443 --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE /bin/bash -i

--- a/images/install-service
+++ b/images/install-service
@@ -20,7 +20,7 @@ Environment="TASK_SECRETS=$SECRETS"
 Restart=always
 RestartSec=60
 ExecStartPre=-/usr/bin/docker rm -f cockpit-images
-ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-images --publish=8090:8080 --publish=8493:8443 --volume=\$TASK_SECRETS:/secrets:ro --volume=\$TASK_CACHE:/cache:rw cockpit/images"
+ExecStart=/bin/sh -xc "/usr/bin/docker run --name=cockpit-images --publish=8090:8080 --publish=8493:8443 --volume=\$TASK_SECRETS:/secrets:ro --volume=\$TASK_CACHE/images:/cache/images:rw cockpit/images"
 ExecStop=/usr/bin/docker rm -f cockpit-images
 
 [Install]

--- a/sink/sink-centosci.yaml
+++ b/sink/sink-centosci.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: v1
+kind: List
+items:
+- kind: ReplicationController
+  apiVersion: v1
+  metadata:
+    name: sink
+  spec:
+    replicas: 1
+    selector:
+      infra: sink
+    template:
+      metadata:
+        name: sink
+        labels:
+          infra: sink
+      spec:
+        containers:
+          - name: sink
+            image: cockpit/images
+            ports:
+              - containerPort: 8080
+                protocol: TCP
+                name: http
+              - containerPort: 8022
+                protocol: TCP
+                name: ssh
+            command: [ 'sh', '-ec', 'OUT=$(sed "/^user:/d; /^$(id -u):/d" /etc/passwd); echo -e "$OUT\nuser:x:$(id -u):0:user:/home/user:/bin/bash" > /etc/passwd; /usr/sbin/sshd -p 8022 -o StrictModes=no -E /dev/stderr; /usr/sbin/nginx -g "daemon off;"' ]
+            volumeMounts:
+            - name: images
+              mountPath: /cache/images
+            - name: webhook-secrets
+              mountPath: /run/secrets/webhook
+              readOnly: true
+            - name: task-secrets
+              mountPath: /secrets
+              readOnly: true
+            - name: config
+              mountPath: /run/config
+              readOnly: true
+            - name: httpd-log
+              mountPath: /var/log/nginx
+            - name: httpd-state
+              mountPath: /var/lib/nginx
+            - name: httpd-state-tmp
+              mountPath: /var/lib/nginx/tmp
+        volumes:
+        - name: images
+          persistentVolumeClaim:
+            claimName: cockpit-images
+        - name: webhook-secrets
+          secret:
+            secretName: webhook-secrets
+        - name: task-secrets
+          secret:
+            secretName: cockpit-tasks-secrets
+        - name: config
+          configMap:
+            name: sink-config
+        - name: httpd-log
+          emptyDir:
+            medium: Memory
+        - name: httpd-state
+          emptyDir:
+            medium: Memory
+        - name: httpd-state-tmp
+          emptyDir:
+            medium: Memory
+
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: sink-http
+  spec:
+    clusterIP: None
+    selector:
+      infra: sink
+    ports:
+    # we use edge termination, so talk to plain http
+    - targetPort: http
+      port: 443
+      protocol: TCP
+      name: http
+
+- kind: Route
+  apiVersion: v1
+  metadata:
+    name: logs-https
+  spec:
+    to:
+      kind: Service
+      name: sink-http
+    port:
+      targetPort: http
+    tls:
+      termination: edge
+
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: sink-ssh
+  spec:
+    clusterIP: None
+    selector:
+      infra: sink
+    ports:
+    - targetPort: 8022
+      port: 8022
+      protocol: TCP
+      name: ssh
+
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: sink-config
+  data:
+    sink: |
+        [Sink]
+        Url: https://logs-https-cockpit.apps.ci.centos.org/logs/%(identifier)s/
+        Logs: /cache/images/logs
+        PruneInterval: 14

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -22,7 +22,7 @@ items:
           - name: TEST_JOBS
             value: '8'
           - name: TEST_PUBLISH
-            value: sink
+            value: sink-local
           - name: AMQP_SERVER
             value: 'amqp.cockpit.svc.cluster.local:5671'
           volumeMounts:


### PR DESCRIPTION
As both of our external sinks are not working, create our own as OpenShift pod. This unfortunately does not work remotely (i. e. for our BOS cluster), but it's at least a better permanent solution for CentOS CI.

This is all rolled out: container rebuild, resources deployed, running. E. g. [log](https://logs-https-cockpit.apps.ci.centos.org/logs/pull-12109-20190621-132121-c86fb7f0-cockpit-project-cockpit-podman-cockpit-fedora-30/log) from PR #12109