### PR TITLE
sink: Fix writing exceptions into log

### DIFF
--- a/sink/sink
+++ b/sink/sink
@@ -340,7 +340,7 @@ class Status(object):
                 reporter.push(data)
             except:
                 traceback.print_exc()
-                traceback.print_exc(file=log)
+                log.write(traceback.format_exc().encode('UTF-8'))
         self.data = data
 
     def begin(self, line, log):


### PR DESCRIPTION
Fixes this crash:
```
  File "./sink", line 624, in <module>
    main()
  File "./sink", line 607, in main
    if status.begin(line, log):
  File "./sink", line 352, in begin
    self.push(data, log)
  File "./sink", line 343, in push
    traceback.print_exc(file=log)
  File "/usr/lib64/python3.6/traceback.py", line 163, in print_exc
    print_exception(*sys.exc_info(), limit=limit, file=file, chain=chain)
  File "/usr/lib64/python3.6/traceback.py", line 105, in print_exception
    print(line, file=file, end="")
TypeError: a bytes-like object is required, not 'str'
```