### PR TITLE
Clean up certificate SANs

### DIFF
--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -46,10 +46,9 @@ keyUsage = keyCertSign, cRLSign
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.2
-subjectAltName=DNS:amqp-cockpit.apps.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cloud.fedoraproject.org
 
 [ server_ca_extensions ]
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
-subjectAltName=DNS:amqp-cockpit.apps.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cloud.fedoraproject.org
+subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests


### PR DESCRIPTION
Remove the triplication of subjectAltName: Make
tasks/credentials/openssl.cnf's server_ca_extensions the single source
of truth, drop the unnecessary SAN from the AMQP client certificate, and
use it in the image certificate script as well.

This also avoids using /etc/pki/tls/openssl.cnf, which does not exist in
Debian/Ubuntu (i.e. on GitHub workflows), and we don't want to rely on
the system config anyway.