### PR TITLE
Two secrets fixes

### DIFF
--- a/ansible/roles/install-secrets-dir/tasks/main.yml
+++ b/ansible/roles/install-secrets-dir/tasks/main.yml
@@ -25,6 +25,7 @@
      dest: /var/lib/cockpit-secrets/
      owner: '1111'
      group: '1111'
+     mode: 'u=rwX,g=rX,o=rX'
      setype: container_file_t
 
  # otherwise ssh bitterly complains: Permissions 0644 for '/secrets/id_rsa' are too open

--- a/ansible/roles/install-secrets-openshift/tasks/main.yml
+++ b/ansible/roles/install-secrets-openshift/tasks/main.yml
@@ -3,15 +3,10 @@
    command: "{{ playbook_dir }}/../../tasks/build-secrets {{ lookup('env', 'XDG_RUNTIME_DIR') }}/ci-secrets"
    register: build_secrets
 
- - name: Delete old OpenShift secrets
+ - name: Update deployed secrets
    command:
-     cmd: "{{ oc_command }} delete --ignore-not-found=true -f -"
+     cmd: "{{ oc_command }} apply -f -"
      stdin: "{{ build_secrets.stdout }}"
 
- - name: Create new secrets
-   command:
-     cmd: "{{ oc_command }} create -f -"
-     stdin: "{{ build_secrets.stdout }}"
-
- - name: Restart all containers to pick up new secrets
-   shell: "{{ oc_command }} get -o name pods | xargs -l -r {{ oc_command }} delete --wait=false"
+- name: Restart all containers to pick up new secrets
+  shell: "{{ oc_command }} get -o name pods | xargs -l -r {{ oc_command }} delete --wait=false"


### PR DESCRIPTION
@marusak : I tried running sync-secrets from my machine, and ended up with correct permissions (644 instead of 664). So this is a shot into the dark -- at least with this fix the files have the same permissions as before.

I also added a nice little tweak for OpenShift secrets which I learned from @mh21 today, thanks!