### PR TITLE
Clean up certificate SANs

### DIFF
--- a/images/generate-image-certs.sh
+++ b/images/generate-image-certs.sh
@@ -1,7 +1,15 @@
 #!/bin/bash -ex
 # Generate image server certificate
 
-SAN="DNS:*.apps.ci.centos.org,DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests"
-openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr -subj '/O=Cockpit/OU=Cockpituous/CN=cockpit-tests' -extensions SAN -reqexts SAN -config <(cat /etc/pki/tls/openssl.cnf; printf "\n[SAN]\nsubjectAltName=$SAN")
-openssl x509 -req -days 365000 -in server.csr -CA ../ca.pem -CAkey ../ca.key -set_serial $(date +%s) -extensions SAN -extfile <(printf "\n[SAN]\nsubjectAltName=$SAN") -out server.pem
+ROOTDIR=$(dirname $(dirname $(realpath $0)))
+OPENSSL_CNF=$ROOTDIR/tasks/credentials/openssl.cnf
+
+openssl req -new -newkey rsa:2048 -nodes -keyout server.key -out server.csr \
+    -subj '/O=Cockpit/OU=Cockpituous/CN=cockpit-tests' \
+    -extensions server_ca_extensions -reqexts server_ca_extensions \
+    -config $OPENSSL_CNF
+openssl x509 -req -days 365000 -in server.csr -out server.pem \
+    -CA ../ca.pem -CAkey ../ca.key \
+    -set_serial $(date +%s) \
+    -extensions server_ca_extensions -extfile $OPENSSL_CNF
 rm server.csr

--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -46,10 +46,9 @@ keyUsage = keyCertSign, cRLSign
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.2
-subjectAltName=DNS:amqp-cockpit.apps.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cloud.fedoraproject.org
 
 [ server_ca_extensions ]
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
-subjectAltName=DNS:amqp-cockpit.apps.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cloud.fedoraproject.org
+subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests


### PR DESCRIPTION
Remove the triplication of subjectAltName: Make
tasks/credentials/openssl.cnf's server_ca_extensions the single source
of truth, drop the unnecessary SAN from the AMQP client certificate, and
use it in the image certificate script as well.

This also avoids using /etc/pki/tls/openssl.cnf, which does not exist in
Debian/Ubuntu (i.e. on GitHub workflows), and we don't want to rely on
the system config anyway.