### PR TITLE
ansible: Update reset-docker playbook

### DIFF
--- a/ansible/maintenance/reset-docker.yml
+++ b/ansible/maintenance/reset-docker.yml
@@ -9,11 +9,12 @@
   tasks:
   - name: Reset docker
     shell: |
+      systemctl stop 'cockpit-tasks@*'
+      systemctl stop cockpit-images || true
       systemctl stop docker
-      sleep 5
       docker-storage-setup --reset
-      sleep 5
       rm -rf /var/lib/docker
-      sleep 5
       docker-storage-setup
       systemctl start docker
+      systemctl start --all 'cockpit-tasks@*'
+      systemctl start cockpit-images || true


### PR DESCRIPTION
The sleeps introduced in commit 83d8c4d9f81e7c were not necessary after
all, they were just a leftover when the commands were done in the wrong
order.

In addition, stop and restart the work containers.