### PR TITLE
ansible: Fix sink url pattern

### DIFF
--- a/ansible/cockpituous/sink.yml
+++ b/ansible/cockpituous/sink.yml
@@ -74,8 +74,9 @@
     copy:
       dest: ~sink/.config/sink
       mode: 0644
+      # don't use ansible_host here, we want to use our proper DNS name
       content: |
         [Sink]
-        Url: https://{{ ansible_host }}/logs/%(identifier)s/
+        Url: https://logs.cockpit-project.org/logs/%(identifier)s/
         Logs: /var/cache/cockpit-tasks/images/logs
         PruneInterval: 0.5


### PR DESCRIPTION
We shouldn't use `ansible_host` there, as that will be something clunky
like `ec2-<IP>.*.amazonaws.com` and not match the TLS certificate's
subjectAlternateNames.

Configure the logs.cockpit-project.org domain name instead. We had this
for  a long time, until the re-deployment earlier this morning changed
it.