### PR TITLE
ansible: Restart all containers in sync-secrets.yml

### DIFF
--- a/ansible/maintenance/sync-secrets.yml
+++ b/ansible/maintenance/sync-secrets.yml
@@ -36,8 +36,8 @@
         cmd: "{{ oc_command }} create -f -"
         stdin: "{{ build_secrets.stdout }}"
 
-    - name: Restart image pods to pick up changed certificates
-      shell: "{{ oc_command }} get -o name -l infra=cockpit-images pods | xargs -l -r {{ oc_command }} delete --wait=false"
+    - name: Restart all containers to pick up new secrets
+      shell: "{{ oc_command }} get -o name pods | xargs -l -r {{ oc_command }} delete --wait=false"
 
 - name: Deploy secrets to e2e and AWS
   hosts: e2e tag_ServiceName_FrontDoorCI
@@ -86,3 +86,6 @@
     - name: Restart image containers to pick up changed secrets
       # The glob avoids failure on machines which are not running cockpit-images
       command: systemctl restart cockpit-images*.service
+
+    - name: Restart systemd controlled tasks containers to pick up changed secrets
+      command: systemctl restart cockpit-tasks@*


### PR DESCRIPTION
Updating the secrets directory yanks it away from existing running
containers and thus breaks them. Commit c78c681725b13 already fixed for
the images containers, but it applies to tasks as well.