### PR TITLE
tasks: Install rsync into cockpit-CI environment

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -35,6 +35,7 @@ RUN dnf -y update && \
         python3-pika \
         rpm-build \
         rpmdevtools \
+        rsync \
         sed \
         tar \
         virt-install \


### PR DESCRIPTION
Use rsync to copy file and folder inside "bots" to "test" folder.
All test related libs will be imported from "test/bots"instead of "bots" in both cockpit-CI and "gating".
No "git clone/fetch" is needed in "gating" test environment.
Use rsync not cp because rsync is better than "cp" + "mkdir".
Why not move the whole bots folder into test? Two reasons:
1. Too big, especially "images" folder
2. Keeping bots in "root" will be easy and convenient for us to debug and run lots of "smart commands"

Here's a `Makefile` target to run rsync:
```
machine: bots
    rsync -avR --exclude="bots/machine/machine_core/__pycache__/" bots/machine/testvm.py bots/machine/identity bots/machine/cloud-init.iso bots/machine/machine_core bots/task/testmap.py test
```
I did not push this update into PR [#931](https://github.com/osbuild/cockpit-composer/pull/931) because the test will be fail without `rsync`.

And I found the release container has `rsync` already, so no update there.