### PR TITLE
tasks-local.sh: Split into functions, add interactive mode

### DIFF
--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -4,30 +4,6 @@
 # similar for "$IMAGES_TAG" for images/sink
 set -eu
 
-PR=
-PR_REPO=cockpit-project/cockpituous
-TOKEN=
-
-while getopts "hs:t:p:r:" opt; do
-    case $opt in
-        h)
-            echo '-p run unit tests in the local deployment against a real PR'
-            echo "-r run unit tests in the local deployment against an owner/repo other than $PR_REPO"
-            echo '-t supply a token which will be copied into the webhook secrets'
-            exit 0
-            ;;
-        p) PR="$OPTARG" ;;
-        r) PR_REPO="$OPTARG" ;;
-        t)
-            if [ ! -e "$OPTARG" ]; then
-                echo $OPTARG does not exist
-                exit 1
-            fi
-            TOKEN="$OPTARG"
-            ;;
-        esac
-done
-
 MYDIR=$(realpath $(dirname $0))
 ROOTDIR=$(dirname $MYDIR)
 DATADIR=$ROOTDIR/local-data
@@ -36,14 +12,41 @@ SECRETS=$DATADIR/secrets
 IMAGES=$DATADIR/images
 IMAGE_PORT=${IMAGE_PORT:-8080}
 
-trap "podman pod rm -f cockpituous" EXIT INT QUIT PIPE
+# CLI option defaults/values
+PR=
+PR_REPO=cockpit-project/cockpituous
+TOKEN=
 
-# clean up data dir from previous round
-rm -rf "$DATADIR"
+parse_options() {
+    while getopts "hs:t:p:r:" opt "$@"; do
+        case $opt in
+            h)
+                echo '-p run unit tests in the local deployment against a real PR'
+                echo "-r run unit tests in the local deployment against an owner/repo other than $PR_REPO"
+                echo '-t supply a token which will be copied into the webhook secrets'
+                exit 0
+                ;;
+            p) PR="$OPTARG" ;;
+            r) PR_REPO="$OPTARG" ;;
+            t)
+                if [ ! -e "$OPTARG" ]; then
+                    echo $OPTARG does not exist
+                    exit 1
+                fi
+                TOKEN="$OPTARG"
+                ;;
+            esac
+    done
+}
 
