### PR TITLE
tasks: Fix and simplify bots checkout

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -35,7 +35,7 @@ function update_bots() {
     if [ -d "$BOTS_DIR" ]; then
         git -C "$BOTS_DIR" pull --rebase
     else
-        git clone -b "$COCKPIT_BOTS_BRANCH" "$COCKPIT_BOTS_REPO" "$BOTS_DIR"
+        git clone --quiet -b "$COCKPIT_BOTS_BRANCH" "$COCKPIT_BOTS_REPO" "$BOTS_DIR"
     fi
 }
 

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -32,20 +32,10 @@ echo "https://cockpituous:$(cat ~/.config/github-token)@github.com" > ~/.git-cre
 echo "Starting testing"
 
 function update_bots() {
-    if [ ! -d "$BOTS_DIR" ]; then
-        git clone "$COCKPIT_BOTS_REPO" "$BOTS_DIR"
-    elif [ -f "$BOTS_DIR/.git/shallow" ]; then
-        # if we ended up with a shallow clone from a previous test, start from
-        # scratch, as this is brittle to clean up afterwards
-        echo "cockpit-tasks: Shallow commits exist in $BOTS_DIR, cannot reset; re-cloning"
-        rm -rf "$BOTS_DIR"
-        git clone "$COCKPIT_BOTS_REPO" "$BOTS_DIR"
+    if [ -d "$BOTS_DIR" ]; then
+        git -C "$BOTS_DIR" pull --rebase
     else
-        # avoid re-cloning in most cases to save GitHub bandwidth
-        git -C "$BOTS_DIR" fetch origin
-        git -C "$BOTS_DIR" reset --hard
-        git -C "$BOTS_DIR" clean -dxff
-        git -C "$BOTS_DIR" checkout "origin/$COCKPIT_BOTS_BRANCH"
+        git clone -b "$COCKPIT_BOTS_BRANCH" "$COCKPIT_BOTS_REPO" "$BOTS_DIR"
     fi
 }
 


### PR DESCRIPTION
Commit 8b27da1eb44ff had a bug where the *first* cockpit-tasks round
always checked out the default branch of bots, instead of
`$COCKPIT_BOTS_BRANCH`. This led to bots PR failures when running
against an outdated master branch from a clone (as they usually are).
Fix that by using the `clone -b` option.

The bots checkout is now only for cockpit-tasks's benefit -- the
individual tasks and tests all check out their own bots. Thus we can
simplify `update_bots()` and only differ between "new checkout for the
first time" and "pull to get the latest version".

-----

Seen in [this bots PR](https://github.com/cockpit-project/bots/pull/1660) in [this workflow](https://github.com/cockpit-project/bots/pull/1660/checks?check_run_id=1871579295)