### PR TITLE
tasks: Move to Fedora 34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ images-shell:
 images-container:
 	$(DOCKER) build -t quay.io/cockpit/images:$(TAG) images
 	$(DOCKER) tag quay.io/cockpit/images:$(TAG) quay.io/cockpit/images:latest
-	$(DOCKER) tag quay.io/cockpit/images:$(TAG) quay.io/cockpit/images:latest
 
 images-push:
 	./push-container quay.io/cockpit/images
@@ -41,7 +40,6 @@ release-shell:
 
 release-container:
 	$(DOCKER) build -t ghcr.io/cockpit-project/release:$(TAG) release
-	$(DOCKER) tag ghcr.io/cockpit-project/release:$(TAG) ghcr.io/cockpit-project/release:latest
 	$(DOCKER) tag ghcr.io/cockpit-project/release:$(TAG) ghcr.io/cockpit-project/release:latest
 
 release-push:
@@ -59,7 +57,6 @@ tasks-shell:
 
 tasks-container:
 	$(DOCKER) build -t quay.io/cockpit/tasks:$(TAG) tasks
-	$(DOCKER) tag quay.io/cockpit/tasks:$(TAG) quay.io/cockpit/tasks:latest
 	$(DOCKER) tag quay.io/cockpit/tasks:$(TAG) quay.io/cockpit/tasks:latest
 
 tasks-push:

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:34
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
 # HACK: chromium-headless 88 crashes with some keyDown commands: https://bugs.chromium.org/p/chromium/issues/detail?id=1170634


### PR DESCRIPTION
 - [x] build container locally
 - [x] run cockpit chromium test locally
 - [x] run cockpit firefox test locally
 - [x] [build/push](https://github.com/cockpit-project/cockpituous/actions/runs/891719500) and deploy
 - [x] wait for successful run on CI: https://github.com/cockpit-project/cockpit/pull/15876: [CentOS CI](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-15876-20210531-050656-6c6472d9-ubuntu-2004/log.html), [e2e firefox](https://logs.cockpit-project.org/logs/pull-15876-20210531-050656-6c6472d9-fedora-33-firefox/log.html), [e2e chromium](https://logs.cockpit-project.org/logs/pull-15876-20210531-050656-6c6472d9-fedora-34/log.html)