### PR TITLE
release container updates

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -3,7 +3,6 @@ LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
 # whois-mkpasswd conflicts with expect and we don't need it
 RUN dnf -y update && \
-    dnf -y remove whois-mkpasswd && \
     dnf -y install \
 bind-utils \
 bodhi-client \

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -35,10 +35,17 @@ dnf-utils \
     dnf -y install 'dnf-command(builddep)' && \
     curl https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec | sed 's/%{npm-version:.*}/0/' > /tmp/cockpit.spec && \
     dnf -y builddep /tmp/cockpit.spec && \
-    dnf clean all && \
-    mkdir -p /usr/local/bin /home/user /build/ && \
-    chmod g=u /etc/passwd && \
-    chmod -R ugo+w /build /home/user
+    dnf clean all
+
+# krb: default in Fedora is KEYRING:, which doesn't work in containers
+RUN mkdir -p /usr/local/bin /build/ && \
+    printf '[libdefaults]\ndefault_ccache_name = FILE:/tmp/krb5.ccache\n' > /etc/krb5.conf.d/0_file_ccache && \
+    groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
+    mkdir -p /home/user/.config /home/user/.ssh && \
+    printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > /home/user/.gitconfig && \
+    chown -R user:user /home/user && \
+    chmod -R ugo+w /build /home/user && \
+    chmod g=u /etc/passwd
 
 ADD * /usr/local/bin/
 
@@ -47,5 +54,6 @@ ENV NODE_PATH=/usr/bin/node.real LANG=C.UTF-8
 RUN mv /usr/bin/node /usr/bin/node.real
 ADD node-stdio-wrapper /usr/bin/node
 
+USER user
 WORKDIR /build
 ENTRYPOINT ["/usr/local/bin/release-runner"]

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -1,8 +1,6 @@
 FROM fedora:latest
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
-ADD https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec /tmp/cockpit.spec
-
 # whois-mkpasswd conflicts with expect and we don't need it
 RUN dnf -y update && \
     dnf -y remove whois-mkpasswd && \
@@ -36,7 +34,7 @@ which \
 dnf-utils \
     && \
     dnf -y install 'dnf-command(builddep)' && \
-    sed -i 's/%{npm-version:.*}/0/' /tmp/cockpit.spec && \
+    curl https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec | sed 's/%{npm-version:.*}/0/' > /tmp/cockpit.spec && \
     dnf -y builddep /tmp/cockpit.spec && \
     dnf clean all && \
     mkdir -p /usr/local/bin /home/user /build/ && \

--- a/release/release-runner
+++ b/release/release-runner
@@ -69,7 +69,7 @@ init_container_home()
     local secrets_dir=/run/secrets/release
     local home_dir='/home/user'
 
-    [ -d "$secrets_dir" ] && [ -d "$home_dir" ] || return 0
+    [ -d "$secrets_dir" ] || return 0
     export HOME=$home_dir
 
     trace "Initializing $HOME"

--- a/release/release-runner
+++ b/release/release-runner
@@ -68,18 +68,17 @@ init_container_home()
 {
     local secrets_dir=/run/secrets/release
     local home_dir='/home/user'
-
-    [ -d "$secrets_dir" ] || return 0
     export HOME=$home_dir
-
-    trace "Initializing $HOME"
 
     # ensure we have a passwd entry for random UIDs
     # https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html
     if ! whoami &> /dev/null && [ -w /etc/passwd ]; then
+       trace "Initializing random user"
        echo "randuser:x:$(id -u):0:random uid:${HOME}:/sbin/nologin" >> /etc/passwd
     fi
 
+    [ -d "$secrets_dir" ] || return 0
+    trace "Initializing $HOME"
      # install credentials from secrets volume; copy to avoid world-readable files
      # (which e. g. ssh complains about), and to make them owned by our random UID.
      local old_umask=$(umask -p)


### PR DESCRIPTION
These make the container easier to use with local podman, in GitHub actions, and GitLab pipelines.

It also updates the container to Fedora 32 (implicitly, as we use `fedora:latest`).