### PR TITLE
task: Accept also "closed" event

### DIFF
--- a/tasks/webhook
+++ b/tasks/webhook
@@ -157,7 +157,7 @@ class ReleaseHandler(github_handler.GithubHandler):
         if action == 'closed' and merged:
             logging.info("pull request was merged, ensuring cockpit checkout is latest master")
             ensure_bots_checkout()
-        if action not in ['opened', 'synchronize', 'edited', 'labeled']:
+        elif action not in ['opened', 'synchronize', 'edited', 'labeled']:
             logging.info("action %s unknown, skipping pull request event" % action)
             return None
 


### PR DESCRIPTION
Otherwise "close" events is skipped as: `action closed unknown, skipping pull request event`