### PR TITLE
Fix rebasing in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,10 @@ jobs:
           fetch-depth: 0
 
       - name: Rebase to current master
-        run: git rebase origin/master
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git rebase origin/master
 
       - name: Build and test tasks container if it changed
         run: |


### PR DESCRIPTION
For an actual rebase to work, git insists on having an user name.

-----

Fixes [this failure](https://github.com/cockpit-project/cockpituous/runs/1769486155?check_suite_focus=true) when branches are actually out of sync with master. I deliberately made this to be an outdated branch, so that we can let this self-test.