### PR TITLE
tasks: Various fixes and improvements; add script to run AMQP+tasks locally

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: tests
+on: [pull_request, workflow_dispatch]
+jobs:
+  tasks:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to get origin/master for git diff
+          fetch-depth: 0
+
+      - name: Rebase to current master
+        run: git rebase origin/master
+
+      - name: Build and test tasks container if it changed
+        run: |
+          changes=$(git diff --name-only origin/master..HEAD -- tasks/)
+          if [ -n "${changes}" ]; then
+              # Run podman as root, as podman is missing slirp4netns by default, and does not have overlayfs by default
+              sudo make tasks-container
+              # This does not do much yet, just iterate to the AMQP queue 30 times and exit
+              # TODO: Inject a workload that does not need /dev/kvm
+              sudo tasks/run-local.sh
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ sink/sinkc
 learn/active
 learn/training-*/
 learn/.*
+tasks/credentials/**/*.key
+tasks/credentials/**/*.pem
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ tasks-shell:
 		--shm-size=1024m \
 		--volume=$(CURDIR)/tasks:/usr/local/bin \
 		--volume=$(TASK_SECRETS):/secrets:ro \
-		--volume=$(WEBHOOK_SECRETS):/run/webhook/secrets:ro \
+		--volume=$(WEBHOOK_SECRETS):/run/secrets/webhook/:ro \
 		--volume=$(TASK_CACHE):/cache:rw \
 		--entrypoint=/bin/bash \
         quay.io/cockpit/tasks -i

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -17,10 +17,19 @@ The container has optional mounts:
    * `image-stores`: Non default locations to try downloading images from (optional)
  * `/run/secrets/webhook`: A directory for secrets shared with the webhook container, with the following files:
    * `.config--github-token`: GitHub token to create and update issues and PRs
+   * `amqp-{client,server}.{pem,key}`: TLS certificates for RabbitMQ
+   * `ca.pem`: The general cockpit CI Certificate Authority which signed the above AMQP certificates
  * `/cache`: A directory for reusable cached data such as downloaded image files
 
 The mounts normally default to `/var/lib/cockpit-secrets/tasks`,
 `/var/lib/cockpit-secrets/webhook`, and `/var/cache/cockpit-tasks` on the host.
