### PR TITLE
release: Move to GitHub registry, add build workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,20 @@
+name: build-release
+on:
+  # this is meant to be run on an approved PR branch for convenience
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Log into container registry
+        run: podman login -u cockpituous -p ${{ secrets.COCKPITUOUS_GHCR_TOKEN }} ghcr.io
+
+      - name: Build release container
+        run: make release-container
+
+      - name: Push container to registry
+        run: make release-push

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ release-shell:
 		--volume=/home/cockpit:/home/user:rw \
 		--volume=/home/cockpit/release:/build:rw \
 		--volume=$(CURDIR)/release:/usr/local/bin \
-		--entrypoint=/bin/bash docker.io/cockpit/release
+		--entrypoint=/bin/bash ghcr.io/cockpit-project/release
 
 # run release container for a Cockpit release
 release-cockpit:
@@ -57,16 +57,16 @@ release-cockpit:
 		--volume=/home/cockpit:/home/user:rw \
 		--volume=/home/cockpit/release:/build:rw \
 		--volume=$(CURDIR)/release:/usr/local/bin \
-		docker.io/cockpit/release \
+		ghcr.io/cockpit-project/release \
 		-r https://github.com/cockpit-project/cockpit /build/tools/cockpituous-release
 
 release-container:
-	$(DOCKER) build -t docker.io/cockpit/release:$(TAG) release
-	$(DOCKER) tag docker.io/cockpit/release:$(TAG) docker.io/cockpit/release:latest
-	$(DOCKER) tag docker.io/cockpit/release:$(TAG) docker.io/cockpit/release:latest
+	$(DOCKER) build -t ghcr.io/cockpit-project/release:$(TAG) release
+	$(DOCKER) tag ghcr.io/cockpit-project/release:$(TAG) ghcr.io/cockpit-project/release:latest
+	$(DOCKER) tag ghcr.io/cockpit-project/release:$(TAG) ghcr.io/cockpit-project/release:latest
 
 release-push:
-	./push-container docker.io/cockpit/release
+	./push-container ghcr.io/cockpit-project/release
 
 tasks-shell:
 	$(DOCKER) run -ti --rm \

--- a/Makefile
+++ b/Makefile
@@ -37,28 +37,7 @@ images-push:
 	./push-container docker.io/cockpit/images
 
 release-shell:
-	test -d /home/cockpit/release || git clone https://github.com/cockpit-project/cockpit /home/cockpit/release
-	chown -R cockpit:cockpit /home/cockpit/release
-	$(DOCKER) run -ti --rm -v /home/cockpit:/home/user:rw \
-		--privileged \
-		--env=RELEASE_SINK=fedorapeople.org \
-		--volume=/home/cockpit:/home/user:rw \
-		--volume=/home/cockpit/release:/build:rw \
-		--volume=$(CURDIR)/release:/usr/local/bin \
-		--entrypoint=/bin/bash ghcr.io/cockpit-project/release
-
-# run release container for a Cockpit release
-release-cockpit:
-	test -d /home/cockpit/release || git clone https://github.com/cockpit-project/cockpit /home/cockpit/release
-	chown -R cockpit:cockpit /home/cockpit/release
-	$(DOCKER) run -ti --rm -v /home/cockpit:/home/user:rw \
-		--privileged \
-		--env=RELEASE_SINK=fedorapeople.org \
-		--volume=/home/cockpit:/home/user:rw \
-		--volume=/home/cockpit/release:/build:rw \
-		--volume=$(CURDIR)/release:/usr/local/bin \
-		ghcr.io/cockpit-project/release \
-		-r https://github.com/cockpit-project/cockpit /build/tools/cockpituous-release
+	$(DOCKER) run -ti --rm --entrypoint=/bin/bash ghcr.io/cockpit-project/release
 
 release-container:
 	$(DOCKER) build -t ghcr.io/cockpit-project/release:$(TAG) release

--- a/push-container
+++ b/push-container
@@ -4,7 +4,7 @@ IMAGE=$1
 DOCKER=$(which podman docker 2>/dev/null | head -n1)
 ID=$($DOCKER images -q $IMAGE:latest | head -n1)
 
-TAGS=$($DOCKER images --format "table {{.Tag}}\t{{.ID}}" $IMAGE | sort -u | grep $ID | awk '{print $1}')
+TAGS=$($DOCKER images --format '{{.Tag}}   {{.ID}}' $IMAGE | sort -u | grep $ID | awk '{print $1}')
 if [ $(echo "$TAGS" | wc -w) -ne "2" ]; then
 	echo "Expected exactly two tags for the image to push: latest and one other"
 	exit 1


### PR DESCRIPTION
We only use the container in GitHub workflows now, so it makes sense to
keep the image in the nearby registry. This also avoids running into
pull rate limits on docker.io.

Add a manually triggered "build-release" workflow that will allow us to
conveniently build and push a new image from a branch.