### PR TITLE
images: Minimize container

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,11 +1,23 @@
-FROM fedora:latest
+FROM fedora:latest AS builder
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
-RUN dnf -y update && \
-    dnf -y install nginx openssh-server /usr/bin/python && \
-    dnf clean all && \
-    mkdir -p /home/user
+# avoid unnecessary stuff in the container; systemd is a protected package, so apply some extra force
+RUN source /etc/os-release && \
+    dnf install -y --releasever=$VERSION_ID --setopt=install_weak_deps=False --installroot=/build \
+        coreutils-single \
+        glibc-minimal-langpack \
+        nginx \
+        openssh-server \
+        tar \
+        /usr/bin/python3 && \
+    rpm --root=/build --verbose --erase --nodeps systemd && \
+    dnf remove -y --installroot=/build systemd-networkd device-mapper dbus-broker cryptsetup && \
+    rm -r /build/var/cache/dnf /build/var/lib/dnf /build/var/lib/rpm*
 
+FROM scratch
+COPY --from=builder /build /
+
+RUN mkdir -p /home/user
 # can't use ../sink/sink with docker build
 ADD https://raw.githubusercontent.com/cockpit-project/cockpituous/master/sink/sink /home/user/sink
 

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -91,8 +91,10 @@ EOF
 fi
 
 # start podman and run RabbitMQ in the background
+# HACK: put data into a tmpfs instead of anonymous volume, see https://github.com/containers/podman/issues/9432
 podman run -d --name cockpituous-rabbitmq --pod=new:cockpituous \
     --publish $IMAGE_PORT:8080 \
+    --tmpfs /var/lib/rabbitmq \
     -v "$RABBITMQ_CONFIG":/etc/rabbitmq:ro \
     -v "$SECRETS"/webhook:/run/secrets/webhook:ro \
     docker.io/rabbitmq:3-management


### PR DESCRIPTION
Use a multi-stage build [1], pick some "small container targetted" basic
packages, and remove some larger packages that we really don't need in
the container. This shrinks the container from 313 to 137 MB.

[1] https://docs.docker.com/develop/develop-images/multistage-build/

----

This was mostly a learning opportunity for me, I just saw @asamalik 's and @fatherlinux 's excellent [building smaller container images](https://devconfcz2021.sched.com/event/gmSS/building-smaller-container-images) devconf.cz talk. But then why not, now I earned some twitter bragging rights. :grin: 

I tested this locally, but our CI will test it in full.