### PR TITLE
tasks: cleanup S3 as part of pruning

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -80,3 +80,8 @@ done
 # Prune old images
 update_bots
 ./image-prune
+
+# Clean up S3
+for region in eu-central-1 us-east-1; do
+    ./image-prune --s3 "https://cockpit-images.${region}.linodeobjects.com/" || true
+done


### PR DESCRIPTION
At tasks container shutdown, also take a chance to run image-prune on
the S3 stores.