### PR TITLE
tasks: Use long tests-scan options

### DIFF
--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -213,8 +213,8 @@ test_pr() {
     cd bots;
     ./tests-scan -p $PR --amqp 'localhost:5671' --repo $PR_REPO;
     for retry in \$(seq 10); do
-        ./tests-scan --repo $PR_REPO -vd;
-        OUT=\$(./tests-scan --repo $PR_REPO -p $PR -dv);
+        ./tests-scan --repo $PR_REPO --human-readable --dry;
+        OUT=\$(./tests-scan --repo $PR_REPO -p $PR --human-readable --dry);
         [ \"\${OUT%unit-tests*}\" = \"\$OUT\" ] || break;
         echo waiting until the status is visible;
         sleep 10;


### PR DESCRIPTION
We want to rename `-d` to `-n` to be consistent with other scripts.
Also, long options are easier to read in scripts.

---

Spotted in https://github.com/cockpit-project/bots/pull/2547 where I [wanted to rename -d -to -n](https://github.com/cockpit-project/bots/commit/9a2b3c9829ac9ae16d1364bf8f20316539bfecd4), but this usage prevents this.