### PR TITLE
tasks: Fix OpenShift S3 keys setup

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -26,7 +26,8 @@ if [ ! -d /secrets/s3-keys ]; then
     # then our container symlink will point into the void, replace it with a directory and set up all files that we can find
     rm ~/.config/cockpit-dev/s3-keys
     mkdir ~/.config/cockpit-dev/s3-keys
-    find /secrets/ -name 's3-keys--*' | while read f; do
+    for f in /secrets/s3-keys--*; do
+        [ -e "$f" ] || continue # non-matching glob
         ln -s "$f" ~/.config/cockpit-dev/s3-keys/"${f#*--}"
     done
 fi

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -73,8 +73,11 @@ else
     echo 'user:$apr1$FzL9bivD$AzG7R8RNjuR.9DQRUrV.k.' > "$SECRETS"/tasks/htpasswd
 
     # dummy S3 keys in OpenShift tasks/build-secrets encoding, for testing their setup
-    echo 'id12 geheim' > tasks/s3-keys--r1.cloud.com
-    echo 'id34 shhht' > tasks/s3-keys--r2.cloud.com
+    mkdir tasks/..data
+    echo 'id12 geheim' > tasks/..data/s3-keys--r1.cloud.com
+    echo 'id34 shhht' > tasks/..data/s3-keys--r2.cloud.com
+    ln -s ..data/s3-keys--r1.cloud.com tasks/s3-keys--r1.cloud.com
+    ln -s ..data/s3-keys--r2.cloud.com tasks/s3-keys--r2.cloud.com
 
      ssh-keygen -f tasks/id_rsa -P ''
      cat <<EOF > tasks/ssh-config


### PR DESCRIPTION
Fix commit cce26c464: The files in /secrets from the OpenShift secrets
volume are themselves links to a hidden ..data/ subdirectory. This
caused `find` to see them twice, and ran into "ln: file exists" errors.

Use a glob instead, and protect against zero matches with `test -e`.