### PR TITLE
Specify docker.io registry on container image pulls

### DIFF
--- a/images/cockpit-images.yaml
+++ b/images/cockpit-images.yaml
@@ -17,7 +17,7 @@ items:
       spec:
         containers:
           - name: images
-            image: cockpit/images
+            image: docker.io/cockpit/images
             ports:
               - containerPort: 8080
                 protocol: TCP

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,7 +73,7 @@ Some helpful commands:
 To update, just pull the new container and restart the cockpit-tasks service.
 It will restart automatically when it finds a pause in the verification work.
 
-    # docker pull cockpit/tasks
+    # docker pull docker.io/cockpit/tasks
 
 ## Deploying on Openshift
 

--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -18,7 +18,7 @@ items:
       spec:
         containers:
           - name: amqp
-            image: rabbitmq:3-management
+            image: docker.io/rabbitmq:3-management
             ports:
             - containerPort: 5671
               protocol: TCP
@@ -31,7 +31,7 @@ items:
               mountPath: /etc/rabbitmq
               readOnly: true
           - name: webhook
-            image: cockpit/tasks
+            image: docker.io/cockpit/tasks
             ports:
               - containerPort: 8080
                 protocol: TCP

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -54,10 +54,9 @@ RestartSec=60
 # give image pull enough time
 TimeoutStartSec=10min
 ExecStartPre=-$RUNC rm -f cockpit-tasks-%i
-ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull $RUNC pull cockpit/tasks
-ExecStartPre=$RUNC pull cockpit/tasks
+ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull $RUNC pull docker.io/cockpit/tasks
 $NETWORK_SETUP
-ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=16g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 cockpit/tasks
+ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=16g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 docker.io/cockpit/tasks
 ExecStop=$RUNC rm -f cockpit-tasks-%i
 $NETWORK_TEARDOWN
 

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
         - name: release
-          image: cockpit/release
+          image: docker.io/cockpit/release
           workingDir: /build
           args: [ "-s", "-r", "%(git_repo)s", "-t", "%(tag)s", "%(script)s" ]
           volumeMounts:


### PR DESCRIPTION
This avoids circling through all available registries, and prevents
accidentally using a wrong image.

Also drop the duplicated non-locked docker pull in
tasks/install-service.