### PR TITLE
tasks: Deploy image/sink in run-local.sh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
 
   tasks:
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,16 +42,7 @@ jobs:
       - name: Set up secrets
         if: steps.tasks_changed.outputs.changed
         run: |
-          # Put the /secrets in place which we'll mount to the tasks-container
-          mkdir -p ~/secrets
           echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
-          echo '${{ secrets.SSH_KNOWN_HOSTS }}' > ~/secrets/known_hosts
-          echo '${{ secrets.SINK_SSH_CONFIG }}' > ~/secrets/ssh-config
-          echo '${{ secrets.SINK_ID_RSA }}' > ~/secrets/id_rsa
-          echo '${{ secrets.SINK_ID_RSA_PUB }}' > ~/secrets/id_rsa.pub
-          chmod 400 ~/secrets/*
-          # change permissions to user in cockpit-tasks container
-          sudo chown 1111:1111 ~/secrets/*
 
       - name: Build tasks container if it changed
         if: steps.tasks_changed.outputs.changed
@@ -64,4 +55,4 @@ jobs:
           PRN=$(echo "$GITHUB_REF" | cut -f3 -d '/')
 
           # Start the amqp/tasks pod, supply working task secrets, and run unit test on our own PR
-          sudo tasks/run-local.sh -p $PRN -s ~/secrets -t ~/.config/github-token
+          sudo tasks/run-local.sh -p $PRN -t ~/.config/github-token

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -144,19 +144,26 @@ command:
 
 # Deploying locally for development
 
-For hacking on the webhook or task container, or validating new container
+For hacking on the webhook, image/sink, or task container, or validating new container
 images, you can also run a simple [podman pod](http://docs.podman.io/en/latest/pod.html)
-locally with a RabbitMQ and a tasks container:
+locally with  RabbitMQ, webhook, images, sink, and tasks containers:
 
     $ tasks/run-local.sh
 
 This will also generate the secrets in a temporary directory, unless they
 already exist in `tasks/credentials/`. By default this will use the
-`quay.io/cockpit/tasks:latest` container, but you can run a different tag by
-setting `$TASKS_TAG`.
+`quay.io/cockpit/{tasks,images}:latest` containers, but you can run a different
+tag by setting `$TASKS_TAG` and/or `$IMAGES_TAG`.
 
-This currently does not yet have any convenient way to inject jobs into the
-AMQP queue; this will be provided at a later point.
+This currently does not yet have any convenient way to inject arbitrary jobs
+into the AMQP queue; this will be provided at a later point. However, you can
+test the whole GitHub → webhook → tasks → sink/GitHub status workflow on some
+cockpituous PR with specifying the PR number and a GitHub token:
+
+    $ tasks/run-local.sh -p 123 -t ~/.config/github-token
+
+This will run tests-scan/tests-trigger on the given PR and trigger an
+[unit-tests](../.cockpit-ci/run) test which simply does `make check`.
 
 # GitHub webhook integration
 


### PR DESCRIPTION
  - Create ssh config/key tasks secrets
 - Expose port 8080 (as "image server") on the pod
 - Start "cockpituous-images" container in the pod, configured like
   sink/sink-centosci.yaml
 - Tell tasks container to use it via `$TEST_PUBLISH`
 - Do some coarse assertions about the sink's generated test logs

 - Revert using the production sink secrets in the tests workflow.
   This will mean the GitHub status URL is http://localhost:8080/...
   which is a bit odd; but that address actually works if you run
   run-local.sh manually locally, and for the workflow run it's not
   really important to have the unit-tests log on the official sink.
   It's much more important to exercise a changed sink interaction.

 - [x] Depends on #370
 - [x] Depends on #371
 - [x] fix ssh failure when running containers in workflow: PR #372 
 - [x] validate that image HTTP server works
 - [x] Update README documentation