### PR TITLE
ansible: Update cockpit-* e2e machine domain names

### DIFF
--- a/ansible/inventory/e2e
+++ b/ansible/inventory/e2e
@@ -1,9 +1,9 @@
 [e2e]
-cockpit-7.e2e.bos.redhat.com ansible_user=root
-cockpit-8.e2e.bos.redhat.com ansible_user=root
-cockpit-9.e2e.bos.redhat.com ansible_user=root
-cockpit-10.e2e.bos.redhat.com ansible_user=root
-cockpit-11.e2e.bos.redhat.com ansible_user=root
+cockpit-7.apps.cnfdb2.e2e.bos.redhat.com ansible_user=root
+cockpit-8.apps.cnfdb2.e2e.bos.redhat.com ansible_user=root
+cockpit-9.apps.cnfdb2.e2e.bos.redhat.com ansible_user=root
+cockpit-10.apps.cnfdb2.e2e.bos.redhat.com ansible_user=root
+cockpit-11.apps.cnfdb2.e2e.bos.redhat.com ansible_user=root
 ci-srv-01.e2e.bos.redhat.com ansible_user=root
 ci-srv-02.e2e.bos.redhat.com ansible_user=root
 ci-srv-03.e2e.bos.redhat.com ansible_user=root


### PR DESCRIPTION
These moved into a different DNS domain a few months ago, since then
the old names were not resolvable any more.

----

Tested with reverting my /etc/hosts hacks and `ansible -m ping -i inventory e2e`