### PR TITLE
tasks: Add git-lfs

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -16,6 +16,7 @@ RUN dnf -y update && \
         fpaste \
         gcc-c++ \
         git \
+        git-lfs \
         gnupg \
         intltool \
         jq \


### PR DESCRIPTION
So that we can check out from repositories that use git lfs.

Note: git lfs also uses hooks to perform its magic, but they seem to
be only needed when actually making changes to files tracked by lfs
and pushing them.  But simply cloning a reporsitory that uses lfs
works fine as long as the git-lfs RPM is installed and configured
globally (which happens during installation).

To setup up the hooks, we would need to run "git lfs install" in the
local repository after cloning.