### PR TITLE
Fix sink on Fedora 31

### DIFF
--- a/sink/sink
+++ b/sink/sink
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import print_function
 

--- a/sink/sink
+++ b/sink/sink
@@ -122,7 +122,7 @@ def contains(expect, result, debug=True):
             if not contains(expect[key], result.get(key), debug):
                 return False
         return True
-    elif cmp(expect, result) != 0:
+    elif expect != result:
         if debug:
             sys.stderr.write("Expecting " + json.dumps(expect) + " but saw " + json.dumps(result) + "\n")
         return False

--- a/sink/test-logic
+++ b/sink/test-logic
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.

--- a/sink/test-logic
+++ b/sink/test-logic
@@ -1,5 +1,4 @@
-#!/usr/bin/python2
-# -*- coding: utf-8 -*-
+#!/usr/bin/python3
 
 # This file is part of Cockpit.
 #
@@ -59,12 +58,12 @@ CONTAINS = [
 ]
 
 import os
-import imp
+import importlib.machinery
 import unittest
 
 # Import the sink code
 BASE = os.path.dirname(__file__)
-sink = imp.load_source("sink", os.path.join(BASE, "sink"))
+sink = importlib.machinery.SourceFileLoader("sink", os.path.join(BASE, "sink")).load_module()
 
 class TestLogic(unittest.TestCase):
     def testContains(self):

--- a/sink/test-sink
+++ b/sink/test-sink
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 # This file is part of Cockpit.


### PR DESCRIPTION
This is currently a hidden mine: As soon as we'll rebuild the cockpit/images container, this will break the sink.