### PR TITLE
tasks: Replace run-local.sh tests-trigger with testmap injection

### DIFF
--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -129,6 +129,7 @@ podman run -d -it --name cockpituous-tasks --pod=cockpituous \
     -e COCKPIT_CA_PEM=/run/secrets/webhook/ca.pem \
     -e COCKPIT_BOTS_REPO=${COCKPIT_BOTS_REPO:-} \
     -e COCKPIT_BOTS_BRANCH=${COCKPIT_BOTS_BRANCH:-} \
+    -e COCKPIT_TESTMAP_INJECT=master/unit-tests \
     -e AMQP_SERVER=localhost:5671 \
     -e TEST_PUBLISH=sink-local \
     quay.io/cockpit/tasks:${TASKS_TAG:-latest}
@@ -169,7 +170,7 @@ if [ -n "$PR" ]; then
 
     podman exec -i cockpituous-tasks sh -exc "
     cd bots;
-    ./tests-trigger -f --repo $PR_REPO $PR unit-tests;
+    ./tests-scan -p $PR --amqp 'localhost:5671' --repo $PR_REPO;
     for retry in \$(seq 10); do
         ./tests-scan --repo $PR_REPO -vd;
         OUT=\$(./tests-scan --repo $PR_REPO -p $PR -dv);
@@ -177,7 +178,6 @@ if [ -n "$PR" ]; then
         echo waiting until the status is visible;
         sleep 10;
     done;
-    ./tests-scan -p $PR --amqp 'localhost:5671' --repo $PR_REPO;
     ./inspect-queue;"
 
     # wait until the unit-test got run and published


### PR DESCRIPTION
In <https://github.com/cockpit-project/bots/pull/1623> the bots testmaps
start to support injecting an additional test with
`COCKPIT_TESTMAP_INJECT=branch/context`. This allows run-local.sh to use
the same event/tests-scan workflow as production, without the `_manual`
testmap hack and calling tests-trigger.

The latter approach would not work at all for writing similar
integration self-tests for bots, as doing tests-trigger races with the
real bots (the bots repo has an issues webhook trigger, unlike
cockpituous).


 - [x] Builds on top of PR #375 
 - [x] Builds on top of PR #377
 - [x] Requires PR #378 
 - [x] Requires bots testmap injection: https://github.com/cockpit-project/bots/pull/1623
 - [x] Drop `COCKPIT_BOTS_{REPO,BRANCH}` hack from workflow again