### PR TITLE
tasks: Install nodejs-devel

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -27,6 +27,7 @@ RUN dnf -y update && \
         libXt \
         nc \
         net-tools \
+        nodejs-devel \
         npm \
         origin-clients \
         psmisc \


### PR DESCRIPTION
It is a required build dependency for JS packages as per
https://docs.fedoraproject.org/en-US/packaging-guidelines/Node.js/#_buildrequires

---

Seen in/blocks https://github.com/skobyda/cockpit-certificates/pull/66

 - [x] Rebuild container: https://github.com/cockpit-project/cockpituous/actions/runs/1244534303
 - [x] Deploy to CI
 - [x] Wait for successful c-certificates test: https://github.com/skobyda/cockpit-certificates/pull/66
 - [x] Adjust cockpit pixel tests for slightly different button rendering: https://github.com/cockpit-project/cockpit/pull/16363