### PR TITLE
tasks: Move to RabbitMQ container on quay.io

### DIFF
--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -18,7 +18,7 @@ items:
       spec:
         containers:
           - name: amqp
-            image: docker.io/rabbitmq:3-management
+            image: quay.io/cockpit/rabbitmq-server
             ports:
             - containerPort: 5671
               protocol: TCP

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -126,7 +126,7 @@ podman run -d --name cockpituous-images --pod=cockpituous --user user \
 
 # wait until AMQP initialized
 sleep 5
-until podman exec -i cockpituous-rabbitmq sh -ec 'ls /var/lib/rabbitmq/mnesia/*.pid'; do
+until podman exec -i cockpituous-rabbitmq timeout 5 rabbitmqctl list_queues; do
     echo "waiting for RabbitMQ to come up..."
     sleep 3
 done

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -104,7 +104,7 @@ podman run -d --name cockpituous-rabbitmq --pod=new:cockpituous \
     --tmpfs /var/lib/rabbitmq \
     -v "$RABBITMQ_CONFIG":/etc/rabbitmq:ro,z \
     -v "$SECRETS"/webhook:/run/secrets/webhook:ro,z \
-    docker.io/rabbitmq:3-management
+    quay.io/cockpit/rabbitmq-server
 
 # start image+sink in the background; see sink/sink-centosci.yaml
 mkdir -p "$IMAGES"

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -225,6 +225,10 @@ if [ -n "$PR" ]; then
 else
     # clean up dummy token, so that image-prune does not try to use it
     rm "$SECRETS"/webhook/.config--github-token
+
+    # tasks can connect to queue
+    OUT=$(podman exec -i cockpituous-tasks bots/inspect-queue --amqp localhost:5671)
+    echo "$OUT" | grep -q 'queue public is empty'
 fi
 
 # tell the tasks container iteration that we are done


### PR DESCRIPTION
Today we ran into a failure on spawning the webhook container due to
pull request rate limits from CentOS CI. Avoid this in the future, and
use our container copy on quay.io instead.

----

 - [ ] Deploy and validate on CentOS CI 