### PR TITLE
tasks: Update to Fedora 33

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:33
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
 RUN dnf -y update && \

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -21,7 +21,8 @@ if RUNC=$(which podman 2>/dev/null); then
     NETWORK_TEARDOWN=''
 else
     RUNC=$(which docker)
-    DEVICES=''  # relying on oci-kvm-hook
+    # rely on oci-kvm-hook for /dev/kvm; but avoid stat failure on Fedora ≥ 33 guests on RHEL 7
+    DEVICES='--security-opt=seccomp=unconfined'
     NETWORK='--network=cockpit-tasks-%i'
     NETWORK_SETUP="ExecStartPre=-$RUNC network rm cockpit-tasks-%i
 ExecStartPre=$RUNC network create --driver bridge cockpit-tasks-%i"


### PR DESCRIPTION
 - CentOS CI [successful](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-14913-20210112-092157-7de669da-fedora-coreos/log.html) [tests](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-14913-20210112-092154-7de669da-ubuntu-2004/log.html)
 - [firefox on e2e](https://logs.cockpit-project.org/logs/pull-15125-20210112-095932-b037f913-fedora-32-firefox/log.html) successful test
 - [RHEL on e2e](https://logs.cockpit-project.org/logs/pull-15125-20210112-095932-b037f913-rhel-8-4/log.html) successful test