### PR TITLE
tasks: Clean temporary work dir between tasks

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -121,6 +121,7 @@ function run_from_queue() {
     cd "$XDG_CACHE_HOME"/cockpit-project/bots
     if /usr/bin/timeout 12h ./run-queue --amqp "$AMQP_SERVER"; then
         work_done=1
+        rm -rf "${TEST_DATA:-/}"/tmp/*
     fi
 }
 


### PR DESCRIPTION
A lot of tasks, particularly failed test runs, tend to leave temporary
files behind. This is particularly painful for VM overlays, which fill
up the /tmp/ tmpfs.

 - [x] Adjust tests for new clipboard permissions: https://github.com/cockpit-project/cockpit/pull/14112