### PR TITLE
metrics: Use light Grafana theme by default

### DIFF
--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -142,6 +142,8 @@ items:
       grafana.ini: |
         [auth.anonymous]
         enabled = true
+        [users]
+        default_theme = light
 
   - kind: Service
     apiVersion: v1


### PR DESCRIPTION
This provides much better contrast, in particular it makes warning
thresholds easier to see.

---

Already rolled out, as usual. Before I just changed that in the admin web UI.