### PR TITLE
aws: Increase disk size of tasks runner

### DIFF
--- a/ansible/aws/launch-tasks.yml
+++ b/ansible/aws/launch-tasks.yml
@@ -16,7 +16,7 @@
         vpc_subnet_id: subnet-05dd25fba5582bb6a
         volumes:
           - device_name: /dev/sda1
-            volume_size: 200
+            volume_size: 800
             delete_on_termination: true
         wait: true
         instance_tags:


### PR DESCRIPTION
200 GB was not enough for the number of tasks containers that the CPU
and RAM are capable of sustaining, so they kept running into ENOSPC.

---

I rolled this out earlier today, and at least that part works fine:

```
/dev/nvme0n1p2  800G   56G  745G   7% /
```