### PR TITLE
ansible/cockpit-copr role: Disable GPG check

### DIFF
--- a/ansible/roles/cockpit-copr/tasks/main.yml
+++ b/ansible/roles/cockpit-copr/tasks/main.yml
@@ -4,6 +4,7 @@
     name: cockpit-preview
     description: Cockpit COPR repo
     baseurl: https://download.copr.fedorainfracloud.org/results/@cockpit/cockpit-preview/epel-8-$basearch/
+    gpgcheck: no
 
 - name: Install Cockpit
   dnf:


### PR DESCRIPTION
Apparently the default on the base image has changed, and the role
previously failed with:

```
TASK [cockpit-copr : Install Cockpit] ****************************************************************************
fatal: [ec2-50-19-34-50.compute-1.amazonaws.com]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for cockpit-234-1.el8.x86_64"}
```