### PR TITLE
tasks: Isolate containers from each other with podman

### DIFF
--- a/tasks/install-service
+++ b/tasks/install-service
@@ -9,7 +9,7 @@ INSTANCES=${INSTANCES:-3}
 if RUNC=$(which podman 2>/dev/null); then
     UNIT_DEPS=''
     DEVICES="--device=/dev/kvm"
-    NETWORK=''  # default works fine
+    NETWORK='--net=slirp4netns'  # isolate containers from each other
     NETWORK_SETUP=''
     NETWORK_TEARDOWN=''
 else


### PR DESCRIPTION
podman in RHEL 8.0 does not yet have the `podman network` commands, so
the containers' networks cannot be isolated in the same way as with
docker. But it does already know about the SLIRP networking, so use
that.

It's more CPU intense than proper kernel bridges, but that doesn't
matter much (it only affects our fallback AWS cloud right now). Let's
move that back to "podman network" once we can rely on RHEL/CentOS 8.1 or
Fedora ≥ 30 on our infrastructure.