### PR TITLE
tasks: Adapt to standalone bots project

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -102,8 +102,8 @@ function run_one_task() {
 
     update_repo "$1" "$2"
 
-    if [ ! -d "$dir/bots" ]; then
-        cp -drl "$XDG_CACHE_HOME"/cockpit-project/bots/bots "$dir/"
+    if [ ! -d "$dir/bots" ] && [ ! -L "$dir/bots" ]; then
+        cp -drl "$XDG_CACHE_HOME"/cockpit-project/bots "$dir/"
     fi
 
     # Get a task and execute it, 12 hours max
@@ -113,19 +113,35 @@ function run_one_task() {
     fi
 }
 
+function run_from_queue() {
+    cd "$XDG_CACHE_HOME"/cockpit-project/bots
+    if /usr/bin/timeout 12h ./run-queue --amqp "$AMQP_SERVER"; then
+        work_done=1
+    fi
+}
+
 # on mass deployment, avoid GitHub stampede
 sleep $(shuf -i 0-120 -n 1)
 
-# Perform a couple of tasks or waits, then restart
+PROJECTS="
+cockpit-project/bots
+cockpit-project/cockpit
+cockpit-project/starter-kit
+cockpit-project/cockpit-podman
+weldr/cockpit-composer
+"
+
+# check for tasks
+update_repo  "$XDG_CACHE_HOME"/cockpit-project/bots https://github.com/cockpit-project/bots
+for P in $PROJECTS; do
+    run_one_task "$XDG_CACHE_HOME"/"$P"                 https://github.com/"$P"
+done
+
+# Consume from queue 30 times, then restart
 for i in $(seq 1 30); do
     work_done=
-
-    update_repo  "$XDG_CACHE_HOME"/cockpit-project/bots             https://github.com/cockpit-project/cockpit
-    run_one_task "$XDG_CACHE_HOME"/cockpit-project/cockpit          https://github.com/cockpit-project/cockpit
-    run_one_task "$XDG_CACHE_HOME"/cockpit-project/starter-kit      https://github.com/cockpit-project/starter-kit
-    run_one_task "$XDG_CACHE_HOME"/weldr/cockpit-composer           https://github.com/weldr/cockpit-composer
-    run_one_task "$XDG_CACHE_HOME"/cockpit-project/cockpit-podman   https://github.com/cockpit-project/cockpit-podman
-
+    update_repo  "$XDG_CACHE_HOME"/cockpit-project/bots https://github.com/cockpit-project/bots
+    run_from_queue || true
     # Nothing to do, or failure
     [ -n "$work_done" ] || slumber
 done

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -20,7 +20,7 @@ logging.getLogger("pika").propagate = False
 HOME_DIR = '/tmp/home'
 WEBHOOK_SECRETS = '/run/secrets/webhook'
 SINK = os.getenv('RELEASE_SINK', 'sink-local')
-COCKPIT_CHECKOUT = HOME_DIR + '/cockpit'
+BOTS_CHECKOUT = HOME_DIR + '/bots'
 
 # Kubernetes Job template for actually running a release
 JOB = '''---
@@ -79,16 +79,16 @@ def setup():
     os.umask(old_umask)
 
     ensure_cockpit_checkout()
-    subprocess.check_call(['bots/tests-scan', '--amqp', 'amqp.cockpit.svc.cluster.local:5671'], cwd=COCKPIT_CHECKOUT)
+    subprocess.check_call([os.path.join(BOTS_CHECKOUT, 'tests-scan'), '--amqp', 'amqp.cockpit.svc.cluster.local:5671', '--repo', 'cockpit-project/cockpit'], cwd=BOTS_CHECKOUT)
 
 def ensure_cockpit_checkout():
-    if not os.path.isdir(COCKPIT_CHECKOUT):
-        url = 'https://github.com/cockpit-project/cockpit'
-        subprocess.check_call(['git', 'clone', url, COCKPIT_CHECKOUT])
-    subprocess.check_call(['git', '-C', COCKPIT_CHECKOUT, 'fetch', 'origin'])
-    subprocess.check_call(['git', '-C', COCKPIT_CHECKOUT, 'reset', '--hard'])
-    subprocess.check_call(['git', '-C', COCKPIT_CHECKOUT, 'clean', '-dxff'])
-    subprocess.check_call(['git', '-C', COCKPIT_CHECKOUT, 'checkout', 'origin/master'])
+    if not os.path.isdir(BOTS_CHECKOUT):
+        url = 'https://github.com/cockpit-project/bots'
+        subprocess.check_call(['git', 'clone', url, BOTS_CHECKOUT])
+    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'fetch', 'origin'])
+    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'reset', '--hard'])
+    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'clean', '-dxff'])
+    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'checkout', 'origin/master'])
 
 @contextlib.contextmanager
 def distributed_queue(amqp_server):


### PR DESCRIPTION
TODO after:
- [ ] remove run_queue from .tasks cockpit-project/cockpit#12873
- [ ] remove bots/ from cockpit-project/cockpit#12872


My only concern is that this kinda messes with the whole chances system. Maybe po-refreshes and other tasks would get drowned out too much.

Currently `https://github.com/Gundersanne/cockpituous/tree/simulate-cockpit-bots` is running on some of our CI to simulate `bots/` being a separate project. This seems to be running fine.