### PR TITLE
ansible: Add SSH gateway user/key to our sink

### DIFF
--- a/ansible/aws/README.md
+++ b/ansible/aws/README.md
@@ -103,6 +103,7 @@ Public log sink/server setup
        ansible-playbook -i inventory aws/setup-host.yml
        ansible-playbook -i inventory maintenance/sync-secrets.yml
        ansible-playbook -i inventory cockpituous/sink.yml
+       ansible-playbook -i inventory aws/sink-ssh-gateway.yml
 
  * Set up an ssh configuration for convenience:
 

--- a/ansible/aws/sink-ssh-gateway.yml
+++ b/ansible/aws/sink-ssh-gateway.yml
@@ -1,0 +1,35 @@
+---
+- hosts: tag_Name_cockpit_sink
+  tasks:
+
+  - name: Create sshgw user
+    user:
+      name: sshgw
+      comment: Cockpit CI ssh gateway
+
+  - name: Create ~sshgw/.ssh dir
+    file:
+      state: directory
+      path: ~sshgw/.ssh
+      owner: sshgw
+      group: sshgw
+      mode: 0700
+
+  - name: Set up sshgw authorized_keys
+    become_user: sshgw
+    shell: |
+      (echo -n 'command="sleep infinity" '; cat /var/lib/cockpit-secrets/tasks/id_sshgw.pub) > ~sshgw/.ssh/authorized_keys
+      chmod 0600 ~sshgw/.ssh/authorized_keys
+
+  - name: Enable SSH gateway ports
+    lineinfile:
+      path: /etc/ssh/sshd_config
+      regexp: '^GatewayPorts '
+      insertafter: '^#GatewayPorts '
+      line: 'GatewayPorts yes'
+    notify:
+      restart sshd
+
+  handlers:
+  - name: restart sshd
+    service: name=sshd state=restarted


### PR DESCRIPTION
This can be used to temporarily expose ports on workflow/pipeline
machines by doing port forwarding to our sink.

Create a new unprivileged user and use a separate key for this,  to get
proper privilege separation to the sink.