### PR TITLE
tasks: Add new zanata client

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,9 +1,7 @@
 FROM fedora:30
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
-# HACK: Do not update `coreutils`, as it breaks `ls .`
-# See https://bugzilla.redhat.com/show_bug.cgi?id=1764152
-RUN dnf -y update -x coreutils && \
+RUN dnf -y update && \
     dnf -y install \
         'dnf-command(builddep)' \
         american-fuzzy-lop \

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -40,6 +40,7 @@ RUN dnf -y update -x coreutils && \
         tar \
         virt-install \
         wget \
+        python3-zanata-client \
         zanata-client && \
     curl -s -o /tmp/cockpit.spec https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec && \
     sed -i 's/%{npm-version:.*}/0/' /tmp/cockpit.spec && \


### PR DESCRIPTION
`zanata-client` does not exist in Fedora 31. Also it requires a lot of
java deps.
`python3-zanata-client` provides `zanata` cli tool.
For now lets have both until all projects migrate to this new zanata
tool.

I'll build and deploy this, then open PR in cockpit which will use this new tool and if that refresh works, then we can land this.