### PR TITLE
tasks: Add packages and configuration for interactive development, fix for toolbox

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -80,4 +80,4 @@ CMD ["/usr/local/bin/cockpit-tasks", "--publish", "$TEST_PUBLISH", "--verbose"]
 LABEL INSTALL /usr/bin/docker run -ti --rm --privileged --volume=/:/host:rw --user=root IMAGE /bin/bash -c \"/usr/sbin/chroot /host /bin/sh -s < /usr/local/bin/install-service\"
 
 # Run a simple interactive instance of the tests container
-LABEL RUN /usr/bin/docker run -ti --rm --privileged --uts=host --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE /bin/bash -i
+LABEL RUN /usr/bin/docker run -ti --rm --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE /bin/bash -i

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -9,7 +9,6 @@ RUN dnf -y update && \
         curl \
         dbus-glib \
         expect \
-        gcc \
         gcc-c++ \
         git \
         gnupg \
@@ -20,16 +19,13 @@ RUN dnf -y update && \
         libvirt-client \
         libvirt-python3 \
         libXt \
-        make \
         nc \
         net-tools \
         npm \
-        openssl \
         origin-clients \
         psmisc \
         procps-ng \
         python3-pyflakes \
-        python \
         python3 \
         python3-pycodestyle \
         python3-pika \
@@ -37,7 +33,6 @@ RUN dnf -y update && \
         rpmdevtools \
         rsync \
         sassc \
-        sed \
         tar \
         virt-install \
         wget && \

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -55,20 +55,20 @@ RUN curl --location 'https://download.mozilla.org/?product=firefox-nightly-lates
 
 COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/
 
-RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
+RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user --home-dir /work && \
     mkdir -p /usr/local/bin /secrets /cache/images /cache/github && \
-    mkdir -p /home/user/.config /home/user/.ssh /home/user/.cache /home/user/.rhel && \
-    printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpituous\n[cockpit "bots"]\n\timages-data-dir = /cache/images\n' >/home/user/.gitconfig && \
-    ln -snf /secrets/ssh-config /home/user/.ssh/config && \
-    ln -snf /secrets/image-stores /home/user/.config/image-stores && \
-    ln -snf /secrets/codecov-token /home/user/.config/codecov-token && \
-    ln -snf /secrets/rhel-login /home/user/.rhel/login && \
-    ln -snf /secrets/rhel-password /home/user/.rhel/pass && \
-    ln -snf /secrets/lorax-test-env.sh /home/user/.config/lorax-test-env && \
-    ln -snf /run/secrets/webhook/.config--github-token /home/user/.config/github-token && \
+    mkdir -p /work/.config /work/.ssh /work/.cache /work/.rhel && \
+    printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpituous\n[cockpit "bots"]\n\timages-data-dir = /cache/images\n' >/work/.gitconfig && \
+    ln -snf /secrets/ssh-config /work/.ssh/config && \
+    ln -snf /secrets/image-stores /work/.config/image-stores && \
+    ln -snf /secrets/codecov-token /work/.config/codecov-token && \
+    ln -snf /secrets/rhel-login /work/.rhel/login && \
+    ln -snf /secrets/rhel-password /work/.rhel/pass && \
+    ln -snf /secrets/lorax-test-env.sh /work/.config/lorax-test-env && \
+    ln -snf /run/secrets/webhook/.config--github-token /work/.config/github-token && \
     chmod g=u /etc/passwd && \
-    chmod -R ugo+w /cache /secrets /cache /home/user && \
-    chown -R user:user /cache /home/user && \
+    chmod -R ugo+w /cache /secrets /cache /work && \
+    chown -R user:user /cache /work && \
     ln -s /app/bin/firefox /usr/bin/firefox && \
     printf '[libdefaults]\ndefault_ccache_name = FILE:/tmp/krb5.ccache\n' > /etc/krb5.conf.d/0_file_ccache
 
@@ -76,13 +76,12 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
 RUN touch /etc/modprobe.d/kvm-amd.conf && touch /etc/modprobe.d/kvm-intel.conf
 
 ENV LANG=C.UTF-8 \
-    HOME=/home/user \
     TEST_OVERLAY_DIR=/tmp
 
 VOLUME /cache/images
 
 USER user
-WORKDIR /home/user
+WORKDIR /work
 CMD ["/usr/local/bin/cockpit-tasks", "--publish", "$TEST_PUBLISH", "--verbose"]
 
 # We execute the script in the host, but it doesn't exist on the host. So pipe it in

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -5,10 +5,14 @@ RUN dnf -y update && \
     dnf -y install \
         'dnf-command(builddep)' \
         american-fuzzy-lop \
