### PR TITLE
tasks: Support custom NPM registry

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -33,6 +33,12 @@ if [ $loop != "yes" ]; then
     exec "$@"
 fi
 
+# set up custom NPM registry
+if [ -n "$NPM_REGISTRY" ]; then
+    npm config set registry "$NPM_REGISTRY"
+    echo "Set NPM registry to $NPM_REGISTRY"
+fi
+
 echo "Starting testing"
 
 function update_repo() {

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -22,6 +22,7 @@ Environment="TEST_JOBS=8"
 Environment="TEST_CACHE=$CACHE"
 Environment="TEST_SECRETS=$SECRETS"
 Environment="TEST_PUBLISH=sink-infracloud"
+Environment="NPM_REGISTRY="
 Restart=always
 RestartSec=60
 # give docker pull enough time
@@ -30,7 +31,7 @@ ExecStartPre=-/usr/bin/docker rm -f cockpit-tasks-%i
 ExecStartPre=/usr/bin/docker pull cockpit/tasks
 ExecStartPre=-/usr/bin/docker network rm cockpit-tasks-%i
 ExecStartPre=/usr/bin/docker network create --driver bridge cockpit-tasks-%i
-ExecStart=/usr/bin/docker run --name=cockpit-tasks-%i --hostname=%i-%H --network=cockpit-tasks-%i --storage-opt size=50G --volume=\${TEST_CACHE}:/cache:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro --shm-size=1024m --user=1111 --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 cockpit/tasks
+ExecStart=/usr/bin/docker run --name=cockpit-tasks-%i --hostname=%i-%H --network=cockpit-tasks-%i --storage-opt size=50G --volume=\${TEST_CACHE}:/cache:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 cockpit/tasks
 ExecStop=/usr/bin/docker rm -f cockpit-tasks-%i
 ExecStop=/usr/bin/docker network rm cockpit-tasks-%i
 


### PR DESCRIPTION
For the Red Hat internal tasks machines we want to use an internal
mirror to lessen the strain on npmjs.com.