### PR TITLE
workflows: Use default GitHub token for pushing to ghcr.io

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,12 +6,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
       - name: Log into container registry
-        run: podman login -u cockpituous -p ${{ secrets.COCKPITUOUS_GHCR_TOKEN }} ghcr.io
+        run: podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: Build release container
         run: make release-container


### PR DESCRIPTION
This is now possible with the recently introduced fine-grained
permissions:
https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions

----

I triggered a [container refresh](https://github.com/cockpit-project/cockpituous/actions/runs/1003193308) on that branch. It succeeded and [pushed a new tag to the registry](https://github.com/cockpit-project/cockpituous/pkgs/container/release).

Once this PR and https://github.com/cockpit-project/cockpit/pull/16051 both land, I'll delete `COCKPITUOUS_GHCR_TOKEN` from our org secrets and the secrets repo.