-# generate flat files from RabbitMQ config map
-mkdir -p $RABBITMQ_CONFIG
-python3 - <<EOF
+# initialize DATADIR and config files
+setup_config() {
+    # clean up data dir from previous round
+    rm -rf "$DATADIR"
+
+    # generate flat files from RabbitMQ config map
+    mkdir -p $RABBITMQ_CONFIG
+    python3 - <<EOF
 import os.path
 import yaml
 
@@ -55,32 +58,32 @@ for name, contents in files.items():
         f.write(contents)
 print(files)
 EOF
-# need to make files world-readable, as rabbitmq container runs as different user
-chmod -R go+rX "$RABBITMQ_CONFIG"
+    # need to make files world-readable, as rabbitmq container runs as different user
+    chmod -R go+rX "$RABBITMQ_CONFIG"
 
-# generate secrets, unless they are already present in the source tree
-if [ -e "$MYDIR/credentials/webhook/amqp-client.key" ]; then
-    SECRETS="$MYDIR/credentials"
-else
-    (mkdir -p "$SECRETS"
-     cd "$SECRETS"
-     $MYDIR/credentials/generate-ca.sh
-     (mkdir -p webhook; cd webhook; $MYDIR/credentials/webhook/generate.sh)
-     (mkdir -p tasks; cd tasks; $ROOTDIR/images/generate-image-certs.sh)
+    # generate secrets, unless they are already present in the source tree
+    if [ -e "$MYDIR/credentials/webhook/amqp-client.key" ]; then
+        SECRETS="$MYDIR/credentials"
+    else
+        (mkdir -p "$SECRETS"
+        cd "$SECRETS"
+        $MYDIR/credentials/generate-ca.sh
+        (mkdir -p webhook; cd webhook; $MYDIR/credentials/webhook/generate.sh)
+        (mkdir -p tasks; cd tasks; $ROOTDIR/images/generate-image-certs.sh)
 
-    # dummy token, for image-upload
-    echo 0123abc > "$SECRETS"/webhook/.config--github-token
-    echo 'user:$apr1$FzL9bivD$AzG7R8RNjuR.9DQRUrV.k.' > "$SECRETS"/tasks/htpasswd
+        # dummy token, for image-upload
+        echo 0123abc > "$SECRETS"/webhook/.config--github-token
+        echo 'user:$apr1$FzL9bivD$AzG7R8RNjuR.9DQRUrV.k.' > "$SECRETS"/tasks/htpasswd
 
-    # dummy S3 keys in OpenShift tasks/build-secrets encoding, for testing their setup
-    mkdir tasks/..data
-    echo 'id12 geheim' > tasks/..data/s3-keys--r1.cloud.com
-    echo 'id34 shhht' > tasks/..data/s3-keys--r2.cloud.com
-    ln -s ..data/s3-keys--r1.cloud.com tasks/s3-keys--r1.cloud.com
-    ln -s ..data/s3-keys--r2.cloud.com tasks/s3-keys--r2.cloud.com
+        # dummy S3 keys in OpenShift tasks/build-secrets encoding, for testing their setup
+        mkdir tasks/..data
+        echo 'id12 geheim' > tasks/..data/s3-keys--r1.cloud.com
+        echo 'id34 shhht' > tasks/..data/s3-keys--r2.cloud.com
+        ln -s ..data/s3-keys--r1.cloud.com tasks/s3-keys--r1.cloud.com
+        ln -s ..data/s3-keys--r2.cloud.com tasks/s3-keys--r2.cloud.com
 
-     ssh-keygen -f tasks/id_rsa -P ''
-     cat <<EOF > tasks/ssh-config
+        ssh-keygen -f tasks/id_rsa -P ''
+        cat <<EOF > tasks/ssh-config
 Host sink-local
     Hostname cockpituous-images
     User user
@@ -91,98 +94,109 @@ Host sink-local
     StrictHostKeyChecking no
     CheckHostIP no
 EOF
-    )
+        )
 
-    # need to make files world-readable, as containers run as different user
-    chmod -R go+rX "$SECRETS"
-fi
+        # need to make files world-readable, as containers run as different user
+        chmod -R go+rX "$SECRETS"
+    fi
+}
 
