### PR TITLE
ansible: Reboot e2e machines in reset-docker.yml

### DIFF
--- a/ansible/maintenance/reset-docker.yml
+++ b/ansible/maintenance/reset-docker.yml
@@ -16,5 +16,6 @@
       rm -rf /var/lib/docker
       docker-storage-setup
       systemctl start docker
-      systemctl start --all 'cockpit-tasks@*'
-      systemctl start cockpit-images || true
+
+  - name: Reboot machines
+    reboot:


### PR DESCRIPTION
In all cases so far I actually want to reboot the e2e machines, instead
of restarting the bots right away. This cleans piled up cruft in the
kernel/kvm which tends to cause funny effects/breakage in docker over
time.