### PR TITLE
aws: Update default AMI

### DIFF
--- a/ansible/aws/aws_defaults.yml
+++ b/ansible/aws/aws_defaults.yml
@@ -1,5 +1,5 @@
 ---
 aws_region: us-east-1
 # current RHEL 8
-aws_rhel_ami: ami-07eeb4db5f7e5a8fb
+aws_rhel_ami: ami-0b0af3577fe5e3532
 aws_key_name: "cockpit-{{ lookup('env', 'USER') }}"

--- a/ansible/aws/setup-host.yml
+++ b/ansible/aws/setup-host.yml
@@ -13,6 +13,6 @@
     yum:
       name:
         - podman
-        - git
+        - git-core
         - python3
       state: latest


### PR DESCRIPTION
The previous one wa for 8.4 beta, move to 8.4 released. On the former,
installing packages does not work any more.

----

I rolled this out on AWS for starting a tasks runner, as e2e is still down.