### PR TITLE
workflows: Run deployment tests with default GitHub token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,10 @@ jobs:
 
   tasks:
     runs-on: ubuntu-20.04
+    permissions:
+      # enough permissions for tests-scan to work
+      pull-requests: read
+      statuses: write
     timeout-minutes: 30
     steps:
       - name: Clone repository
@@ -53,6 +57,6 @@ jobs:
 
       - name: Test local deployment
         run: |
-          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
           PRN=$(echo "$GITHUB_REF" | cut -f3 -d '/')
           sudo tasks/run-local.sh -p $PRN -t ~/.config/github-token


### PR DESCRIPTION
This avoids another usage of our cockpituous token.

---

 - [x] blocked on https://github.com/cockpit-project/bots/pull/2194
 
I am not sure if we even want that -- it's kinda sorta a validation that our cockpituous token works and has the required privileges. But then again, we usually don't run a cockpituous PR test when we change the token (we usually learn about it because our tests explode :boom: ). So for now this is more of a "let's see if this even works" exercise.

If this works and we want it, I'll do the same to bots -- this test run is the only usage of the cockpituous token by cockpituous.git and bots.git, so it'll make it easier to move this into an environment.