### PR TITLE
tasks: Move to quay.io registry, add build workflow

### DIFF
--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -1,0 +1,21 @@
+name: build-tasks
+on:
+  # this is meant to be run on an approved PR branch for convenience
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      # use podman as root, so that it uses overlayfs; user with vfs takes too long and uses too much space
+      - name: Log into container registry
+        run: sudo podman login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+
+      - name: Build tasks container
+        run: sudo make tasks-container
+
+      - name: Push container to registry
+        run: sudo make tasks-push

--- a/Makefile
+++ b/Makefile
@@ -55,15 +55,15 @@ tasks-shell:
 		--volume=$(WEBHOOK_SECRETS):/run/webhook/secrets:ro \
 		--volume=$(TASK_CACHE):/cache:rw \
 		--entrypoint=/bin/bash \
-        docker.io/cockpit/tasks -i
+        quay.io/cockpit/tasks -i
 
 tasks-container:
-	$(DOCKER) build -t docker.io/cockpit/tasks:$(TAG) tasks
-	$(DOCKER) tag docker.io/cockpit/tasks:$(TAG) docker.io/cockpit/tasks:latest
-	$(DOCKER) tag docker.io/cockpit/tasks:$(TAG) docker.io/cockpit/tasks:latest
+	$(DOCKER) build -t quay.io/cockpit/tasks:$(TAG) tasks
+	$(DOCKER) tag quay.io/cockpit/tasks:$(TAG) quay.io/cockpit/tasks:latest
+	$(DOCKER) tag quay.io/cockpit/tasks:$(TAG) quay.io/cockpit/tasks:latest
 
 tasks-push:
-	./push-container docker.io/cockpit/tasks
+	./push-container quay.io/cockpit/tasks
 
 tasks-secrets:
 	@cd tasks && ./build-secrets $(TASK_SECRETS)

--- a/ansible/cockpituous/images.yml
+++ b/ansible/cockpituous/images.yml
@@ -17,7 +17,7 @@
         Description=Regularly sync cockpit images from other servers
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/podman run -i --rm --volume=/var/cache/cockpit-tasks/images:/cache/images:rw docker.io/cockpit/tasks sh -exc 'mkdir -p ~/.cache; ln -s /cache/images ~/.cache/cockpit-images; git clone https://github.com/cockpit-project/bots; bots/image-download; bots/image-prune -c --force'
+        ExecStart=/usr/bin/podman run -i --rm --volume=/var/cache/cockpit-tasks/images:/cache/images:rw quay.io/cockpit/tasks sh -exc 'mkdir -p ~/.cache; ln -s /cache/images ~/.cache/cockpit-images; git clone https://github.com/cockpit-project/bots; bots/image-download; bots/image-prune -c --force'
         TimeoutStartSec=1h
 
   - name: "Set up image syncing: timer"

--- a/ansible/maintenance/deploy-tasks-container.yml
+++ b/ansible/maintenance/deploy-tasks-container.yml
@@ -18,7 +18,7 @@
   tasks:
   - name: Pre-pull current container image to avoid long downtime
     # avoid docker_image module, that requires python-docker
-    command: docker pull docker.io/cockpit/tasks
+    command: docker pull quay.io/cockpit/tasks
 
   - name: Restart systemd controlled tasks containers
     command: systemctl restart cockpit-tasks@*

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -73,7 +73,7 @@ Some helpful commands:
 To update, just pull the new container and restart the cockpit-tasks service.
 It will restart automatically when it finds a pause in the verification work.
 
-    # docker pull docker.io/cockpit/tasks
+    # docker pull quay.io/cockpit/tasks
 
 ## Deploying on Openshift
 

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: cockpit-tasks
-        image: docker.io/cockpit/tasks
+        image: quay.io/cockpit/tasks
         env:
         - name: TEST_JOBS
           value: '5'

--- a/tasks/cockpit-tasks-psi.yaml
+++ b/tasks/cockpit-tasks-psi.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: cockpit-tasks
-        image: docker.io/cockpit/tasks
+        image: quay.io/cockpit/tasks
         env:
         - name: TEST_JOBS
           value: '5'

--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -31,7 +31,7 @@ items:
               mountPath: /etc/rabbitmq
               readOnly: true
           - name: webhook
-            image: docker.io/cockpit/tasks
+            image: quay.io/cockpit/tasks
             ports:
               - containerPort: 8080
                 protocol: TCP

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -54,9 +54,9 @@ RestartSec=60
 # give image pull enough time
 TimeoutStartSec=10min
 ExecStartPre=-$RUNC rm -f cockpit-tasks-%i
-ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull $RUNC pull docker.io/cockpit/tasks
+ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull $RUNC pull quay.io/cockpit/tasks
 $NETWORK_SETUP
-ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=24g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} --env=AMQP_SERVER=amqp-frontdoor.apps.ocp.ci.centos.org:443 docker.io/cockpit/tasks
+ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=24g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} --env=AMQP_SERVER=amqp-frontdoor.apps.ocp.ci.centos.org:443 quay.io/cockpit/tasks
 ExecStop=$RUNC rm -f cockpit-tasks-%i
 $NETWORK_TEARDOWN
 


### PR DESCRIPTION
Our internal e2e machines can't pull from docker.io any more due to the
pull rate limits. Move them to https://quay.io/repository/cockpit/tasks
now.

Add a manually triggered "build-tasks" workflow that will allow us to
conveniently build and push a new image from a branch.