### PR TITLE
release: Consistent VERSION/RELEASE replacement

### DIFF
--- a/release/release-dockerhub
+++ b/release/release-dockerhub
@@ -82,16 +82,16 @@ prepare()
 
     gitfiles=$(find $WORKDIR -name Dockerfile -printf '%P\n')
     files=$(find $WORKDIR -name Dockerfile)
-    sed -i -e "s/ENV VERSION .*/ENV VERSION $version/" \
-           -e "s/ENV RELEASE .*/ENV RELEASE $release/" \
+    sed -i -e "s/ENV VERSION[ =].*/ENV VERSION=$version/" \
+           -e "s/ENV RELEASE[ =].*/ENV RELEASE=$release/" \
            $files
 
     sed -i -e "s/ARG VERSION.*/ARG VERSION=$version/" \
            -e "s/ARG RELEASE.*/ARG RELEASE=$release/" \
            $files
 
-    sed -i -e "s/LABEL VERSION.*/LABEL VERSION $version/" \
-           -e "s/LABEL RELEASE.*/LABEL RELEASE $release/" \
+    sed -i -e "s/LABEL VERSION[ =].*/LABEL VERSION=$version/" \
+           -e "s/LABEL RELEASE[ =].*/LABEL RELEASE=$release/" \
            $files
 
     if git -C $WORKDIR diff --exit-code; then


### PR DESCRIPTION
`LABEL` only officially suports the `=` form. `ENV` still supports both [2],
but let's just be consistent.

[1] https://docs.docker.com/engine/reference/builder/#label
[2] https://docs.docker.com/engine/reference/builder/#env