### PR TITLE
Update cockpit composer urls for organization change 

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -42,7 +42,7 @@ way that they all prepare their steps, and then commit them after everything
 has been prepared. See the delivery scripts of
 [cockpit](https://github.com/cockpit-project/cockpit/blob/master/tools/cockpituous-release)
 and
-[cockpit-composer](https://github.com/weldr/cockpit-composer/blob/master/utils/cockpituous-release)
+[cockpit-composer](https://github.com/osbuild/cockpit-composer/blob/master/utils/cockpituous-release)
 as examples.
 
 You can test your script locally (possibly in a

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -133,7 +133,7 @@ cockpit-project/cockpit
 cockpit-project/starter-kit
 cockpit-project/cockpit-podman
 cockpit-project/cockpit-ostree
-weldr/cockpit-composer
+osbuild/cockpit-composer
 weldr/lorax
 "
 


### PR DESCRIPTION
Cockpit-composer is migrating from the weldr to the osbuild github organization so its github url has changed. The references to weldr/cockpit-composer are changed to osbuild/cockpit-composer.

This PR should not be merged until after cockpit-composer has moved to the osbuild organization.