### PR TITLE
images: Fix MIME type of prometheus file

### DIFF
--- a/images/nginx.conf
+++ b/images/nginx.conf
@@ -40,6 +40,7 @@ http {
                 add_header Content-Encoding gzip;
                 types { text/plain gz; }
             }
+            location ~ .*/prometheus { default_type text/plain; }
         }
     }
 
@@ -78,6 +79,7 @@ http {
                 add_header Content-Encoding gzip;
                 types { text/plain gz; }
             }
+            location ~ .*/prometheus { default_type text/plain; }
         }
     }
 }


### PR DESCRIPTION
This makes it convenient to look at in a browser.

--

I tested this with a locally built container and a cobbled-together images directory:
```
❱❱❱ curl -k --head https://images-frontdoor.apps.ocp.ci.centos.org/prometheus
HTTP/1.1 200 OK
Server: nginx/1.18.0
Date: Wed, 17 Mar 2021 06:58:16 GMT
Content-Type: application/octet-stream
[...]

❱❱❱ curl --head http://localhost:8080/prometheus
HTTP/1.1 200 OK
Server: nginx/1.18.0
Date: Wed, 17 Mar 2021 06:58:28 GMT
Content-Type: text/plain
[...]

❱❱❱ curl -k --head https://localhost:8493/prometheus
HTTP/1.1 200 OK
Server: nginx/1.18.0
Date: Wed, 17 Mar 2021 06:58:44 GMT
Content-Type: text/plain
[...]
```

I also tested it with firefox, and the file can be watched inline. Right now https://images-frontdoor.apps.ocp.ci.centos.org/prometheus just gives you a download dialog.