### PR TITLE
images: Fix container to run as user, test it in workflow, move to quay.io

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,21 @@
+name: build-images
+on:
+  # this is meant to be run on an approved PR branch for convenience
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      # use podman as root, so that it uses overlayfs; user with vfs takes too long and uses too much space
+      - name: Log into container registry
+        run: sudo podman login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+
+      - name: Build images container
+        run: sudo make images-container
+
+      - name: Push container to registry
+        run: sudo make images-push

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,16 +30,20 @@ jobs:
           git config user.email github-actions@github.com
           git rebase origin/master
 
-      - name: Check if tasks container changed
-        id: tasks_changed
+      - name: Check which containers changed
+        id: containers_changed
         run: |
-          changes=$(git diff --name-only origin/master..HEAD -- tasks/)
+          tasks=$(git diff --name-only origin/master..HEAD -- tasks/)
+          images=$(git diff --name-only origin/master..HEAD -- images/)
           # print for debugging
-          echo "$changes"
-          [ -z "$changes" ] || echo "::set-output name=changed::true"
+          echo "tasks: $tasks"
+          echo "images: $images"
+          [ -z "$tasks" ] || echo "::set-output name=tasks::true"
+          [ -z "$images" ] || echo "::set-output name=images::true"
+          [ -z "$images" -a -z "$tasks" ] || echo "::set-output name=any::true"
 
       - name: Set up secrets
-        if: steps.tasks_changed.outputs.changed
+        if: steps.containers_changed.outputs.any
         run: |
           # Put the /secrets in place which we'll mount to the tasks-container
           mkdir -p ~/secrets
