### PR TITLE
aws: Add webhook

### DIFF
--- a/ansible/aws/README.md
+++ b/ansible/aws/README.md
@@ -63,7 +63,7 @@ Tasks runner setup
 
  * Enable more runners to fill up the 96 CPUs/188 GiB RAM:
 
-       ansible -i inventory -m shell -a 'systemctl enable --now cockpit-tasks@{5..12}' tag_ServiceComponent_Tasks
+       ansible -i inventory -m shell -a 'systemctl enable --now cockpit-tasks@{5..15}' tag_ServiceComponent_Tasks
 
 Public log sink/server setup
 ----------------------------

--- a/ansible/aws/README.md
+++ b/ansible/aws/README.md
@@ -47,6 +47,7 @@ Persistent resources
 --------------------
 
  * eni-0fece6d6c83cd9eca, aka "cockpit-public-sink": network device with stable external IP 54.89.13.31 (DNS: logs.cockpit-project.org)
+ * eni-004f5b4f714f3fda9, aka "cockpit-public-webhook": network device with stable external IP 3.228.126.27 (DNS: ec2-3-228-126-27.compute-1.amazonaws.com)
 
 Tasks runner setup
 ------------------
@@ -87,6 +88,24 @@ Public log sink/server setup
 
 The logs.cockpit-project.org domain (managed by Red Hat, ask sgallagh about it)
 points to the stable IP 54.89.13.31 of that instance.
