### PR TITLE
Fix release-source for cockpit, massively simplify it

### DIFF
--- a/release/release-source
+++ b/release/release-source
@@ -75,28 +75,6 @@ autogen_or_configure()
     fi
 }
 
-# Prints out an existing tarball archive for the given version
-#  $1: The tarball version
-#  $2: The directory containing tarballs
-#  $3: The directory containing the temporary repository
-find_and_extract_tarballs()
-{
-    local archive name
-
-    archive=
-    find "$2" -maxdepth 1 -name "*-$1.tar.*" | LC_ALL=C sort | while read name; do
-
-        tar -xf "$name" -C "$3" --strip-components=1
-	git -C "$3" reset --quiet --hard HEAD
-
-        # The first tarball is the main one
-        if [ -z "$archive" ]; then
-            archive="$name"
-            echo "$name"
-	fi
-    done
-}
-
 # Copies all tarballs from build into source directory, clears
 # all previously existing tarballs, and prints name of first tarball
 #  $1: The make build directory
@@ -130,7 +108,6 @@ prepare()
     workdir=$(mktemp --directory source.XXXXXX)
     repodir=$workdir/repo
     stagedir=$workdir/stage
-    archive=""
 
     mkdir -p "$SOURCE"
 
@@ -139,35 +116,29 @@ prepare()
     head=$(git -C $repodir rev-parse HEAD)
     git -C $repodir checkout -q --detach $TAG
 
-    # Find archives in the source directory
-    archive="$(find_and_extract_tarballs $TAG $SOURCE $repodir)"
-
     if [ -x ./autogen.sh ] || [ -x ./configure ]; then
         is_autotools=1
     else
         is_autotools=
     fi
 
-    # If it is missing rebuild the tarball from latest tag and copy into place
-    if [ -z "$archive" ]; then
-        trace "Creating first tarball"
+    trace "Creating first tarball"
 
-        if [ -n "$is_autotools" ]; then
-            # autotools based projects
-            autogen_or_configure $repodir
-            $MAKE -C $repodir/_build dist
-            archive="$(output_tarballs $repodir/_build $SOURCE)"
-        else
-            # plain Makefile projects
-            $MAKE -C $repodir dist || $MAKE -C $repodir dist-gzip
-            archive=$(find $repodir -maxdepth 1 -name "*-${TAG}.tar.*")
-            if [ "$(echo "$archive" | wc -l)" != 1 ]; then
-                echo "ERROR: Expecting exactly one *-${TAG}.tar.*" >&2
-                exit 1
-            fi
-            find "$SOURCE" -maxdepth 1 -name "*-*.tar.*" -delete
-            cp "$archive" "$SOURCE"
+    if [ -n "$is_autotools" ]; then
+        # autotools based projects
+        autogen_or_configure $repodir
+        $MAKE -C $repodir/_build dist
+        archive="$(output_tarballs $repodir/_build $SOURCE)"
+    else
+        # plain Makefile projects
+        $MAKE -C $repodir dist || $MAKE -C $repodir dist-gzip
+        archive=$(find $repodir -maxdepth 1 -name "*-${TAG}.tar.*")
+        if [ "$(echo "$archive" | wc -l)" != 1 ]; then
+            echo "ERROR: Expecting exactly one *-${TAG}.tar.*" >&2
+            exit 1
         fi
+        find "$SOURCE" -maxdepth 1 -name "*-*.tar.*" -delete
+        cp "$archive" "$SOURCE"
     fi
 
     trace "Committing first tarball"

--- a/release/release-source
+++ b/release/release-source
@@ -3,13 +3,7 @@
 # release-source
 #
 # A script that takes a git repo in the current working directory and builds
