### PR TITLE
workflows: Run quay.io image builds in quay.io environment

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: quay.io
     timeout-minutes: 30
     steps:
       - name: Clone repository

--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: quay.io
     timeout-minutes: 30
     steps:
       - name: Clone repository


### PR DESCRIPTION
These two workflows are now the only users of the quay.io robot token,
so it got moved from the cockpit-project org to a new cockpituous
"quay.io" environment.

 - [x] Refresh images container to prove that it works: [workflow run](https://github.com/cockpit-project/cockpituous/actions/runs/1010772202): [updated container is on quay.io](https://quay.io/repository/cockpit/images?tab=tags)

----

I sent a corresponding PR to ci-secrets.git (internal) to move the secret into the github/env/ dir.