### PR TITLE
metrics: Automate remaining Grafana setup steps

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -21,13 +21,10 @@ regularly read these metrics and store them in a database, and [Grafana](https:/
 
    After that, Grafana should be available at https://grafana-frontdoor.apps.ocp.ci.centos.org and show the Cockpit CI dashboard at https://grafana-frontdoor.apps.ocp.ci.centos.org/d/ci/cockpit-ci
 
-## Configuration
-
-These steps are not automated yet, but should be at some point:
-
- - On Grafana, choose "Sign in" from the left menu bar at the bottom, log in as `admin` with the initial password "admin", and immediately change it to the password mentioned in the [internal CI secrets repository](https://gitlab.cee.redhat.com/front-door-ci-wranglers/ci-secrets/-/blob/master/cockpituous.txt). Then sign out again.
 
 ## Dashboard maintenance
+
+You can log into Grafana with "Sign in" from the left menu bar at the bottom, as user `admin`. The password is in the [internal CI secrets repository](https://gitlab.cee.redhat.com/front-door-ci-wranglers/ci-secrets/-/blob/master/metrics/grafana-admin).
 
 The metrics are meant to implement and measure our [Service Level objectives](https://github.com/cockpit-project/cockpit/wiki/DevelopmentPrinciples#our-testsci-error-budget). They are not complete yet.
 

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -15,24 +15,17 @@ regularly read these metrics and store them in a database, and [Grafana](https:/
    Once this gets bound, it is ready to use. If that does not happen
    automatically, file a support ticket like [#341](https://pagure.io/centos-infra/issue/341).
 
- - Whenever the YAML resources change, first clean up all old resources and re-deploy everything:
+ - Whenever the YAML resources or the dashboards change, this script cleans up all old resources and re-deploys everything:
 
-       oc delete -f metrics.yaml
-       oc create -f metrics.yaml
+       metrics/deploy.sh
 
-   After that, Grafana should be available at https://grafana-frontdoor.apps.ocp.ci.centos.org
+   After that, Grafana should be available at https://grafana-frontdoor.apps.ocp.ci.centos.org and show the Cockpit CI dashboard at https://grafana-frontdoor.apps.ocp.ci.centos.org/d/ci/cockpit-ci
 
 ## Configuration
 
 These steps are not automated yet, but should be at some point:
 
- - On Grafana, choose "Sign in" from the left menu bar at the bottom, log in as `admin` with the initial password "admin", and immediately change it to the password mentioned in the [internal CI secrets repository](https://gitlab.cee.redhat.com/front-door-ci-wranglers/ci-secrets/-/blob/master/cockpituous.txt).
-
- - On Dashboards → Manage, click "Import", paste in the contents of [cockpit-ci.json](./cockpit-ci.json) (e.g. with `wl-copy < metrics/cockpit-ci.json` under Wayland) and confirm the loading.
-
- - Sign out again.
-
- - Confirm that https://grafana-frontdoor.apps.ocp.ci.centos.org/d/ci/cockpit-ci exists and shows the metrics.
+ - On Grafana, choose "Sign in" from the left menu bar at the bottom, log in as `admin` with the initial password "admin", and immediately change it to the password mentioned in the [internal CI secrets repository](https://gitlab.cee.redhat.com/front-door-ci-wranglers/ci-secrets/-/blob/master/cockpituous.txt). Then sign out again.
 
 ## Dashboard maintenance
 

--- a/metrics/deploy.sh
+++ b/metrics/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Generate/Update grafana-dashboards ConfigMap for the default dashboards, and (re)deploy Prometheus/Grafana
+set -eux
+MYDIR=$(realpath -m "$0"/..)
+
+# clean up old deployment
+kubectl delete configmap/grafana-dashboards || true
+kubectl delete -f $MYDIR/metrics.yaml || true
+
+kubectl create configmap grafana-dashboards --from-file $MYDIR/cockpit-ci.json
+kubectl create -f $MYDIR/metrics.yaml

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -45,8 +45,14 @@ items:
             - name: grafana-config
               mountPath: /grafana-config
               readOnly: true
-            - name: grafana-datasources
+            - name: grafana-provisioning-datasources
               mountPath: /etc/grafana/provisioning/datasources
+              readOnly: true
+            - name: grafana-provisioning-dashboards
+              mountPath: /etc/grafana/provisioning/dashboards
+              readOnly: true
+            - name: grafana-dashboards
+              mountPath: /dashboards
               readOnly: true
 
           volumes:
@@ -60,9 +66,16 @@ items:
             - name: grafana-config
               configMap:
                 name: grafana-config
-            - name: grafana-datasources
+            - name: grafana-provisioning-datasources
               configMap:
-                name: grafana-datasources
+                name: grafana-provisioning-datasources
+            - name: grafana-provisioning-dashboards
+              configMap:
+                name: grafana-provisioning-dashboards
+            - name: grafana-dashboards
+              configMap:
+                # this is not defined here, but gets built from *.json files in ./deploy.sh
+                name: grafana-dashboards
 
   - kind: ConfigMap
     apiVersion: v1
@@ -92,7 +105,7 @@ items:
   - kind: ConfigMap
     apiVersion: v1
     metadata:
-      name: grafana-datasources
+      name: grafana-provisioning-datasources
     data:
       datasource.yaml: |
         apiVersion: 1
@@ -103,6 +116,18 @@ items:
           isDefault: true
           access: proxy
           editable: true
+
+  - kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: grafana-provisioning-dashboards
+    data:
+      all.yaml: |
+        apiVersion: 1
+        providers:
+        - name: default
+          options:
+            path: /dashboards/
 
   - kind: ConfigMap
     apiVersion: v1

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -37,6 +37,11 @@ items:
               value: /grafana-config/grafana.ini
             - name: GF_PATHS_PROVISIONING
               value: /etc/grafana/provisioning
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: metrics-secrets
+                  key: grafana-admin
             ports:
             - containerPort: 3000
               protocol: TCP

--- a/tasks/build-secrets
+++ b/tasks/build-secrets
@@ -38,3 +38,16 @@ cd "$BASE/webhook"
 for f in $(find -type f -o -type l); do
     printf '    %s: %s\n' "$(echo $f | sed 's!^./!!; s!/!--!g')" "$(base64 --wrap=0 $f)"
 done
+
+# metrics secrets
+cat <<EOF
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: metrics-secrets
+  data:
+EOF
+cd "$BASE/metrics"
+for f in $(find -type f -o -type l); do
+    printf '    %s: %s\n' "$(echo -e $f | sed 's!^./!!; s!/!--!g')" "$(tr -d '\n' < $f | base64 --wrap=0)"
+done


### PR DESCRIPTION
See individual commits. This morning was the second time when our https://grafana-frontdoor.apps.ocp.ci.centos.org/d/ci/cockpit-ci dashboard went AWOL and the admin user was reset to the default password. Now the whole deployment is automated.

I already rolled this out, and adjusted the secrets in the internal dir.