### PR TITLE
release: Quiesce make

### DIFF
--- a/release/release-source
+++ b/release/release-source
@@ -37,7 +37,7 @@ VERBOSE=${RELEASE_VERBOSE:-0}
 SOURCE=${RELEASE_SOURCE:-}
 TAG=${RELEASE_TAG:-}
 
-MAKE="make V=1 -j$(nproc)"
+MAKE="make -j$(nproc)"
 
 # When building tarballs it's important to have a consistent
 # locale and charmap in particular when generating documentation


### PR DESCRIPTION
Don't run `make` with `V=1`. There are no surprises in the build log
during a release, and no unit test runs either.

This reduces the release log by ~ 90%.