-# a tarball from a tag plus patches for each commit up until
-# the current HEAD, plus another commit/patch for the corresponding build
-# system changes (autotools/webpack) from the previous commits.
-#
-# The output patchset is in git patch format with the intent that it can
-# contain binary patches. The resulting patch file names are placed in the
-# current directory and their names are printed on stdout.
+# a tarball from a tag.
 #
 # $ git tag -as 122
 # $ release-source -o source-output
@@ -99,21 +93,16 @@ output_tarballs()
 }
 
 
-# Use the specified patches to build an input git repo
-# Add another commit with build system changes
+# Build release tarball
 prepare()
 {
-    local workdir stagedir repodir commit archive archives author date name exist
+    local repodir commit archive archives author date name exist
 
-    workdir=$(mktemp --directory source.XXXXXX)
-    repodir=$workdir/repo
-    stagedir=$workdir/stage
-
+    repodir=$(mktemp --directory source.XXXXXX)
     mkdir -p "$SOURCE"
 
     # Clone the repo into our repodir
     git clone -q . $repodir
-    head=$(git -C $repodir rev-parse HEAD)
     git -C $repodir checkout -q --detach $TAG
 
     if [ -x ./autogen.sh ] || [ -x ./configure ]; then
@@ -122,13 +111,13 @@ prepare()
         is_autotools=
     fi
 
-    trace "Creating first tarball"
+    trace "Creating tarball"
 
     if [ -n "$is_autotools" ]; then
         # autotools based projects
         autogen_or_configure $repodir
         $MAKE -C $repodir/_build dist
-        archive="$(output_tarballs $repodir/_build $SOURCE)"
+        output_tarballs $repodir/_build $SOURCE
     else
         # plain Makefile projects
         $MAKE -C $repodir dist || $MAKE -C $repodir dist-gzip
@@ -140,59 +129,7 @@ prepare()
         find "$SOURCE" -maxdepth 1 -name "*-*.tar.*" -delete
         cp "$archive" "$SOURCE"
     fi
-
-    trace "Committing first tarball"
-    mkdir $stagedir
-    git -C $stagedir init -q
-    git -C $stagedir config core.autocrlf false
-    git -C $stagedir config core.safecrlf false
-    git -C $stagedir config gc.auto 0
-
-    # Mark all sorts of extra files as binary for diffing purposes
-    printf "*.min.* binary\n*.map binary\n/dist/** binary\n" > $stagedir/.git/info/attributes
-
-    # HACK: Exclude node_modules/ which was in cockpit tarballs
-    tar -C $stagedir --exclude="node_modules" \
-        --strip-components=1 -xf "$archive"
-    git -C $stagedir add -f .
-    git -C $stagedir commit -q --message="initial"
-    git -C $stagedir tag -a initial --message="initial"
-
-    # If there are commits since $TAG, apply and generate patch for build-system changes
-    # This is only supported for autotools projects, as plain Makefile ones often don't support out-of-tree builds
-    if [ -n "$is_autotools" ] && [ "$(git -C $repodir rev-parse HEAD)" != "$head" ]; then
-        trace "Committing patches"
-        git format-patch --stdout $TAG.. | git -C $stagedir am -
-
-        git -C $repodir checkout -q --detach "$head"
-        trace "Cleaning out build and rebuilding with commits on top of $TAG"
-
-        rm -rf $repodir/_build
-        autogen_or_configure $repodir
-        $MAKE -C $repodir/_build dist-gzip distdir=release-patched
-
-        trace "Committing build system generated changes"
-
-        # Now extract the tarball into our stage directory and commit it
-        # HACK: Exclude node_modules/ which was in cockpit tarballs
-        tar -C $stagedir --exclude="node_modules" --exclude=".tarball" \
-            --strip-components=1 -xzf - < $repodir/_build/release-patched.tar.gz
-        git -C $stagedir add -f .
-
-        if ! git -C $stagedir diff-index --exit-code --quiet HEAD --; then
-            git -C $stagedir commit --author="Cockpitous <cockpituous@cockpit-project.org>" \
-                -m "Build system generated changes from patches"
-        fi
-
-        trace "Extracting tarball expanded patches"
-
-        # Extract patches for everything that was staged and put in right place
-        find "$SOURCE" -maxdepth 1 -name '*.patch' -delete
-        git -C $stagedir format-patch --output-directory=$SOURCE initial..HEAD^
-        git -C $stagedir format-patch --output-directory=$SOURCE --start-number=999 HEAD^..
-    fi
-
-    rm -rf $workdir
+    rm -rf $repodir
 }
 
 while getopts "f:p:qt:vx" opt; do