+
+Webhook setup
+-------------
+Normally our webhook runs on [CentOS CI](../tasks/cockpit-tasks-webhook.yaml), but for times when this is down we can spin up a webhook in AWS.
+
+ * Create the instance:
+
+       ansible-playbook -i inventory aws/launch-webhook.yml
+
+ * Run the setup playbooks:
+
+       ansible-playbook -i inventory aws/setup-host.yml
+       ansible-playbook -i inventory maintenance/sync-secrets.yml
+       ansible-playbook -i inventory cockpituous/webhook.yml
+
+Using this deployment requires changing all the GitHub project webhooks to
+https://ec2-3-228-126-27.compute-1.amazonaws.com and changing `DEFAULT_AMQP_SERVER` in
+[bots](https://github.com/cockpit-project/bots/blob/master/task/distributed_queue.py).
 
 Cockpit demo setup
 ------------------

--- a/ansible/aws/launch-demo.yml
+++ b/ansible/aws/launch-demo.yml
@@ -33,8 +33,6 @@
     - name: Wait for SSH to come up
       delegate_to: "{{ item.public_dns_name }}"
       wait_for_connection:
-        delay: 60
-        timeout: 320
       loop: "{{ ec2.instances }}"
 
 - name: Configure instances

--- a/ansible/aws/launch-public-sink.yml
+++ b/ansible/aws/launch-public-sink.yml
@@ -37,8 +37,6 @@
     - name: Wait for SSH to come up
       delegate_to: "{{ item.private_ip }}"
       wait_for_connection:
-        delay: 60
-        timeout: 320
       loop: "{{ ec2.instances }}"
 
 - name: Configure instances

--- a/ansible/aws/launch-tasks.yml
+++ b/ansible/aws/launch-tasks.yml
@@ -37,10 +37,6 @@
     - name: Wait for SSH to come up
       delegate_to: "{{ item.private_ip }}"
       wait_for_connection:
-        # metal instances take a long time to initialize
-        delay: 120
-        sleep: 30
-        timeout: 1800
       loop: "{{ ec2.instances }}"
 
 - name: Configure instances

--- a/ansible/aws/launch-webhook.yml
+++ b/ansible/aws/launch-webhook.yml
@@ -1,0 +1,45 @@
+---
+- name: Create public webhook EC2 instance
+  hosts: localhost
+  gather_facts: false
+  vars_files: aws_defaults.yml
+
+  tasks:
+    - name: Create EC2 instance
+      ec2:
+        key_name: "{{ aws_key_name }}"
+        region: "{{ aws_region }}"
+        image: "{{ aws_rhel_ami }}"
+        instance_type: t2.small
+        monitoring: true
+        # persistent network device with stable external IP 3.228.126.27
+        network_interfaces: eni-004f5b4f714f3fda9
+        wait: true
+        instance_tags:
+          Name: cockpit-webhook
+          ServiceOwner: FrontDoorSST
+          ServiceName: FrontDoorCI
+          ServiceComponent: Webhook
+          ServicePhase: Prod
+          AppCode: ARR-001
+      register: ec2
+
+    - name: Add new instance to host group
+      add_host:
+        hostname: "{{ item.dns_name }}"
+        groupname: launched
+      loop: "{{ ec2.instances }}"
+
+    - name: Wait for SSH to come up
+      wait_for_connection:
+      delegate_to: "{{ item.dns_name }}"
+      loop: "{{ ec2.instances }}"
+
+- name: Configure instances
+  hosts: launched
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Set host name
+      hostname:
+        name: aws-webhook

--- a/ansible/cockpituous/webhook.yml
+++ b/ansible/cockpituous/webhook.yml
@@ -1,0 +1,48 @@
+---
+- hosts: tag_ServiceComponent_Webhook
+  gather_facts: false
+
+  tasks:
+  - name: Upload RabbitMQ k8s resource
+    copy:
+      src: "{{ playbook_dir }}/../../tasks/cockpit-tasks-webhook.yaml"
+      dest: /run/cockpit-tasks-webhook.yaml
+      mode: preserve
+
+  # keep this in sync with tasks/run-local.sh
+  - name: Generate flat files from RabbitMQ config map
+    shell: |
+      rm -r /etc/rabbitmq
+      mkdir -p /etc/rabbitmq
+      python3 - <<EOF
+      import os.path
+      import yaml
+      with open("/run/cockpit-tasks-webhook.yaml") as f:
+          y = yaml.load(f)
+      files = [item for item in y["items"] if item["metadata"]["name"] == "amqp-config"][0]["data"]
+      for name, contents in files.items():
+          with open(os.path.join('/etc/rabbitmq', name), 'w') as f:
+              f.write(contents)
+      EOF
+
+  - name: Clean up existing pod
+    shell: |
+      podman pod rm -f cockpituous || true
+
+  # FIXME: wrap into systemd to survive reboots, convert to YAML resource
+  - name: Launch pod with RabbitMQ
+    shell: |
+      podman run -d --rm --name cockpituous-rabbitmq --pod=new:cockpituous \
+          --publish 5671:5671 --publish 80:8080 \
+          --tmpfs /var/lib/rabbitmq \
+          -v /etc/rabbitmq:/etc/rabbitmq:ro,z \
+          -v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
+          quay.io/cockpit/rabbitmq-server
+
+  - name: Launch webhook container in pod
+    shell: |
+      podman run -d --rm --name cockpituous-webhook --pod=cockpituous \
+          -e AMQP_SERVER=localhost:5671 \
+          -v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
+          quay.io/cockpit/tasks webhook
+

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -187,7 +187,7 @@ for more information.
 ## Set up bot as collaborator
 
  * On your project's "Settings → Manage Access" page, invite the [cockpituous user](https://github.com/cockpituous) as a collaborator.
- * Once you see the "Pending invite", in the list, the clipboard symbol copies the corresponding `/invitations` URL to the clipboard. Send that to Martin Pitt (`pitti` in `#cockpit` on FreeNode IRC) or Marius Vollmer (`mvollmer` on IRC), who will log into GitHub as `cockpituous` user and accept the invite.
+ * Once you see the "Pending invite", in the list, the clipboard symbol copies the corresponding `/invitations` URL to the clipboard. Send that to Martin Pitt (`pitti` in `#cockpit` on [libera.chat IRC](https://libera.chat/)) or Marius Vollmer (`mvollmer` on IRC), who will log into GitHub as `cockpituous` user and accept the invite.
 
 ## Set up automatic test triggering
 

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -72,7 +72,7 @@ for i in $(seq 1 30); do
     cd "$BOTS_DIR"
 
     # run-queue fails on empty queues; don't poll too often
-    timeout 12h ./run-queue --amqp "$AMQP_SERVER" || slumber
+    timeout 12h ./run-queue ${AMQP_SERVER:+--amqp} ${AMQP_SERVER:-} || slumber
     # clean up after tests, in particular large qcow overlays
     rm -rf /tmp/* || true
 done

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -20,8 +20,6 @@ spec:
           value: '5'
         - name: TEST_PUBLISH
           value: sink-local-4
-        - name: AMQP_SERVER
-          value: 'amqp.frontdoor.svc:5671'
         - name: RUN_STATISTICS_QUEUE
           value: '1'
         volumeMounts:

--- a/tasks/cockpit-tasks-psi.yaml
+++ b/tasks/cockpit-tasks-psi.yaml
@@ -20,8 +20,6 @@ spec:
           value: '5'
         - name: TEST_PUBLISH
           value: sink
-        - name: AMQP_SERVER
-          value: 'amqp-cockpit.apps.ci.centos.org:443'
         volumeMounts:
         - name: secrets
           mountPath: "/secrets"

--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -40,9 +40,6 @@ items:
             - name: webhook-secrets
               mountPath: /run/secrets/webhook
               readOnly: true
-            env:
-            - name: AMQP_SERVER
-              value: 'amqp.frontdoor.svc:5671'
         volumes:
         - name: webhook-secrets
           secret:

--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -41,8 +41,6 @@ items:
               mountPath: /run/secrets/webhook
               readOnly: true
             env:
-            - name: RELEASE_SINK
-              value: sink-local-4
             - name: AMQP_SERVER
               value: 'amqp.frontdoor.svc:5671'
         volumes:

--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -51,4 +51,4 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
-subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous-images,DNS:*.compute-1.amazonaws.com
+subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous-images,DNS:*.compute-1.amazonaws.com,DNS:localhost

--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -51,4 +51,4 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
-subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous-images
+subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous-images,DNS:*.compute-1.amazonaws.com

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -57,7 +57,7 @@ TimeoutStartSec=10min
 ExecStartPre=-$RUNC rm -f cockpit-tasks-%i
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull $RUNC pull quay.io/cockpit/tasks
 $NETWORK_SETUP
-ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=24g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} --env=AMQP_SERVER=amqp-frontdoor.apps.ocp.ci.centos.org:443 quay.io/cockpit/tasks
+ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK --storage-opt size=50G --memory=24g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} quay.io/cockpit/tasks
 ExecStop=$RUNC rm -f cockpit-tasks-%i
 $NETWORK_TEARDOWN
 

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -19,7 +19,6 @@ logging.getLogger("pika").propagate = False
 
 HOME_DIR = '/tmp/home'
 WEBHOOK_SECRETS = '/run/secrets/webhook'
-SINK = os.getenv('RELEASE_SINK', 'sink-local')
 AMQP_SERVER = os.getenv('AMQP_SERVER', 'amqp.frontdoor.svc:5671')
 COCKPIT_BOTS_REPO = os.getenv('COCKPIT_BOTS_REPO', 'https://github.com/cockpit-project/bots')
 COCKPIT_BOTS_BRANCH = os.getenv('COCKPIT_BOTS_BRANCH', 'master')

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -19,7 +19,7 @@ logging.getLogger("pika").propagate = False
 
 HOME_DIR = '/tmp/home'
 WEBHOOK_SECRETS = '/run/secrets/webhook'
-AMQP_SERVER = os.getenv('AMQP_SERVER', 'amqp.frontdoor.svc:5671')
+AMQP_SERVER = None  # initialized in setup()
 COCKPIT_BOTS_REPO = os.getenv('COCKPIT_BOTS_REPO', 'https://github.com/cockpit-project/bots')
 COCKPIT_BOTS_BRANCH = os.getenv('COCKPIT_BOTS_BRANCH', 'master')
 BOTS_CHECKOUT = HOME_DIR + '/bots'
@@ -35,6 +35,7 @@ fi
 
 def setup():
     '''Prepare temporary home directory from secrets'''
+    global AMQP_SERVER
 
     if os.path.isdir(HOME_DIR):
         return
@@ -57,6 +58,9 @@ def setup():
 
     ensure_bots_checkout()
     from lib import testmap
+    from task.distributed_queue import DEFAULT_AMQP_SERVER
+    AMQP_SERVER = os.getenv('AMQP_SERVER', DEFAULT_AMQP_SERVER)
+
     for project in testmap.projects():
         subprocess.check_call([os.path.join(BOTS_CHECKOUT, 'tests-scan'), '--amqp',
                                AMQP_SERVER, '--repo', project],

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -48,6 +48,8 @@ def setup():
         if f.startswith('..'):
             continue  # secrets volume internal files
         src = os.path.join(WEBHOOK_SECRETS, f)
+        if os.path.isdir(src):
+            continue  # happens with real directory instead of k8s secrets volumes
         dest = os.path.join(HOME_DIR, f.replace('--', '/'))
         os.makedirs(os.path.dirname(dest), exist_ok=True)
         shutil.copyfile(src, dest)


### PR DESCRIPTION
Normally our webhook runs on CentOS CI, but that is a single point of failure. Add an AWS deployment as a fallback.
    
This is not very robust nor elegant yet, but good enough as initial emergency fallback.

 - [x] rebuild tasks container to pick up webhook script fix: [log](https://github.com/cockpit-project/cockpituous/actions/runs/920932801)
 - [x] deploy
 - [x] update AMQP server URL in bots: https://github.com/cockpit-project/bots/pull/2094
 - [x] adjust cockpit's webhook URL in GitHub from http://webhook-frontdoor.apps.ocp.ci.centos.org/tools/cockpituous-release to http://ec2-3-228-126-27.compute-1.amazonaws.com/ (the release path is not relevant any more)
 - [x] drop hardcoding of AMQP server in tasks containers
 - [x] adjust all other project webhook URLs
 - [x] fix setup of github-webhook-token, that's only in the dir, not wrapped in a `dir--name` plain file
 - [x] re-deploy webhook to make sure it now works without manual hacks
