### PR TITLE
release, tasks: Install sassc

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -28,6 +28,7 @@ npm \
 psmisc \
 rpm-build \
 rsync \
+sassc \
 tar \
 which \
 dnf-utils \

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf -y update && \
         rpm-build \
         rpmdevtools \
         rsync \
+        sassc \
         sed \
         tar \
         virt-install \


### PR DESCRIPTION
The node-sass NPM package contains/builds ELF binaries, which is
problematic for some distributions. Let's move from node-sass to
sassc, which is packaged in all major distributions.

Install sassc into the tasks container so that packages can start using
it.