### PR TITLE
tasks: Prune images at the end of cockpit-tasks

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -74,3 +74,8 @@ for i in $(seq 1 30); do
     # Nothing to do, or failure
     [ -n "$work_done" ] || slumber
 done
+
+# Prune old images
+update_repo  "$WORKDIR"/cockpit-project/bots https://github.com/cockpit-project/bots
+cd "$WORKDIR"/cockpit-project/bots
+./image-prune


### PR DESCRIPTION
Since we moved image-trigger to a GitHub workflow [1], nothing called
image-prune in our tasks bots any more. This led to overflowing cache
directories.

Run it at the end of each container tasks cycle now, which makes sure
that it covers all our deployed bots.

https://github.com/cockpit-project/bots/commit/25d733ed6be0e9