### PR TITLE
tasks: Add back intltool

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -15,6 +15,7 @@ RUN dnf -y update -x coreutils && \
         gcc-c++ \
         git \
         gnupg \
+        intltool \
         jq \
         libappstream-glib \
         libvirt-daemon-kvm \


### PR DESCRIPTION
It recently fell out of cockpit master's build dependencies [1]. Put it
back for the stable cockpit rhel-7.x branches.

[1] https://github.com/cockpit-project/cockpit/pull/12979