@@ -53,12 +57,16 @@ jobs:
           sudo chown 1111:1111 ~/secrets/*
 
       - name: Build tasks container if it changed
-        if: steps.tasks_changed.outputs.changed
+        if: steps.containers_changed.outputs.tasks
         # Run podman as root, as podman is missing slirp4netns by default, and does not have overlayfs by default
         run: sudo make tasks-container
 
-      - name: Test tasks container if it changed
-        if: steps.tasks_changed.outputs.changed
+      - name: Build images container if it changed
+        if: steps.containers_changed.outputs.images
+        run: sudo make images-container
+
+      - name: Test local deployment if any container changed
+        if: steps.containers_changed.outputs.any
         run: |
           PRN=$(echo "$GITHUB_REF" | cut -f3 -d '/')
 

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,12 @@ images-shell:
         cockpit/images -i
 
 images-container:
-	$(DOCKER) build -t docker.io/cockpit/images:$(TAG) images
-	$(DOCKER) tag docker.io/cockpit/images:$(TAG) docker.io/cockpit/images:latest
-	$(DOCKER) tag docker.io/cockpit/images:$(TAG) docker.io/cockpit/images:latest
+	$(DOCKER) build -t quay.io/cockpit/images:$(TAG) images
+	$(DOCKER) tag quay.io/cockpit/images:$(TAG) quay.io/cockpit/images:latest
+	$(DOCKER) tag quay.io/cockpit/images:$(TAG) quay.io/cockpit/images:latest
 
 images-push:
-	./push-container docker.io/cockpit/images
+	./push-container quay.io/cockpit/images
 
 release-shell:
 	$(DOCKER) run -ti --rm --entrypoint=/bin/bash ghcr.io/cockpit-project/release

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -20,6 +20,7 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
     ln -sf /dev/stderr /var/log/nginx/error.log && \
     rm -rf /usr/share/nginx/html && \
     ln -snf /cache/images /usr/share/nginx/html && \
+    chmod -R 777 /var/log/nginx /var/lib/nginx && \
     chmod a+x /home/user/sink && \
     chmod g=u /etc/passwd
 
@@ -28,6 +29,7 @@ COPY nginx.conf /etc/nginx/
 
 VOLUME /cache/images
 
+USER user
 EXPOSE 8080 8443
 STOPSIGNAL SIGQUIT
 CMD /usr/sbin/nginx -g "daemon off;"

--- a/images/README.md
+++ b/images/README.md
@@ -6,12 +6,12 @@ This is an image store for hosting VMs for Cockpit integration tests.
 
 Secrets need to be set up in the same way as for the [tasks container](../tasks/README.md). This container particularly needs the [CA](../tasks/credentials/generate-ca.sh) and [server SSL certificates](./generate-image-certs.sh) and the `htpasswd` file for authenticating users that are allowed to upload.
 
-    $ sudo docker pull cockpit/images
-    $ sudo atomic install cockpit/images
+    $ sudo docker pull quay.io/cockpit/images
+    $ sudo atomic install quay.io/cockpit/images
 
 Or, if the `atomic` command is not available, run
 
-    $ sudo docker inspect --format '{{ index .Config.Labels "INSTALL"}}' cockpit/images  | sed 's_IMAGE_cockpit/images_'
+    $ sudo docker inspect --format '{{ index .Config.Labels "INSTALL"}}' quay.io/cockpit/images  | sed 's_IMAGE_cockpit/images_'
 
 and execute that command.
 

--- a/images/cockpit-images.yaml
+++ b/images/cockpit-images.yaml
@@ -17,7 +17,7 @@ items:
       spec:
         containers:
           - name: images
-            image: docker.io/cockpit/images
+            image: quay.io/cockpit/images
             ports:
               - containerPort: 8080
                 protocol: TCP

--- a/images/install-service
+++ b/images/install-service
@@ -28,7 +28,7 @@ Environment="TASK_SECRETS=$SECRETS"
 Restart=always
 RestartSec=60
 ExecStartPre=-$RUNC rm -f cockpit-images
-ExecStart=/bin/sh -xc "$RUNC run --name=cockpit-images --publish=8090:8080 --publish=8493:8443 --volume=\$TASK_SECRETS:/secrets:ro --volume=\$TASK_CACHE/images:/cache/images:rw cockpit/images"
+ExecStart=/bin/sh -xc "$RUNC run --name=cockpit-images --publish=8090:8080 --publish=8493:8443 --volume=\$TASK_SECRETS:/secrets:ro --volume=\$TASK_CACHE/images:/cache/images:rw quay.io/cockpit/images"
 ExecStop=$RUNC rm -f cockpit-images
 
 [Install]

--- a/images/install-service
+++ b/images/install-service
@@ -28,7 +28,7 @@ Environment="TASK_SECRETS=$SECRETS"
 Restart=always
 RestartSec=60
 ExecStartPre=-$RUNC rm -f cockpit-images
-ExecStart=/bin/sh -xc "$RUNC run --name=cockpit-images --publish=8090:8080 --publish=8493:8443 --volume=\$TASK_SECRETS:/secrets:ro --volume=\$TASK_CACHE/images:/cache/images:rw quay.io/cockpit/images"
+ExecStart=/bin/sh -xc "$RUNC run --name=cockpit-images --publish=8080:8080 --publish=8493:8443 --volume=\$TASK_SECRETS:/secrets:ro --volume=\$TASK_CACHE/images:/cache/images:rw quay.io/cockpit/images"
 ExecStop=$RUNC rm -f cockpit-images
 
 [Install]

--- a/sink/sink-centosci.yaml
+++ b/sink/sink-centosci.yaml
@@ -18,7 +18,7 @@ items:
       spec:
         containers:
           - name: sink
-            image: cockpit/images
+            image: quay.io/cockpit/images
             ports:
               - containerPort: 8080
                 protocol: TCP

--- a/sink/sink-centosci.yaml
+++ b/sink/sink-centosci.yaml
@@ -39,12 +39,6 @@ items:
             - name: config
               mountPath: /run/config
               readOnly: true
-            - name: httpd-log
-              mountPath: /var/log/nginx
-            - name: httpd-state
-              mountPath: /var/lib/nginx
-            - name: httpd-state-tmp
-              mountPath: /var/lib/nginx/tmp
         volumes:
         - name: images
           persistentVolumeClaim:
@@ -58,15 +52,6 @@ items:
         - name: config
           configMap:
             name: sink-config
-        - name: httpd-log
-          emptyDir:
-            medium: Memory
-        - name: httpd-state
-          emptyDir:
-            medium: Memory
-        - name: httpd-state-tmp
-          emptyDir:
-            medium: Memory
 
 - kind: Service
   apiVersion: v1


### PR DESCRIPTION
Old container fails like this:
```
❱❱❱ podman run -it --rm -p 8080:8080 -u user -v ./local-data/secrets/tasks:/secrets:ro docker.io/cockpit/images 
nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (13: Permission denied)
2021/01/28 10:11:10 [warn] 1#0: the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:1
2021/01/28 10:11:10 [warn] 1#0: could not build optimal types_hash, you should increase either types_hash_max_size: 2048 or types_hash_bucket_size: 64; ignoring types_hash_bucket_size
2021/01/28 10:11:10 [emerg] 1#0: mkdir() "/var/lib/nginx/tmp/client_body" failed (13: Permission denied)
```
This is also what makes the workflow fail in PR #368. In GitHub's version of podman using `--tmpfs ..:mode=777` is broken. But moreover, let's not require this hack in the first place!

With the rebuilt container, this works nicely locally, and you can do http://localhost:8080/ to test nginx.