### PR TITLE
tasks: Support extra CA for custom npm registry

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -38,6 +38,9 @@ if [ -n "$NPM_REGISTRY" ]; then
     npm config set registry "$NPM_REGISTRY"
     echo "Set NPM registry to $NPM_REGISTRY"
 fi
+if [ -r /secrets/npm-registry.crt ]; then
+    export NODE_EXTRA_CA_CERTS=/secrets/npm-registry.crt
+fi
 
 echo "Starting testing"
 


### PR DESCRIPTION
Using a non-default registry may need a custom SSL certificate. If
present in the secrets, set it through `$NODE_EXTRA_CA_CERTS`.

https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file