### PR TITLE
tasks: Use git credentials store

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -44,6 +44,10 @@ fi
 
 XDG_CACHE_HOME=${XDG_CACHE_HOME:-/build}
 
+# Set up github user and token
+git config --global credential.helper store
+echo "https://cockpituous:$(cat ~/.config/github-token)@github.com" > ~/.git-credentials
+
 echo "Starting testing"
 
 function update_repo() {


### PR DESCRIPTION
So we are able to do `git push` directly.
See https://manpages.ubuntu.com/manpages/precise/en/man1/git-credential-store.1.html