### PR TITLE
tasks: Adjust webhook's bots testmap import

### DIFF
--- a/tasks/webhook
+++ b/tasks/webhook
@@ -55,7 +55,7 @@ def setup():
     os.umask(old_umask)
 
     ensure_bots_checkout()
-    from task import testmap
+    from lib import testmap
     for project in testmap.projects():
         subprocess.check_call([os.path.join(BOTS_CHECKOUT, 'tests-scan'), '--amqp',
                                AMQP_SERVER, '--repo', project],


### PR DESCRIPTION
https://github.com/cockpit-project/bots/commit/7a3c71968d5684 moved the
testmap.

This is super-urgent, as the current webhook container fails to start, and thus we can't run any tests.