### PR TITLE
run-local.sh: Test image-{upload,download} and attachments

### DIFF
--- a/.cockpit-ci/run
+++ b/.cockpit-ci/run
@@ -2,4 +2,7 @@
 
 set -eux
 
+if [ -n "$TEST_ATTACHMENTS" ]; then
+    echo "heisenberg compensator at 99.8% efficiency" > "$TEST_ATTACHMENTS"/bogus.log
+fi
 make check

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -190,6 +190,9 @@ if [ -n "$PR" ]; then
     echo "$LOG" | grep -q 'Running on: `cockpituous`'
     echo "$LOG" | grep -q '^OK'
     echo "$LOG" | grep -q 'Test run finished, return code: 0'
+    # validate test attachment
+    BOGUS_LOG=$(curl $RESULTS_DIR_URL/bogus.log)
+    echo "$BOGUS_LOG" | grep -q 'heisenberg compensator'
 else
     # clean up dummy token, so that image-prune does not try to use it
     rm "$SECRETS"/webhook/.config--github-token


### PR DESCRIPTION
Create a GitHub token and corresponding htpasswd; the latter is
statically computed, as we don't want to introduce a `htpasswd` program
dependency, and reimplementing `$apr1` is too cumbersome. For that
reason, delay setting up the real GitHub token until the time when the
test touches the PR.

Test that image uploading and downloading works. This needs to happen in
a copy of the primary bots checkout, as the cockpit-tasks main loop
constantly resets this to origin/master; but we need to modify the bot
checkout's ca.pem to the locally generated one.