### PR TITLE
tasks: Increase /tmp to 14 GB

### DIFF
--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -63,4 +63,4 @@ spec:
       - name: tmp
         emptyDir:
           medium: Memory
-          sizeLimit: 10G
+          sizeLimit: 14G

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -7,6 +7,8 @@ CACHE=/var/cache/cockpit-tasks
 INSTANCES=${INSTANCES:-3}
 TMPFS_GB=14
 
+systemctl stop 'cockpit-tasks@*.service'
+
 # if the host has plenty of RAM, use a tmpfs for /tmp for getting less IO contention;
 # note the *2 as the containers also need actual RAM for themselves
 if awk "/MemAvailable:/ { exit (\$2 > ${TMPFS_GB}*1048576*2*${INSTANCES}) ? 0 : 1  }" /proc/meminfo; then
@@ -34,8 +36,6 @@ fi
 mkdir -p $SECRETS/tasks $SECRETS/webhook $CACHE
 chown -R 1111:1111 $SECRETS $CACHE
 chcon -R -t container_file_t $SECRETS $CACHE
-
-systemctl stop 'cockpit-tasks@*.service'
 
 cat <<EOF > /etc/systemd/system/cockpit-tasks@.service
 [Unit]

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -5,7 +5,7 @@ set -eufx
 SECRETS=/var/lib/cockpit-secrets
 CACHE=/var/cache/cockpit-tasks
 INSTANCES=${INSTANCES:-3}
-TMPFS_GB=10
+TMPFS_GB=14
 
 # if the host has plenty of RAM, use a tmpfs for /tmp for getting less IO contention;
 # note the *2 as the containers also need actual RAM for themselves


### PR DESCRIPTION
Current cockpit tests often need a bit more than 10 GB as especially the
nondestructive VMs pile up a lot of cruft in their overlays.

----

I deployed this, and our tasks containers now have a 14 GB /tmp.

This happend particularly badly in https://github.com/cockpit-project/cockpit/pull/15484 , I'll now retry this PR to validate that it is enough.