-# start podman and run RabbitMQ in the background
-# HACK: put data into a tmpfs instead of anonymous volume, see https://github.com/containers/podman/issues/9432
-podman run -d --name cockpituous-rabbitmq --pod=new:cockpituous \
-    --publish $IMAGE_PORT:8080 \
-    --tmpfs /var/lib/rabbitmq \
-    -v "$RABBITMQ_CONFIG":/etc/rabbitmq:ro,z \
-    -v "$SECRETS"/webhook:/run/secrets/webhook:ro,z \
-    quay.io/cockpit/rabbitmq-server
+launch_containers() {
+    trap "podman pod rm -f cockpituous" EXIT INT QUIT PIPE
 
-# start image+sink in the background; see sink/sink-centosci.yaml
-mkdir -p "$IMAGES"
-chmod -R go+w "$IMAGES"  # allow unprivileged sink container to write
-SINK_CONFIG="$DATADIR/sink.cfg"
-cat <<EOF > "$SINK_CONFIG"
+    # start podman and run RabbitMQ in the background
+    # HACK: put data into a tmpfs instead of anonymous volume, see https://github.com/containers/podman/issues/9432
+    podman run -d --name cockpituous-rabbitmq --pod=new:cockpituous \
+        --publish $IMAGE_PORT:8080 \
+        --tmpfs /var/lib/rabbitmq \
+        -v "$RABBITMQ_CONFIG":/etc/rabbitmq:ro,z \
+        -v "$SECRETS"/webhook:/run/secrets/webhook:ro,z \
+        quay.io/cockpit/rabbitmq-server
+
+    # start image+sink in the background; see sink/sink-centosci.yaml
+    mkdir -p "$IMAGES"
+    chmod -R go+w "$IMAGES"  # allow unprivileged sink container to write
+    SINK_CONFIG="$DATADIR/sink.cfg"
+    cat <<EOF > "$SINK_CONFIG"
 [Sink]
 Url: http://localhost:$IMAGE_PORT/logs/%(identifier)s/
 Logs: /cache/images/logs
 PruneInterval: 0.5
 EOF
-podman run -d --name cockpituous-images --pod=cockpituous --user user \
-    -v "$IMAGES":/cache/images:z \
-    -v "$SINK_CONFIG":/run/config/sink:ro,z \
-    -v "$SECRETS"/tasks:/secrets:ro,z \
-    -v "$SECRETS"/webhook:/run/secrets/webhook:ro,z \
-    quay.io/cockpit/images:${IMAGES_TAG:-latest} \
-    sh -ec '/usr/sbin/sshd -p 8022 -o StrictModes=no -E /dev/stderr; /usr/sbin/nginx -g "daemon off;"'
+    podman run -d --name cockpituous-images --pod=cockpituous --user user \
+        -v "$IMAGES":/cache/images:z \
+        -v "$SINK_CONFIG":/run/config/sink:ro,z \
+        -v "$SECRETS"/tasks:/secrets:ro,z \
+        -v "$SECRETS"/webhook:/run/secrets/webhook:ro,z \
+        quay.io/cockpit/images:${IMAGES_TAG:-latest} \
+        sh -ec '/usr/sbin/sshd -p 8022 -o StrictModes=no -E /dev/stderr; /usr/sbin/nginx -g "daemon off;"'
 
-# wait until AMQP initialized
-sleep 5
-until podman exec -i cockpituous-rabbitmq timeout 5 rabbitmqctl list_queues; do
-    echo "waiting for RabbitMQ to come up..."
-    sleep 3
-done
-
-# Run tasks container in the backgroud
-podman run -d -it --name cockpituous-tasks --pod=cockpituous \
-    -v "$SECRETS"/tasks:/secrets:ro,z \
-    -v "$SECRETS"/webhook:/run/secrets/webhook:ro,z \
-    -e COCKPIT_CA_PEM=/run/secrets/webhook/ca.pem \
-    -e COCKPIT_BOTS_REPO=${COCKPIT_BOTS_REPO:-} \
-    -e COCKPIT_BOTS_BRANCH=${COCKPIT_BOTS_BRANCH:-} \
-    -e COCKPIT_TESTMAP_INJECT=main/unit-tests \
-    -e AMQP_SERVER=localhost:5671 \
-    -e TEST_PUBLISH=sink-local \
-    quay.io/cockpit/tasks:${TASKS_TAG:-latest}
-
-# Follow the output
-podman logs -f cockpituous-tasks &
-
-# test image upload (htpasswd credentials setup)
-podman exec -i cockpituous-tasks timeout 30 sh -ec '
-    # wait until tasks container has set up itself and checked out bots
-    until [ -f bots/tests-trigger ]; do echo "waiting for tasks to initialize"; sleep 5; done
-
-    for retry in $(seq 10); do
-        echo "waiting for image server to initialize"
-        curl --silent --fail --head --cacert $COCKPIT_CA_PEM https://cockpituous-images:8443 && break
-        sleep 5
+    # wait until AMQP initialized
+    sleep 5
+    until podman exec -i cockpituous-rabbitmq timeout 5 rabbitmqctl list_queues; do
+        echo "waiting for RabbitMQ to come up..."
+        sleep 3
     done
 
-    # test image-upload
-    cd bots
-    echo world  > /cache/images/hello.txt
-    ./image-upload --store https://cockpituous-images:8443 --state hello.txt
-    '
-test "$(cat "$IMAGES/hello.txt")" = "world"
+    # Run tasks container in the backgroud
+    podman run -d -it --name cockpituous-tasks --pod=cockpituous \
+        -v "$SECRETS"/tasks:/secrets:ro,z \
+        -v "$SECRETS"/webhook:/run/secrets/webhook:ro,z \
+        -e COCKPIT_CA_PEM=/run/secrets/webhook/ca.pem \
+        -e COCKPIT_BOTS_REPO=${COCKPIT_BOTS_REPO:-} \
+        -e COCKPIT_BOTS_BRANCH=${COCKPIT_BOTS_BRANCH:-} \
+        -e COCKPIT_TESTMAP_INJECT=main/unit-tests \
+        -e AMQP_SERVER=localhost:5671 \
+        -e TEST_PUBLISH=sink-local \
+        quay.io/cockpit/tasks:${TASKS_TAG:-latest}
+}
 
