### PR TITLE
images: Fix GitHub token symlink

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -23,7 +23,7 @@ ADD https://raw.githubusercontent.com/cockpit-project/cockpituous/main/sink/sink
 
 RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user && \
     mkdir -p /home/user/.ssh && ln -sf /secrets/id_rsa.pub /home/user/.ssh/authorized_keys && \
-    mkdir -p /home/user/.config && ln -sf /run/secrets/webhook/.config/github-token /home/user/.config/github-token && \
+    mkdir -p /home/user/.config && ln -sf /run/secrets/webhook/.config--github-token /home/user/.config/github-token && \
     ln -sf /run/config/sink /home/user/.config/sink && \
     ssh-keygen -A && \
     chmod -R ga+r /etc/ssh /home/user && \

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -178,6 +178,9 @@ podman exec -i cockpituous-tasks sh -exc '
     grep -q "^world" /cache/images/hello.txt
     '
 
+# validate that sink has the GitHub token to do status updates
+podman exec -i cockpituous-images cat /home/user/.config/github-token | grep -q ^0123abc
+
 # if we have a PR number, run a unit test inside local deployment, and update PR status
 if [ -n "$PR" ]; then
     # need to use real GitHub token for this


### PR DESCRIPTION
Fix the ~user/.config/github-token symlink to point to the correct
Kubernetes secret encoded file name, exactly like tasks/Dockerfile does.
Since a recent cleanup of our secrets,
secret_volume/.config/github-token has not existed any more. This
broke direct image uploads from tasks containers (which got hidden by
the images also uploading to S3), and sink status credentials (which got
hidden by tasks bots sending the token as part of the request, until
[1]).

Add a test to ensure that the images/sink container has a working token.

[1] https://github.com/cockpit-project/bots/pull/2186

----

[Image container rebuild](https://github.com/cockpit-project/cockpituous/actions/runs/1008311700)