### PR TITLE
ansible: Get secrets from git, fix image containers after secrets update

### DIFF
--- a/ansible/inventory/e2e
+++ b/ansible/inventory/e2e
@@ -1,7 +1,3 @@
-# master copy of secrets
-[master]
-cockpit-9.e2e.bos.redhat.com ansible_user=root
-
 [e2e]
 cockpit-7.e2e.bos.redhat.com ansible_user=root
 cockpit-8.e2e.bos.redhat.com ansible_user=root

--- a/ansible/maintenance/sync-secrets.yml
+++ b/ansible/maintenance/sync-secrets.yml
@@ -87,3 +87,8 @@
       file:
         path: /tmp/secrets.tar.gz
         state: absent
+
+    # the above empties the /secrets volume for running containers
+    - name: Restart image containers to pick up changed secrets
+      # The glob avoids failure on machines which are not running cockpit-images
+      command: systemctl restart cockpit-images*.service

--- a/ansible/maintenance/sync-secrets.yml
+++ b/ansible/maintenance/sync-secrets.yml
@@ -1,86 +1,89 @@
-# Sync secrets from the [master] host to all tasks runners, including OpenShift
+# Deploy secrets from our ci-secrets.git to all tasks runners, including OpenShift
 # This uses `oc`, thus you must already be logged into OpenShift.
 ---
-- hosts: e2e tag_ServiceName_FrontDoorCI
-  gather_facts: false
-
-  tasks:
-  - name: Archive master secrets
-    archive:
-      path: /var/lib/cockpit-secrets/
-      dest: /tmp/secrets.tar.gz
-    when: inventory_hostname == groups.master[0]
-
-  - name: Get master secrets
-    slurp:
-      src: /tmp/secrets.tar.gz
-    register: secrets
-    when: inventory_hostname == groups.master[0]
-
-  - name: Clone cockpituous
-    git:
-      repo: https://github.com/cockpit-project/cockpituous/
-      dest: /root/cockpituous
-    when: inventory_hostname == groups.master[0]
-
-  - name: Build tasks/webhook secrets YAML for Kubernetes
-    command: /root/cockpituous/tasks/build-secrets
-    register: build_tasks_secrets
-    when: inventory_hostname == groups.master[0]
-
-  - name: Register task/webhook secrets YAML as fact
-    set_fact:
-      tasks_secrets_yaml: "{{ build_tasks_secrets.stdout }}"
-    when: inventory_hostname == groups.master[0]
-
-  - name: Upload secrets
-    copy:
-      content: "{{ hostvars[groups.master[0]].secrets.content | b64decode }}"
-      dest: /tmp/secrets.tar.gz
-      mode: 0600
-    when: inventory_hostname != groups.master[0]
-
-  - name: Clean up old secrets directory
-    file:
-      path: /var/lib/cockpit-secrets
-      state: absent
-    when: inventory_hostname != groups.master[0]
-
-  - name: Set up secrets dir
-    file:
-      path: /var/lib/cockpit-secrets
-      owner: '1111'
-      group: '1111'
-      state: directory
-      setype: container_file_t
-
-  - name: Unarchive secrets
-    unarchive:
-      src: /tmp/secrets.tar.gz
-      remote_src: true
-      dest: /var/lib/cockpit-secrets/
-      owner: '1111'
-      group: '1111'
-      setype: container_file_t
-    when: inventory_hostname != groups.master[0]
-
-  - name: Clean up secrets archive
-    file:
-      path: /tmp/secrets.tar.gz
-      state: absent
-
-- hosts: localhost
+- name: Set up secrets and deploy them to OpenShift
+  hosts: localhost
   gather_facts: false
   tasks:
-    - name: Delete old CentOS CI OpenShift tasks secrets
+    - name: Clone secrets repository
+      git:
+        repo: git@gitlab.cee.redhat.com:front-door-ci-wranglers/ci-secrets.git
+        # use a directory which is guaranteed to be on tmpfs
+        dest: "{{ lookup('env', 'XDG_RUNTIME_DIR') }}/ci-secrets"
+        depth: 1
+
+    # copy module is waaaay to slow for recursive directory copy; only upload one tarball
+    # we need to resolve symlinks for ../ca.pem due to how container --volumes work
+    # also don't include unnecessary secrets, like the CA key or workflow secrets
+    - name: Generate secrets archive
+      shell: |
+        tar -C $XDG_RUNTIME_DIR/ci-secrets  -hz --hard-dereference -c webhook tasks > $XDG_RUNTIME_DIR/ci-secrets.tar.gz
+      args:
+        # archive module does not support dereferencing links
+        warn: false
+
+    - name: Get OpenShift secrets build script
+      get_url:
+        url: https://raw.githubusercontent.com/cockpit-project/cockpituous/master/tasks/build-secrets
+        dest: "{{ lookup('env', 'XDG_RUNTIME_DIR') }}/build-secrets"
+        mode: "0755"
+
+    - name: Build OpenShift secrets
+      command: "{{ lookup('env', 'XDG_RUNTIME_DIR') }}/build-secrets {{ lookup('env', 'XDG_RUNTIME_DIR') }}/ci-secrets"
+      register: build_secrets
+
+    - name: Delete old OpenShift secrets
       command:
         cmd: "{{ oc_command }} delete --ignore-not-found=true -f -"
-        stdin: "{{ hostvars[groups.master[0]].tasks_secrets_yaml }}"
+        stdin: "{{ build_secrets.stdout }}"
 
-    - name: Create CentOS CI OpenShift tasks secrets
+    - name: Create new secrets
       command:
         cmd: "{{ oc_command }} create -f -"
-        stdin: "{{ hostvars[groups.master[0]].tasks_secrets_yaml }}"
+        stdin: "{{ build_secrets.stdout }}"
 
-    - name: Restart CentOS CI OpenShift image pods to pick up changed certificates
+    - name: Restart image pods to pick up changed certificates
       shell: "{{ oc_command }} get -o name -l infra=cockpit-images pods | xargs -l -r {{ oc_command }} delete --wait=false"
+
+- name: Deploy secrets to e2e and AWS
+  hosts: e2e tag_ServiceName_FrontDoorCI
+  gather_facts: false
+  tasks:
+    - name: Upload secrets
+      copy:
+        src: "{{ lookup('env', 'XDG_RUNTIME_DIR') }}/ci-secrets.tar.gz"
+        dest: /tmp/secrets.tar.gz
+        mode: '0600'
+
+    - name: Clean up old secrets directory
+      file:
+        path: /var/lib/cockpit-secrets
+        state: absent
+
+    - name: Set up secrets dir
+      file:
+        path: /var/lib/cockpit-secrets
+        owner: '1111'
+        group: '1111'
+        state: directory
+        setype: container_file_t
+
+    - name: Unarchive secrets
+      unarchive:
+        src: /tmp/secrets.tar.gz
+        remote_src: true
+        dest: /var/lib/cockpit-secrets/
+        owner: '1111'
+        group: '1111'
+        setype: container_file_t
+
+    # otherwise ssh bitterly complains: Permissions 0644 for '/secrets/id_rsa' are too open
+    - name: Fix permissions of private SSH key file
+      file:
+        path: /var/lib/cockpit-secrets/tasks/id_rsa
+        mode: '0600'
+
+    - name: Clean up secrets archive
+      file:
+        path: /tmp/secrets.tar.gz
+        state: absent


### PR DESCRIPTION
The tasks/webhook secrets are now in the internal CI secrets git
repository. Change sync-secrets.yml to get them from git, stop
considering cockpit-9 as the "holy master copy", and treat all machines
equally.

----

I ran this on my machine and rolled it out everywhere.