-# validate OpenShift s3 keys secrets setup
-R1=$(podman exec -i cockpituous-tasks sh -ec 'cat ~/.config/cockpit-dev/s3-keys/r1.cloud.com')
-test "$R1" = "id12 geheim"
-R2=$(podman exec -i cockpituous-tasks sh -ec 'cat ~/.config/cockpit-dev/s3-keys/r2.cloud.com')
-test "$R2" = "id34 shhht"
+cleanup_containers() {
+    # clean up dummy token, so that image-prune does not try to use it
+    rm "$SECRETS"/webhook/.config--github-token
 
-# validate image downloading
-podman exec -i cockpituous-tasks sh -exc '
-    rm /cache/images/hello.txt
-    cd bots
-    ./image-download --store https://cockpituous-images:8443 --state hello.txt
-    grep -q "^world" /cache/images/hello.txt
-    '
+    # tell the tasks container iteration that we are done
+    podman exec cockpituous-tasks kill -TERM 1
+}
 
-# validate that sink has the GitHub token to do status updates
-podman exec -i cockpituous-images cat /home/user/.config/github-token | grep -q ^0123abc
+test_image() {
+    # test image upload (htpasswd credentials setup)
+    podman exec -i cockpituous-tasks timeout 30 sh -ec '
+        # wait until tasks container has set up itself and checked out bots
+        until [ -f bots/tests-trigger ]; do echo "waiting for tasks to initialize"; sleep 5; done
 
-# if we have a PR number, run a unit test inside local deployment, and update PR status
-if [ -n "$PR" ]; then
+        for retry in $(seq 10); do
+            echo "waiting for image server to initialize"
+            curl --silent --fail --head --cacert $COCKPIT_CA_PEM https://cockpituous-images:8443 && break
+            sleep 5
+        done
+
+        # test image-upload
+        cd bots
+        echo world  > /cache/images/hello.txt
+        ./image-upload --store https://cockpituous-images:8443 --state hello.txt
+        '
+    test "$(cat "$IMAGES/hello.txt")" = "world"
+
+    # validate OpenShift s3 keys secrets setup
+    R1=$(podman exec -i cockpituous-tasks sh -ec 'cat ~/.config/cockpit-dev/s3-keys/r1.cloud.com')
+    test "$R1" = "id12 geheim"
+    R2=$(podman exec -i cockpituous-tasks sh -ec 'cat ~/.config/cockpit-dev/s3-keys/r2.cloud.com')
+    test "$R2" = "id34 shhht"
+
+    # validate image downloading
+    podman exec -i cockpituous-tasks sh -exc '
+        rm /cache/images/hello.txt
+        cd bots
+        ./image-download --store https://cockpituous-images:8443 --state hello.txt
+        grep -q "^world" /cache/images/hello.txt
+        '
+
+    # validate that sink has the GitHub token to do status updates
+    podman exec -i cockpituous-images cat /home/user/.config/github-token | grep -q ^0123abc
+}
+
+test_pr() {
     # need to use real GitHub token for this
     [ -z "$TOKEN" ] || cp -fv "$TOKEN" "$SECRETS"/webhook/.config--github-token
 
@@ -225,17 +239,32 @@ if [ -n "$PR" ]; then
         BOGUS_LOG=$(curl $RESULTS_DIR_URL/bogus.log)
         echo "$BOGUS_LOG" | grep -q 'heisenberg compensator'
     fi
-else
-    # clean up dummy token, so that image-prune does not try to use it
-    rm "$SECRETS"/webhook/.config--github-token
+}
 
+test_queue() {
     # tasks can connect to queue
     OUT=$(podman exec -i cockpituous-tasks bots/inspect-queue --amqp localhost:5671)
     echo "$OUT" | grep -q 'queue public is empty'
-fi
+}
 
-# tell the tasks container iteration that we are done
-podman exec cockpituous-tasks kill -TERM 1
+# 
+# main
+#
 
+parse_options "$@"
+setup_config
+launch_containers
+
+# Follow the output
+podman logs -f cockpituous-tasks &
+
+# tests which don't need GitHub interaction
+test_image
+test_queue
+
+# if we have a PR number, run a unit test inside local deployment, and update PR status
+[ -z "$PR" ] || test_pr
+
+cleanup_containers
 # bring logs -f to the foreground
 wait


### PR DESCRIPTION
This is some initial work to make it easier to work with a local deployment. The first commit is huge, but it's really just moving code around into functions -- I did not make any "fine-grained" changes other than passing `"$@"` to `getopts` (that's a technical necessity for moving it into a function).