### PR TITLE
tasks: Call inspect-queue on local AMQP server in run-local.sh

### DIFF
--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -178,7 +178,7 @@ if [ -n "$PR" ]; then
         echo waiting until the status is visible;
         sleep 10;
     done;
-    ./inspect-queue;"
+    ./inspect-queue --amqp localhost:5671;"
 
     # wait until the unit-test got run and published
     for retry in $(seq 60); do


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/1687 changes the default
AMQP server to the real official one on CentOS CI. Specify the local one
explicitly to avoid relying on the internal default.