--- a/release/release-source
+++ b/release/release-source
@@ -56,19 +56,6 @@ message()
     echo "release-source: $@" >&2
 }
 
-# Runs autogen.sh or configure in the source directory
-# with a $(builddir) subdirectory of '_build'
-#  $1: The source directory
-autogen_or_configure()
-{
-    mkdir -p $1/_build
-    if [ -x $1/autogen.sh ]; then
-        ( cd $1 && NOCONFIGURE=1 ./autogen.sh && cd _build && ../configure )
-    else
-        ( cd $1/_build && ../configure )
-    fi
-}
-
 # Copies all tarballs from build into source directory, clears
 # all previously existing tarballs, and prints name of first tarball
 #  $1: The make build directory
@@ -105,19 +92,12 @@ prepare()
     git clone -q . $repodir
     git -C $repodir checkout -q --detach $TAG
 
-    if [ -x ./autogen.sh ] || [ -x ./configure ]; then
-        is_autotools=1
-    else
-        is_autotools=
-    fi
-
     trace "Creating tarball"
 
-    if [ -n "$is_autotools" ]; then
+    if [ -x ./autogen.sh ]; then
         # autotools based projects
-        autogen_or_configure $repodir
-        $MAKE -C $repodir/_build dist
-        output_tarballs $repodir/_build $SOURCE
+        (cd $repodir; ./autogen.sh && $MAKE dist)
+        output_tarballs $repodir $SOURCE
     else
         # plain Makefile projects
         $MAKE -C $repodir dist || $MAKE -C $repodir dist-gzip


### PR DESCRIPTION
This fixes today's [cockpit release failure](https://github.com/cockpit-project/cockpit/actions/runs/575050528): Unlike our CI, release-source is doing an out-of-tree build, which somehow confuses our build system.
```
Traceback (most recent call last):
  File "/build/source.5Z5zt7/repo/_build/../tools/build-debian-copyright", line 162, in <module>
    license = module_license(moddir)
  File "/build/source.5Z5zt7/repo/_build/../tools/build-debian-copyright", line 62, in module_license
    raise SystemError('Could not determine license from %s' % moddir)
SystemError: Could not determine license from node_modules/@patternfly/react-core
```
PatternFly (and most other NPM modules) are not actually supposed to be in the dist tarball any more.

I also took the opportunity to throw out the 95% of cruft code that we don't use any more. Now it's much simpler to see what this *does*, and much easier to test this.

## Testing
Do exactly what tools/cockpituous-release is doing, starting from a pristine checkout:

    RELEASE_SOURCE=$PWD/_release/source ~/upstream/cockpituous/release/release-source

This reproduces the original failure, and with this PR it works fine now.

I tested this with cockpit.git, then it produced

```
❱❱❱ ls -l _release/source/
total 59524
-rw-r--r--. 1 martin martin  7428228 17. Feb 17:48 cockpit-238.tar.xz
-rw-r--r--. 1 martin martin 53521940 17. Feb 17:48 cockpit-cache-238.tar.xz
```

I also tested it against cockpit-podman, for the "plain Makefile project" case. I did a local fake "30" tag, and it produced
```
❱❱❱ ls -l _release/source/
total 1352
-rw-r--r--. 1 martin martin 1382319 Feb 17 17:39 cockpit-podman-30.tar.gz
``