+        byobu \
         chromium-headless \
         curl \
         dbus-glib \
+        diffstat \
         expect \
+        fedpkg \
+        fpaste \
         gcc-c++ \
         git \
         gnupg \
@@ -33,7 +37,10 @@ RUN dnf -y update && \
         rpmdevtools \
         rsync \
         sassc \
+        socat \
+        strace \
         tar \
+        vim-enhanced \
         virt-install \
         wget && \
     curl -s -o /tmp/cockpit.spec https://raw.githubusercontent.com/cockpit-project/cockpit/master/tools/cockpit.spec && \
@@ -61,7 +68,9 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
     ln -snf /run/secrets/webhook/.config--github-token /home/user/.config/github-token && \
     chmod g=u /etc/passwd && \
     chmod -R ugo+w /cache /secrets /cache /home/user && \
-    ln -s /app/bin/firefox /usr/bin/firefox
+    chown -R user:user /cache /home/user && \
+    ln -s /app/bin/firefox /usr/bin/firefox && \
+    printf '[libdefaults]\ndefault_ccache_name = FILE:/tmp/krb5.ccache\n' > /etc/krb5.conf.d/0_file_ccache
 
 # Prevent us from screwing around with KVM settings in the container
 RUN touch /etc/modprobe.d/kvm-amd.conf && touch /etc/modprobe.d/kvm-intel.conf
@@ -81,3 +90,6 @@ LABEL INSTALL /usr/bin/docker run -ti --rm --privileged --volume=/:/host:rw --us
 
 # Run a simple interactive instance of the tests container
 LABEL RUN /usr/bin/docker run -ti --rm --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE /bin/bash -i
+
+# Start a container in the background; attach to it with "docker exec -it <name> byobu"
+LABEL DEV /usr/bin/docker run -d --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE sleep infinity

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -75,9 +75,9 @@ It will restart automatically when it finds a pause in the verification work.
 
     # docker pull quay.io/cockpit/tasks
 
-## Deploying on Openshift
+# Deploying on OpenShift
 
-The testing machines can run on Openshift cluster(s).
+The testing machines can run on OpenShift cluster(s).
 
 Create a service account for use by the testing machines. Make sure to have the
 `oci-kvm-hook` package installed on all nodes.  This is because of the requirement

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -246,3 +246,14 @@ the scheduling for free, and is really easy to set up.
    public queue (depending on whether it has access to Red Hat internal
    infrastructure), executes it, publishes the log, updates the GitHub status,
    and finally acks the queue item.
+
+# Using with toolbox
+
+This container can also be used for local development with
+[toolbox](https://github.com/containers/toolbox), to get an "official" Cockpit
+development environment that's independent from the host:
+
+```sh
+toolbox create --image quay.io/cockpit/tasks -c cockpit
+toolbox enter cockpit
+```

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -18,7 +18,8 @@ fi
 # ensure we have a passwd entry for random UIDs
 # https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html
 if ! whoami && [ -w /etc/passwd ]; then
-    echo "user:x:$(id -u):0:random uid:${HOME:-/home/user}:/sbin/nologin" >> /etc/passwd
+    echo "user:x:$(id -u):0:random uid:/work:/sbin/nologin" >> /etc/passwd
+    export HOME=/work
 fi
 
 # If interactive arguments then just exec


### PR DESCRIPTION
With these, developers can run a cockpit/tasks container pretty much
anywhere to do Cockpit development. This works well on our e2e machines
or for toolbox. Further packages can always be installed with
`docker exec -it -u root`, but these provide the most important tools.

Fix ~user home directory permissions, so that tmux and ssh work.

Configure kerberos to use a file ccache, as nothing else (reliably)
works in a container.

A comfortable and recommended workflow is to start the container in the
background and (re)attach to it through byobu. Add a `DEV` run label
with a comment to show how this works. Do *not* pass in the production
cockpit secrets, developers ought to use their own token in such a
situation.

-----

This also fixes the tasks container to Just Work™ with toolbox:

        toolbox create --image quay.io/cockpit/tasks -c cockpit
        toolbox enter cockpit

During the week when I had no laptop, I had used https://github.com/martinpitt/fedora-dev on an e2e machine. This is 95% what cockpit/tasks is, so let's unify this. I know @allisonkarlitskaya has also used that during her laptop breakage, and in general it seems useful for us to occasionally do some development/debugging on these super-fast machines.

The main thing that is missing from my fedora-dev container is the ssh config and the [setup-cockpit](https://github.com/martinpitt/fedora-dev/blob/master/setup-cockpit) script, but that's easy enough to pull in through  curl -- in retrospect, this should not have been in the container in the first place.