### PR TITLE
aws: Update RHEL AMI

### DIFF
--- a/ansible/aws/aws_defaults.yml
+++ b/ansible/aws/aws_defaults.yml
@@ -1,5 +1,5 @@
 ---
 aws_region: us-east-1
 # current RHEL 8
-aws_rhel_ami: ami-098f16afa9edf40be
+aws_rhel_ami: ami-07eeb4db5f7e5a8fb
 aws_key_name: "cockpit-{{ lookup('env', 'USER') }}"


### PR DESCRIPTION
Move to the current 8.4 daily. The previous image was still 8.2.

----

I tested this today with an UX demo instance as well as a "big" tasks runner (as e2e broke down last night)