### PR TITLE
release: Build a node-cache tarball in release-source

### DIFF
--- a/release/release-source
+++ b/release/release-source
@@ -101,13 +101,12 @@ prepare()
     else
         # plain Makefile projects
         $MAKE -C $repodir dist || $MAKE -C $repodir dist-gzip
-        archive=$(find $repodir -maxdepth 1 -name "*-${TAG}.tar.*")
-        if [ "$(echo "$archive" | wc -l)" != 1 ]; then
-            echo "ERROR: Expecting exactly one *-${TAG}.tar.*" >&2
-            exit 1
+        if grep -q '^node-cache:' Makefile; then
+            $MAKE -C $repodir node-cache
         fi
+        archive=$(find $repodir -maxdepth 1 -name "*-${TAG}.tar.*")
         find "$SOURCE" -maxdepth 1 -name "*-*.tar.*" -delete
-        cp "$archive" "$SOURCE"
+        cp $archive "$SOURCE"
     fi
     rm -rf $repodir
 }


### PR DESCRIPTION
If a (plain Makefile) project defines a `make node-cache` rule, then
call this during release-source. We will gradually add these to our
projects to fulfill Fedora's packaging policy.

Drop the requirement that there is exactly one tarball.

-----

I tested this with cockpit-certificates, see https://github.com/skobyda/cockpit-certificates/pull/65.

I also tested this with cockpit-podman (which does not have such a rule), and it correctly produces a single _release/source/cockpit-podman-34.tar.gz

 - [ ] rebuild container after landing