### PR TITLE
tasks: Stop copying bots into bots

### DIFF
--- a/push-container
+++ b/push-container
@@ -4,7 +4,7 @@ IMAGE=$1
 DOCKER=$(which podman docker 2>/dev/null | head -n1)
 ID=$($DOCKER images -q $IMAGE:latest | head -n1)
 
-TAGS=$($DOCKER images --format "table {{.Tag}}\t{{.ID}}" $IMAGE | grep $ID | awk '{print $1}')
+TAGS=$($DOCKER images --format "table {{.Tag}}\t{{.ID}}" $IMAGE | sort -u | grep $ID | awk '{print $1}')
 if [ $(echo "$TAGS" | wc -w) -ne "2" ]; then
 	echo "Expected exactly two tags for the image to push: latest and one other"
 	exit 1

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -102,7 +102,7 @@ function run_one_task() {
 
     update_repo "$1" "$2"
 
-    if [ ! -d "$dir/bots" ] && [ ! -L "$dir/bots" ]; then
+    if [ "$(basename $repo_url)" != "bots" ] && [ ! -d "$dir/bots" ] && [ ! -L "$dir/bots" ]; then
         cp -drl "$XDG_CACHE_HOME"/cockpit-project/bots "$dir/"
     fi
 
@@ -132,7 +132,6 @@ weldr/cockpit-composer
 "
 
 # check for tasks
-update_repo  "$XDG_CACHE_HOME"/cockpit-project/bots https://github.com/cockpit-project/bots
 for P in $PROJECTS; do
     run_one_task "$XDG_CACHE_HOME"/"$P"                 https://github.com/"$P"
 done


### PR DESCRIPTION
Only copy our bots checkout into a project directory if it the target
isn't the bots project  itself.

Also drop the redundant explicit `run_one_task()` call for bots, the
loop below will do that as the first thing.