### PR TITLE
Fix and run unit tests as GitHub workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,20 @@
 name: tests
 on: [pull_request, workflow_dispatch]
 jobs:
+  unit-tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make python3-pyflakes python3-pep8
+
+      - name: Run unit tests
+        run: make check
+
   tasks:
     runs-on: ubuntu-20.04
     steps:

--- a/sink/sink
+++ b/sink/sink
@@ -5,6 +5,7 @@ import errno
 import fcntl
 import json
 import os
+import pwd
 import select
 import shutil
 import signal
@@ -559,10 +560,12 @@ def main():
     args = parser.parse_args()
 
     # Load up configuration if available
-    try:
-        user = os.environ.get("LOGNAME", os.getlogin())
-    except:
-        user = os.environ.get("LOGNAME", None)
+    user = os.environ.get("LOGNAME")
+    if not user:
+        try:
+            user = os.getlogin()
+        except OSError:
+            user = pwd.getpwuid(os.getuid()).pw_name
     config = ConfigParser({"user": user, "identifier": "@@"})
     config.read_file(StringIO(DEFAULTS))
     config.read([os.path.expanduser(args.config)])


### PR DESCRIPTION
As mentioned in #359, now that we have a workflow on PRs anyway, let's run the unit tests there as well. With that we have everything CI related inside our repo again.