### PR TITLE
tasks: Update to Fedora 35, downgrade Chromium to 93

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:35
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
 # HACK: chromium-headless 88 crashes with some keyDown commands: https://bugs.chromium.org/p/chromium/issues/detail?id=1170634

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,13 +1,14 @@
 FROM fedora:35
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
-# HACK: chromium-headless 88 crashes with some keyDown commands: https://bugs.chromium.org/p/chromium/issues/detail?id=1170634
-# install full chromium for the time being
+# HACK: chromium-headless 88 crashes with some keyDown commands: https://bugs.chromium.org/p/chromium/issues/detail?id=1170634, install full chromium for the time being
+# HACK: chromium 94 crashes left and right: https://bugzilla.redhat.com/show_bug.cgi?id=2013095, downgrade to 93
 RUN dnf -y update && \
     dnf -y install \
         'dnf-command(builddep)' \
         byobu \
-        chromium \
+        https://kojipkgs.fedoraproject.org//packages/chromium/93.0.4577.63/1.fc35/x86_64/chromium-common-93.0.4577.63-1.fc35.x86_64.rpm \
+        https://kojipkgs.fedoraproject.org//packages/chromium/93.0.4577.63/1.fc35/x86_64/chromium-headless-93.0.4577.63-1.fc35.x86_64.rpm \
         curl \
         dbus-glib \
         diffstat \


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2013095

I built this locally and created a toolbox out of this. This works quite fine for starter-kit, machines, and cockpit itself, so I think it's ready.

 - [x] https://github.com/cockpit-project/starter-kit/pull/501
 - [x] https://github.com/cockpit-project/cockpit-machines/pull/422
 - [x] https://github.com/cockpit-project/cockpit-podman/pull/794
 - [x] https://github.com/osbuild/cockpit-composer/pull/1366
 - [x] https://github.com/candlepin/subscription-manager/pull/2831
 - [x] https://github.com/cockpit-project/cockpit/pull/16451
 - [x] https://github.com/cockpit-project/cockpit/pull/16452
 - [x] https://github.com/cockpit-project/cockpit/pull/16457
 - [x] fix cockpit for npm 7: https://github.com/cockpit-project/cockpit/pull/16469
 - [x] https://github.com/cockpit-project/cockpit-ostree/pull/203