### PR TITLE
ansible: Add playbook to reset docker on e2e machines

### DIFF
--- a/ansible/maintenance/reset-docker.yml
+++ b/ansible/maintenance/reset-docker.yml
@@ -1,0 +1,19 @@
+---
+# Sometimes docker gets itself into a bad state where containers are bad,
+# undeletable, or starting/stopping them throws weird storage errors. This
+# playbook does a "factory reset". This removes all containers, images,
+# and volumes.
+- hosts: e2e
+  gather_facts: false
+
+  tasks:
+  - name: Reset docker
+    shell: |
+      systemctl stop docker
+      sleep 5
+      docker-storage-setup --reset
+      sleep 5
+      rm -rf /var/lib/docker
+      sleep 5
+      docker-storage-setup
+      systemctl start docker


### PR DESCRIPTION
Sometimes docker gets itself into a bad state where containers are bad,
undeletable, or starting/stopping them throws weird storage errors. This
playbook does a "factory reset". This removes all containers, images,
and volumes.

----

I just used that to repair some accrued damage on our e2e machines. Don't ask too much about the sleeps.. It was not totally obvious how to do that right, so I'd like to keep this as a recipe.