### PR TITLE
tasks: Fix race condition in run-local.sh

### DIFF
--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -51,4 +51,4 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
-subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests
+subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous-images


### PR DESCRIPTION
Wait for the images server to be fully up before calling image-upload.
In GitHub workflow it sometimes starts too late (perhaps because of
container image downloads happening in the background?)

Also add "cockpituous-images" to the list of valid DNS names covered by
the TSL certificate, so that we don't need to jump through hoops to use
curl directly.