### PR TITLE
tasks: Kill libvirtd in between iterations

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -71,6 +71,10 @@ for i in $(seq 1 30); do
     update_bots
     cd "$BOTS_DIR"
 
+    # avoid stale state and sockets
+    virsh list --id --all | xargs --no-run-if-empty virsh destroy
+    pkill libvirtd || true
+
     # run-queue fails on empty queues; don't poll too often
     timeout 12h ./run-queue ${AMQP_SERVER:+--amqp} ${AMQP_SERVER:-} || slumber
     # clean up after tests, in particular large qcow overlays


### PR DESCRIPTION
Also ensure that there are no leftover VMs.

This may help with

    Failed to connect socket to '/work/.cache/libvirt/libvirt-sock'

errors which have plagued us for a while. Normally libvirtd removes the
socket right before it times out, but either there is a race condition
which we hit often, or something removes stuff in ~/.cache/libvirtd/.

----

This is totally a shot into the dark, to fix failures [like this](https://logs.cockpit-project.org/logs/pull-15934-20210611-093034-a98e957e-fedora-34/log.html).