### PR TITLE
release-bodhi: Use `--autotime` option

### DIFF
--- a/release/release-bodhi
+++ b/release/release-bodhi
@@ -87,7 +87,7 @@ commit()
     fi
 
     echo "$PASSWORD" | setsid -w -- bodhi updates new --type=enhancement --close-bugs --notes="$NOTES" \
-        --stable-karma=2 --unstable-karma=-1 --autokarma --request=stable --user $USER  \
+        --stable-karma=2 --unstable-karma=-1 --autokarma --autotime --request=stable --user $USER  \
         ${fednvr}
 )
 


### PR DESCRIPTION
Otherwise updates are not directly pushed to stable after 7 days.

This used to work but is not for at least the last month. No idea though when or why it changed, maybe it is a bug-report candidate?
But in any case `--autotime` cannot hurt.