### PR TITLE
tasks: Set up S3 secrets for OpenShift, stop iteration when receiving SIGTERM

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -21,6 +21,16 @@ if [ -r /secrets/npm-registry.crt ]; then
     export NODE_EXTRA_CA_CERTS=/secrets/npm-registry.crt
 fi
 
+# set up S3 keys for OpenShift secrets volume
+if [ ! -d /secrets/s3-keys ]; then
+    # then our container symlink will point into the void, replace it with a directory and set up all files that we can find
+    rm ~/.config/cockpit-dev/s3-keys
+    mkdir ~/.config/cockpit-dev/s3-keys
+    find /secrets/ -name 's3-keys--*' | while read f; do
+        ln -s "$f" ~/.config/cockpit-dev/s3-keys/"${f#*--}"
+    done
+fi
+
 # let's just do our work in the current directory
 WORKDIR="$PWD"
 BOTS_DIR="$WORKDIR"/bots

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -61,8 +61,12 @@ function slumber() {
 # on mass deployment, avoid GitHub stampede
 slumber 0-120
 
-# Consume from queue 30 times, then restart
+# Consume from queue 30 times, then restart; listen to SIGTERM for orderly shutdown
+shutdown=
+trap "echo 'received SIGTERM, stopping main loop'; shutdown=1" TERM
+
 for i in $(seq 1 30); do
+    [ -z "$shutdown" ] || break
     update_bots
     cd "$BOTS_DIR"
 

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -72,6 +72,10 @@ else
     echo 0123abc > "$SECRETS"/webhook/.config--github-token
     echo 'user:$apr1$FzL9bivD$AzG7R8RNjuR.9DQRUrV.k.' > "$SECRETS"/tasks/htpasswd
 
+    # dummy S3 keys in OpenShift tasks/build-secrets encoding, for testing their setup
+    echo 'id12 geheim' > tasks/s3-keys--r1.cloud.com
+    echo 'id34 shhht' > tasks/s3-keys--r2.cloud.com
+
      ssh-keygen -f tasks/id_rsa -P ''
      cat <<EOF > tasks/ssh-config
 Host sink-local
@@ -156,6 +160,12 @@ podman exec -i cockpituous-tasks timeout 30 sh -ec '
     ./image-upload --store https://cockpituous-images:8443 --state hello.txt
     '
 test "$(cat "$IMAGES/hello.txt")" = "world"
+
+# validate OpenShift s3 keys secrets setup
+R1=$(podman exec -i cockpituous-tasks sh -ec 'cat ~/.config/cockpit-dev/s3-keys/r1.cloud.com')
+test "$R1" = "id12 geheim"
+R2=$(podman exec -i cockpituous-tasks sh -ec 'cat ~/.config/cockpit-dev/s3-keys/r2.cloud.com')
+test "$R2" = "id34 shhht"
 
 # validate image downloading
 podman exec -i cockpituous-tasks sh -exc '

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -224,5 +224,8 @@ else
     rm "$SECRETS"/webhook/.config--github-token
 fi
 
-# bring logs -f to the foreground; press Control-C or let the "30 polls" iteration finish
+# tell the tasks container iteration that we are done
+podman exec cockpituous-tasks kill -TERM 1
+
+# bring logs -f to the foreground
 wait


### PR DESCRIPTION
I tested this locally with a hacked up secrets dir and a local container. The integration tests model the situation quite closely.

The "test local deployment" step now takes only 2:15 minutes instead of the previous 7 minutes. :tada: 