### PR TITLE
tasks: Change default release sink to cluster-local sink

### DIFF
--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -42,7 +42,7 @@ items:
               readOnly: true
             env:
             - name: RELEASE_SINK
-              value: sink
+              value: sink-local
         volumes:
         - name: webhook-secrets
           secret:

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -16,7 +16,7 @@ import github_handler
 
 HOME_DIR = '/tmp/home'
 WEBHOOK_SECRETS = '/run/secrets/webhook'
-SINK = os.getenv('RELEASE_SINK', 'fedorapeople.org')
+SINK = os.getenv('RELEASE_SINK', 'sink-local')
 COCKPIT_CHECKOUT = HOME_DIR + '/cockpit'
 
 # Kubernetes Job template for actually running a release


### PR DESCRIPTION
After commit 6fea47f28 we now have a local sink, which is more robust
than a remote one. Similarly to CentOS CI tasks (commit 702389db),
switch the default release sink to the local service.