### PR TITLE
tasks: Bump container RAM

### DIFF
--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -41,7 +41,7 @@ spec:
           mountPath: "/tmp"
         resources:
           limits:
-            memory: 16G
+            memory: 24G
       volumes:
       - name: secrets
         secret:

--- a/tasks/cockpit-tasks-psi.yaml
+++ b/tasks/cockpit-tasks-psi.yaml
@@ -40,7 +40,7 @@ spec:
             cpu: 7750m
           limits:
             cpu: 7750m
-            memory: 16G
+            memory: 24G
       volumes:
       - name: secrets
         secret:

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -56,7 +56,7 @@ TimeoutStartSec=10min
 ExecStartPre=-$RUNC rm -f cockpit-tasks-%i
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull $RUNC pull docker.io/cockpit/tasks
 $NETWORK_SETUP
-ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=16g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 docker.io/cockpit/tasks
+ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=24g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} --env=AMQP_SERVER=amqp-cockpit.apps.ci.centos.org:443 docker.io/cockpit/tasks
 ExecStop=$RUNC rm -f cockpit-tasks-%i
 $NETWORK_TEARDOWN
 


### PR DESCRIPTION
With the current combination of chromium, `$TEST_JOBS`, and cockpit
tests, the tests ran into the oom-killer a lot with 16 GiB, causing a
lot of "weird" and unspecific test failures. Bump to 24 GiB.