### PR TITLE
tasks: Update to Firefox nightly builds, prepare for $TEST_DATA elimination

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,14 +1,13 @@
 FROM fedora:32
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
-# HACK: Install Firefox 69, since 70 has broken cdp, see https://bugzilla.mozilla.org/show_bug.cgi?id=1593226
 RUN dnf -y update && \
     dnf -y install \
         'dnf-command(builddep)' \
         american-fuzzy-lop \
         chromium-headless \
-        https://kojipkgs.fedoraproject.org//packages/firefox/69.0.3/2.module_f30+6823+393aa9e5/x86_64/firefox-69.0.3-2.module_f30+6823+393aa9e5.x86_64.rpm \
         curl \
+        dbus-glib \
         expect \
         gcc \
         gcc-c++ \
@@ -20,6 +19,7 @@ RUN dnf -y update && \
         libvirt-daemon-kvm \
         libvirt-client \
         libvirt-python3 \
+        libXt \
         make \
         nc \
         net-tools \
@@ -44,6 +44,11 @@ RUN dnf -y update && \
     sed -i 's/%{npm-version:.*}/0/' /tmp/cockpit.spec && \
     dnf -y builddep /tmp/cockpit.spec && \
     dnf clean all
+
+# Install nightly firefox, as neither the betas nor Fedora distro builds have the remote debugger
+RUN curl --location 'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US' | \
+        tar -C /usr/local/lib/ -xj && \
+    ln -s /usr/local/lib/firefox/firefox /usr/local/bin/
 
 COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/
 

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -69,7 +69,7 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
     ln -snf /secrets/lorax-test-env.sh /home/user/.config/lorax-test-env && \
     ln -snf /run/secrets/webhook/.config--github-token /home/user/.config/github-token && \
     chmod g=u /etc/passwd && \
-    chmod -R ugo+w /build /secrets /cache /home/user && \
+    chmod -R ugo+w /cache /build /secrets /cache /home/user && \
     ln -s /app/bin/firefox /usr/bin/firefox
 
 # Prevent us from screwing around with KVM settings in the container
@@ -84,7 +84,7 @@ ENV LANG=C.UTF-8 \
     TEST_DATA=/build \
     TEST_PUBLISH=
 
-VOLUME /cache
+VOLUME /cache/images
 
 USER user
 WORKDIR /build

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -55,7 +55,7 @@ COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/
 RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
     mkdir -p /usr/local/bin /build /secrets /cache/images /cache/github /build/libvirt/qemu && \
     mkdir -p /home/user/.config /home/user/.ssh /home/user/.cache /home/user/.rhel && \
-    printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpituous\n' >/home/user/.gitconfig && \
+    printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpituous\n[cockpit "bots"]\n\timages-data-dir = /cache/images\n' >/home/user/.gitconfig && \
     ln -s /cache/images /build/images && \
     ln -s /cache/images /build/virt-builder && \
     ln -s /cache/github /build/github && \
@@ -80,6 +80,7 @@ ENV LANG=C.UTF-8 \
     HOME=/home/user \
     TMPDIR=/tmp \
     TEMPDIR=/tmp \
+    TEST_OVERLAY_DIR=/tmp \
     TEST_DATA=/build \
     TEST_PUBLISH=
 

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -53,14 +53,13 @@ RUN curl --location 'https://download.mozilla.org/?product=firefox-nightly-lates
 COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/
 
 RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
-    mkdir -p /home/user/.ssh && mkdir -p /usr/local/bin && \
-    mkdir -p /build /secrets /cache/images /cache/github /build/libvirt/qemu && \
+    mkdir -p /usr/local/bin /build /secrets /cache/images /cache/github /build/libvirt/qemu && \
+    mkdir -p /home/user/.config /home/user/.ssh /home/user/.cache /home/user/.rhel && \
     printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpituous\n' >/home/user/.gitconfig && \
     ln -s /cache/images /build/images && \
     ln -s /cache/images /build/virt-builder && \
     ln -s /cache/github /build/github && \
     ln -s /tmp /build/tmp && \
-    mkdir -p /home/user/.config /home/user/.ssh /home/user/.rhel && \
     ln -snf /secrets/ssh-config /home/user/.ssh/config && \
     ln -snf /secrets/image-stores /home/user/.config/image-stores && \
     ln -snf /secrets/codecov-token /home/user/.config/codecov-token && \

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -57,7 +57,7 @@ ExecStartPre=-$RUNC rm -f cockpit-tasks-%i
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull $RUNC pull cockpit/tasks
 ExecStartPre=$RUNC pull cockpit/tasks
 $NETWORK_SETUP
-ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=16g --volume=\${TEST_CACHE}:/cache:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 cockpit/tasks
+ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=16g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 cockpit/tasks
 ExecStop=$RUNC rm -f cockpit-tasks-%i
 $NETWORK_TEARDOWN
 


### PR DESCRIPTION
This will finally get us off the old version 69.
https://bugzilla.mozilla.org/show_bug.cgi?id=1593226 was fixed, so
versions ≥ 77 work again for testing Cockpit.

Unfortunately neither upstream beta nor Fedora downstream builds contain
the remote debugger any more, thus we are forced to use nightlies now.

 - [x] Adjust cockpit tests: https://github.com/cockpit-project/cockpit/pull/14192
 - [x] Fix cockpit-composer for new firefox: https://github.com/osbuild/cockpit-composer/pull/988
 - [x] Fix remaining composer failure: https://github.com/osbuild/cockpit-composer/pull/990
 - [x] Fix most of cockpit for new firefox: https://github.com/cockpit-project/cockpit/pull/14199