+
+To generate the [certificates needed for cross-cluster AMQP](https://www.rabbitmq.com/ssl.html) authentication,
+run the [credentials/webhook/generate.sh script](./credentials/webhook/generate.sh) script.
+This requires a generic "Cockpit CI" certificate authority first, so if you
+don't have that yet, run [credentials/generate-ca.sh](./credentials/generate-ca.sh) first.
+Run either script in the target directory (e.g.
+`/var/lib/cockpit-secrets/webhook/`).
 
 # Deploying on a host
 
@@ -55,11 +64,6 @@ You may want to customize things like the operating system to test or number of 
 And now you can restart the service:
 
     $ sudo systemctl restart cockpit-tasks@*
-
-To generate the certificates needed for cross-cluster amqp auth follow this
-guide:
-
-    https://www.rabbitmq.com/ssl.html
 
 ## Troubleshooting
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -138,9 +138,9 @@ command:
 
     $ oc scale rc cockpit-tasks --replicas=3
 
-## GitHub webhook integration
+# GitHub webhook integration
 
-### GitHub setup
+## GitHub setup
 
 Add a webhook to your GitHub project on the Settings → Webhooks page of your project:
 
@@ -157,18 +157,18 @@ Add a webhook to your GitHub project on the Settings → Webhooks page of your p
 See [GitHub development documentation](https://developer.github.com/webhooks/)
 for more information.
 
-### Set up bot as collaborator
+## Set up bot as collaborator
 
  * On your project's "Settings → Manage Access" page, invite the [cockpituous user](https://github.com/cockpituous) as a collaborator.
  * Once you see the "Pending invite", in the list, the clipboard symbol copies the corresponding `/invitations` URL to the clipboard. Send that to Martin Pitt (`pitti` in `#cockpit` on FreeNode IRC) or Marius Vollmer (`mvollmer` on IRC), who will log into GitHub as `cockpituous` user and accept the invite.
 
-### Set up automatic test triggering
+## Set up automatic test triggering
 
  * In the [Cockpit bots project](https://github.com/cockpit-project/bots), add your project to the [test map](https://github.com/cockpit-project/bots/blob/master/task/testmap.py). Start with `_manual` tests.
  * Send a first PR to your project and use [bots/tests-trigger](https://github.com/cockpit-project/bots/blob/master/tests-trigger) to trigger the contexts that you want. They should be picked up and run.
  * Once you fix your tests to succeed, adjust the test map again to move them to the "master" branch. From now on, every PR against master will automatically trigger these tests.
 
-### Automated testing
+## Automated testing
 
 When a pull request event or a status event is received, the webhook will
 trigger tests for the tasks bots (see "Event flow" below for details).
@@ -177,7 +177,7 @@ A pull request event is queued when the pull request is opened or synchronized.
 A status event is only queued where the description ends with "(direct
 trigger)".
 
-### Event flow for PRs and issues
+## Event flow for PRs and issues
 
 We don't directly connect webhook events to tasks bots, as workers come and
 go, and fail quite often; also, we need something to schedule the incoming

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -142,6 +142,22 @@ command:
 
     $ oc scale rc cockpit-tasks --replicas=3
 
+# Deploying locally for development
+
+For hacking on the webhook or task container, or validating new container
+images, you can also run a simple [podman pod](http://docs.podman.io/en/latest/pod.html)
+locally with a RabbitMQ and a tasks container:
+
+    $ tasks/run-local.sh
+
+This will also generate the secrets in a temporary directory, unless they
+already exist in `tasks/credentials/`. By default this will use the
+`quay.io/cockpit/tasks:latest` container, but you can run a different tag by
+setting `$TASKS_TAG`.
+
+This currently does not yet have any convenient way to inject jobs into the
+AMQP queue; this will be provided at a later point.
+
 # GitHub webhook integration
 
 ## GitHub setup

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -48,9 +48,9 @@ function update_repo() {
     fi
 }
 
-# wait between 1 and 10 minutes
+# wait between 1 and 10 minutes, but not in an interactive terminal (annoying for debugging)
 function slumber() {
-    sleep $(shuf -i 60-600 -n 1)
+    [ -t 0 ] || sleep $(shuf -i ${1:-60-600} -n 1)
 }
 
 work_done=
@@ -64,7 +64,7 @@ function run_from_queue() {
 }
 
 # on mass deployment, avoid GitHub stampede
-sleep $(shuf -i 0-120 -n 1)
+slumber 0-120
 
 # Consume from queue 30 times, then restart
 for i in $(seq 1 30); do

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -ex
+set -eux
 
 # ensure we have a passwd entry for random UIDs
 # https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html
@@ -10,7 +10,7 @@ if ! whoami && [ -w /etc/passwd ]; then
 fi
 
 # set up custom NPM registry
-if [ -n "$NPM_REGISTRY" ]; then
+if [ -n "${NPM_REGISTRY:-}" ]; then
     npm config set registry "$NPM_REGISTRY"
     echo "Set NPM registry to $NPM_REGISTRY"
 fi

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -1,34 +1,12 @@
 #!/bin/sh
 
-set -e
-
-# If first argument starts with a path no loop
-loop=yes
-case ${1-} in
-    /*)
-        loop=no
-        ;;
-esac
-
-# Set to verbose when looping
-if [ $loop = "yes" ]; then
-    set -x
-fi
+set -ex
 
 # ensure we have a passwd entry for random UIDs
 # https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html
 if ! whoami && [ -w /etc/passwd ]; then
     echo "user:x:$(id -u):0:random uid:/work:/sbin/nologin" >> /etc/passwd
     export HOME=/work
-fi
-
-# If interactive arguments then just exec
-if [ $loop != "yes" ]; then
-    if [ ! -d cockpit ]; then
-        git clone https://github.com/cockpit-project/cockpit cockpit
-    fi
-    cd cockpit/
-    exec "$@"
 fi
 
 # set up custom NPM registry

--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -124,7 +124,7 @@ items:
             "vhosts": [
                 {
                     "name": "/"
-                },
+                }
             ],
             "permissions": [
                 {

--- a/tasks/credentials/generate-ca.sh
+++ b/tasks/credentials/generate-ca.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+# Generate CA
+
+openssl req -config $(dirname $0)/openssl.cnf -x509  -newkey rsa:2048 -days 365000 -out ca.pem -keyout ca.key -outform PEM -subj /O=Cockpit/OU=Cockpituous/CN=CA/ -nodes

--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -1,0 +1,55 @@
+[ ca ]
+default_ca = cockpitamqp
+
+[ cockpitamqp ]
+certificate = ca.pem
+database = index.txt
+new_certs_dir = certs
+private_key = ca.key
+serial = serial
+
+default_crl_days = 7
+default_days = 365000
+default_md = sha256
+
+policy = cockpitamqp_policy
+x509_extensions = certificate_extensions
+
+[ cockpitamqp_policy ]
+commonName = supplied
+stateOrProvinceName = optional
+countryName = optional
+emailAddress = optional
+organizationName = optional
+organizationalUnitName = optional
+domainComponent = optional
+
+[ certificate_extensions ]
+basicConstraints = CA:false
+
+[ req ]
+default_bits = 2048
+default_keyfile = ca.key
+default_md = sha256
+prompt = yes
+distinguished_name = root_ca_distinguished_name
+x509_extensions = root_ca_extensions
+
+[ root_ca_distinguished_name ]
+commonName = hostname
+
+[ root_ca_extensions ]
+basicConstraints = CA:true
+keyUsage = keyCertSign, cRLSign
+
+[ client_ca_extensions ]
+basicConstraints = CA:false
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = 1.3.6.1.5.5.7.3.2
+subjectAltName=DNS:amqp-cockpit.apps.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cloud.fedoraproject.org
+
+[ server_ca_extensions ]
+basicConstraints = CA:false
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = 1.3.6.1.5.5.7.3.1
+subjectAltName=DNS:amqp-cockpit.apps.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cloud.fedoraproject.org

--- a/tasks/credentials/webhook/generate.sh
+++ b/tasks/credentials/webhook/generate.sh
@@ -1,0 +1,24 @@
+#!/bin/sh -ex
+# Generate AMQP server certs
+
+OPENSSL_CONF=$(dirname $0)/../openssl.cnf
+
+touch index.txt
+echo 01 > serial
+mkdir certs
+
+ln -s ../ca.key
+ln ../ca.pem
+
+openssl genrsa -out amqp-server.key 2048
+openssl req -new -key amqp-server.key -out req.pem -outform PEM -subj /CN=cockpit-amqp-server/O=amqp-server/ -nodes
+openssl ca  -config $OPENSSL_CONF  -in req.pem -out amqp-server.pem -notext -batch -extensions server_ca_extensions
+rm -f req.pem
+
+openssl genrsa -out amqp-client.key 2048
+openssl req -new -key amqp-client.key -out req.pem -outform PEM -subj /CN=cockpit-amqp/O=client/ -nodes
+openssl ca -config $OPENSSL_CONF -in req.pem -out amqp-client.pem -notext -batch -extensions client_ca_extensions
+rm -f req.pem
+
+rm -f index.txt* serial serial.old ca.key
+rm -rf certs

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Run a local pod with a AMQP and a tasks container
+# You can run against a tasks container tag different than latest by setting "$TASKS_TAG"
+set -eu
+
+MYDIR=$(realpath $(dirname $0))
+RABBITMQ_CONFIG=$(mktemp -dt rabbitmq-config.XXXXXX)
+SECRETS=$(mktemp -dt cockpituous-secrets.XXXXXX)
+trap "rm -rf '$RABBITMQ_CONFIG' '$SECRETS'; podman pod rm -f cockpituous" EXIT INT QUIT PIPE
+
+# generate flat files from RabbitMQ config map
+python3 - <<EOF
+import os.path
+import yaml
+
+with open("$MYDIR/cockpit-tasks-webhook.yaml") as f:
+    y = yaml.full_load(f)
+files = [item for item in y["items"] if item["metadata"]["name"] == "amqp-config"][0]["data"]
+for name, contents in files.items():
+    with open(os.path.join('$RABBITMQ_CONFIG', name), 'w') as f:
+        f.write(contents)
+print(files)
+EOF
+# need to make files world-readable, as rabbitmq container runs as different user
+chmod -R go+rX "$RABBITMQ_CONFIG"
+
+# generate secrets, unless they are already present in the source tree
+if [ -e "$MYDIR/credentials/webhook/amqp-client.key" ]; then
+    SECRETS="$MYDIR/credentials"
+else
+    (cd $SECRETS
+     $MYDIR/credentials/generate-ca.sh
+     mkdir -p webhook
+     cd webhook
+     $MYDIR/credentials/webhook/generate.sh
+     cd ..
+    )
+    # need to make files world-readable, as rabbitmq container runs as different user
+    chmod -R go+rX "$SECRETS"/webhook
+fi
+
+# start podman and run RabbitMQ in the background
+podman run -d --name cockpituous-rabbitmq --pod=new:cockpituous -v "$RABBITMQ_CONFIG":/etc/rabbitmq:ro -v "$SECRETS"/webhook:/run/secrets/webhook:ro docker.io/rabbitmq:3-management
+
+# wait until AMQP initialized
+sleep 5
+until podman exec -i cockpituous-rabbitmq sh -ec 'ls /var/lib/rabbitmq/mnesia/*.pid'; do
+    echo "waiting for RabbitMQ to come up..."
+    sleep 3
+done
+
+# Run tasks container in the foreground to see the output
+# Press Control-C or let the "30 polls" iteration finish
+podman run -it --name cockpituous-tasks -v "$SECRETS"/webhook:/run/secrets/webhook:ro -e AMQP_SERVER=localhost:5671 --pod=cockpituous quay.io/cockpit/tasks:${TASKS_TAG:-latest}


### PR DESCRIPTION
I would like to make our tasks container self-testable, and run integration tests on tasks container refreshes and changes to the logic eventually. This is as far as I got today. It's not yet self-testing, but at least one can now run it locally in a very easy way. Please test it and let me know how it works for you!