### PR TITLE
images: Properly serve compressed log files

### DIFF
--- a/images/nginx.conf
+++ b/images/nginx.conf
@@ -36,6 +36,10 @@ http {
             autoindex on;
 
             location /logs/ { default_type text/plain; }
+            location ~ /logs/.*log.gz {
+                add_header Content-Encoding gzip;
+                types { text/plain gz; }
+            }
         }
     }
 
@@ -70,6 +74,10 @@ http {
             dav_access user:rw all:r;
 
             location /logs/ { default_type text/plain; }
+            location ~ /logs/.*log.gz {
+                add_header Content-Encoding gzip;
+                types { text/plain gz; }
+            }
         }
     }
 }


### PR DESCRIPTION
Without that, they got served as application/gzip and thus could only be
downloaded. Like that they can be watched inline in the browser
conveniently.