### PR TITLE
tasks: Add packages and configuration for interactive development

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -80,4 +80,4 @@ CMD ["/usr/local/bin/cockpit-tasks", "--publish", "$TEST_PUBLISH", "--verbose"]
 LABEL INSTALL /usr/bin/docker run -ti --rm --privileged --volume=/:/host:rw --user=root IMAGE /bin/bash -c \"/usr/sbin/chroot /host /bin/sh -s < /usr/local/bin/install-service\"
 
 # Run a simple interactive instance of the tests container
-LABEL RUN /usr/bin/docker run -ti --rm --privileged --uts=host --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE /bin/bash -i
+LABEL RUN /usr/bin/docker run -ti --rm --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE /bin/bash -i

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -5,10 +5,14 @@ RUN dnf -y update && \
     dnf -y install \
         'dnf-command(builddep)' \
         american-fuzzy-lop \
+        byobu \
         chromium-headless \
         curl \
         dbus-glib \
+        diffstat \
         expect \
+        fedpkg \
+        fpaste \
         gcc-c++ \
         git \
         gnupg \
@@ -33,7 +37,10 @@ RUN dnf -y update && \
         rpmdevtools \
         rsync \
         sassc \
+        socat \
+        strace \
         tar \
+        vim-enhanced \
         virt-install \
         wget && \
     curl -s -o /tmp/cockpit.spec https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec && \
@@ -61,7 +68,10 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
     ln -snf /run/secrets/webhook/.config--github-token /home/user/.config/github-token && \
     chmod g=u /etc/passwd && \
     chmod -R ugo+w /cache /secrets /cache /home/user && \
-    ln -s /app/bin/firefox /usr/bin/firefox
+    chown -R user:user /cache /home/user && \
+    chmod -R go-rwx /home/user/.ssh && \
+    ln -s /app/bin/firefox /usr/bin/firefox && \
+    printf '[libdefaults]\ndefault_ccache_name = FILE:/tmp/krb5.ccache\n' > /etc/krb5.conf.d/0_file_ccache
 
 # Prevent us from screwing around with KVM settings in the container
 RUN touch /etc/modprobe.d/kvm-amd.conf && touch /etc/modprobe.d/kvm-intel.conf
@@ -81,3 +91,6 @@ LABEL INSTALL /usr/bin/docker run -ti --rm --privileged --volume=/:/host:rw --us
 
 # Run a simple interactive instance of the tests container
 LABEL RUN /usr/bin/docker run -ti --rm --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE /bin/bash -i
+
+# Start a container in the background; attach to it with "docker exec -it <name> byobu"
+LABEL DEV /usr/bin/docker run -d --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE sleep infinity

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -9,7 +9,6 @@ RUN dnf -y update && \
         curl \
         dbus-glib \
         expect \
-        gcc \
         gcc-c++ \
         git \
         gnupg \
@@ -20,16 +19,13 @@ RUN dnf -y update && \
         libvirt-client \
         libvirt-python3 \
         libXt \
-        make \
         nc \
         net-tools \
         npm \
-        openssl \
         origin-clients \
         psmisc \
         procps-ng \
         python3-pyflakes \
-        python \
         python3 \
         python3-pycodestyle \
         python3-pika \
@@ -37,7 +33,6 @@ RUN dnf -y update && \
         rpmdevtools \
         rsync \
         sassc \
-        sed \
         tar \
         virt-install \
         wget && \


### PR DESCRIPTION
With these, developers can run a cockpit/tasks container pretty much
anywhere to do Cockpit development. This works well on our e2e machines
or for toolbox. Further packages can always be installed with
`docker exec -it -u root`, but these provide the most important tools.

Fix ~user home directory permissions, so that tmux and ssh work.

Configure kerberos to use a file ccache, as nothing else (reliably)
works in a container.

A comfortable and recommended workflow is to start the container in the
background and (re)attach to it through byobu. Add a `DEV` run label
with a comment to show how this works. Do *not* pass in the production
cockpit secrets, developers ought to use their own token in such a
situation.

-----

During the week when I had no laptop, I had used https://github.com/martinpitt/fedora-dev on an e2e machine. This is 95% what cockpit/tasks is, so let's unify this. I know @allisonkarlitskaya has also used that during her laptop breakage, and in general it seems useful for us to occasionally do some development/debugging on these super-fast machines.

The main thing that is missing from my fedora-dev container is the ssh config and the [setup-cockpit](https://github.com/martinpitt/fedora-dev/blob/master/setup-cockpit) script, but that's easy enough to pull in through  curl -- in retrospect, this should not have been in the container in the first place.