### PR TITLE
remove sedery from release-srpm

### DIFF
--- a/release/release-srpm
+++ b/release/release-srpm
@@ -62,13 +62,6 @@ dash_bullets()
             -e 's/^[^ *-]/- /'
 }
 
-# Trim tag message on stdio
-trim_tag()
-{
-    # Remove line with just tag name. Remove signature
-    sed -e '/^\s*'$TAG'\s*$/d' -e '/-----BEGIN/,/-----END/d'
-}
-
 # Format a date for a changelog
 #  $1: The date to format
 changelog_date()
@@ -95,7 +88,7 @@ tagdate=%(taggerdate:short)
 tagauthor=%(taggername)
 tagemail=%(taggeremail)' "refs/tags/$1")
         tagdate="$(changelog_date $tagdate)"
-        tagbody="$(git for-each-ref --format='%(contents)' "refs/tags/$1" | trim_tag | dash_bullets)"
+        tagbody="$(git for-each-ref --format='%(contents:body)' "refs/tags/$1" | dash_bullets)"
     fi
 
     if [ -z "$tagdate" ]; then

--- a/release/release-srpm
+++ b/release/release-srpm
@@ -55,13 +55,6 @@ message()
     echo "release-srpm: $@" >&2
 }
 
-dash_bullets()
-{
-        sed -e 's/^\* /- /' \
-            -e 's/^ \* /- /' \
-            -e 's/^[^ *-]/- /'
-}
-
 # Format a date for a changelog
 #  $1: The date to format
 changelog_date()
@@ -88,7 +81,7 @@ tagdate=%(taggerdate:short)
 tagauthor=%(taggername)
 tagemail=%(taggeremail)' "refs/tags/$1")
         tagdate="$(changelog_date $tagdate)"
-        tagbody="$(git for-each-ref --format='%(contents:body)' "refs/tags/$1" | dash_bullets)"
+        tagbody="$(git for-each-ref --format='%(contents:body)' "refs/tags/$1")"
     fi
 
     if [ -z "$tagdate" ]; then
@@ -102,6 +95,12 @@ tagemail=%(taggeremail)' "refs/tags/$1")
 
     if [ -z "$tagbody" ]; then
         tagbody="- Update to upstream $TAG release"
+    fi
+
+    # ensure that the body only contains point form
+    if printf "%s\n" "$tagbody" | grep -v '^- ' >&2; then
+        echo '*** tag body not in point form (see above)' >&2
+        exit 1
     fi
 
     printf "* %s %s %s - %s-%s\n" "$tagdate" "$tagauthor" "$tagemail" "$1" "$2"


### PR DESCRIPTION
This bit us on the latest cockpit-ostree release.  Make two changes:

 - use git (not sed) to strip the parts of the tag we don't care about
 - use grep to force the correct format, instead of using sed to attempt to "fix" things

 - [x] rebuild release container: https://github.com/cockpit-project/cockpituous/actions/runs/1004887412
 - [x] test cockpit-ostree release 186.1 with bogus tag body: https://github.com/cockpit-project/cockpit-ostree/actions/runs/1004908828