### PR TITLE
tasks: Use pika from the official repository

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -28,6 +28,7 @@ RUN dnf -y update && \
         procps-ng \
         python \
         python3 \
+        python3-pika \
         rpm-build \
         rpmdevtools \
         sed \
@@ -38,8 +39,7 @@ RUN dnf -y update && \
     curl -s -o /tmp/cockpit.spec https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec && \
     sed -i 's/%{npm-version:.*}/0/' /tmp/cockpit.spec && \
     dnf -y builddep /tmp/cockpit.spec && \
-    dnf clean all && \
-    pip3 install 'pika<0.14.0' # python3-pika RPM doesn't support SNI extension for TLS, which is needed for SSL auth with RabbitMQ on OpenShift
+    dnf clean all
 
 COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/
 

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -94,18 +94,18 @@ def distributed_queue(amqp_server):
     except ValueError:
         logging.error('Please format amqp_server as host:port')
         sys.exit(1)
+
+    context = ssl.create_default_context(cafile='/run/secrets/webhook/ca.pem')
+    context.load_cert_chain(keyfile='/run/secrets/webhook/amqp-client.key',
+        certfile='/run/secrets/webhook/amqp-client.pem')
+    context.check_hostname = False
     connection = pika.BlockingConnection(pika.ConnectionParameters(
         host=host,
         port=int(port),
-        ssl=True,
-        ssl_options=pika.SSLOptions(
-            ssl_version=ssl.PROTOCOL_TLSv1_2,
-            cafile='/run/secrets/webhook/ca.pem',
-            keyfile='/run/secrets/webhook/amqp-client.key',
-            certfile='/run/secrets/webhook/amqp-client.pem',
-            server_hostname=host),
+        ssl_options=pika.SSLOptions(context, server_hostname=host),
         credentials=pika.credentials.ExternalCredentials()))
     channel = connection.channel()
+
     channel.queue_declare(queue='webhook', auto_delete=False)
     yield channel
     connection.close()


### PR DESCRIPTION
The python3-pika package now supports SNI extension.

- [x] https://github.com/cockpit-project/cockpit/pull/12148
- [x] redeploy