### PR TITLE
tasks: Increase RabbitMQ ACK timeout

### DIFF
--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -148,3 +148,4 @@ items:
         auth_mechanisms.1 = EXTERNAL
         ssl_cert_login_from = common_name
         management.load_definitions = /etc/rabbitmq/definitions.json
+        consumer_timeout = 9000000


### PR DESCRIPTION
The default is 30 minutes, which is too short for most of our tests.
Increase it to 2.5 hours, which is our 2 hour global test timeout plus
some extra setup/teardown. This does not need to be particularly tight,
as broken bots will be considered dead quickly due to missing
heartbeats.

See https://www.rabbitmq.com/consumers.html#acknowledgement-timeout

-----

This will hopefully address the many "duplicate test runs" problem that we've seen for some time. [latest example](https://logs.cockpit-project.org/logs/pull-16117-20210719-165231-8be6c386-rhel-9-0/)

 - [x]  check on Wednesday (Jul 21) if there are any further duplicates.

This is how to find them on our AWS sink:

    find /var/cache/cockpit-tasks/images/logs/pull*20210720* -name backup*

(adjust or losen the date fnmatch accordingly)

I rolled this out, let's check if that really fixes it before landing.

In the previous instance we got tons of errors:

    operation none caused a channel exception precondition_failed: consumer ack timed out on channel 1

So the timeout is definitively involved. I did not see any errors about heartbeats, and their default 60s feels okay.  So also check this:

    oc logs -c amqp webhook-7jlf7