### PR TITLE
release: Bump FMF plan refs in release-koji

### DIFF
--- a/release/release-koji
+++ b/release/release-koji
@@ -203,10 +203,17 @@ prepare()
             echo "/$file" >> $WORKDIR/.gitignore
         done
 
+        # until FMF has a way to determine the ref dynamically: https://github.com/psss/tmt/issues/585
+        trace "Updating FMF plan refs"
+        if files=$(git -C $WORKDIR grep -l "ref.*$oldver" plans/*.fmf); then
+            (cd $WORKDIR; sed -i "/ref:/ s/\b${oldver}\b/${version}/" "$files")
+            ADD_FMF=plans
+        fi
+
         trace "Committing changes"
 
         # Add the the sources file and spec file
-        git -C $WORKDIR add sources $PACKAGE.spec .gitignore
+        git -C $WORKDIR add sources $PACKAGE.spec .gitignore ${ADD_FMF:-}
 
         # Commit all of that with an appropriate message
         (


### PR DESCRIPTION
As of today, Fedora dist-git FMF test plans have to specify a git repo
and fixed ref for where to find the tests to run.
(https://github.com/psss/tmt/issues/585)

We don't want to bump this manually on every release, so teach
release-koji to do that automatically for every old version that appears
in plans/*.fmf.

This can be dropped once there is a way to just run the tests from the
upstream tarball in the dist-git, or run any "pre-discover" code.