### PR TITLE
tasks: Add subjectAltName for recently changed e2e domain

### DIFF
--- a/ansible/roles/install-secrets-openshift/tasks/main.yml
+++ b/ansible/roles/install-secrets-openshift/tasks/main.yml
@@ -8,5 +8,5 @@
      cmd: "{{ oc_command }} apply -f -"
      stdin: "{{ build_secrets.stdout }}"
 
-- name: Restart all containers to pick up new secrets
-  shell: "{{ oc_command }} get -o name pods | xargs -l -r {{ oc_command }} delete --wait=false"
+ - name: Restart all containers to pick up new secrets
+   shell: "{{ oc_command }} get -o name pods | xargs -l -r {{ oc_command }} delete --wait=false"

--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -51,4 +51,4 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
-subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.apps.cnfdb2.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous-images,DNS:*.compute-1.amazonaws.com,DNS:localhost
+subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.apps.cnfdb2.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous,DNS:*.compute-1.amazonaws.com,DNS:localhost

--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -51,4 +51,4 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
-subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous-images,DNS:*.compute-1.amazonaws.com,DNS:localhost
+subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.apps.cnfdb2.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous-images,DNS:*.compute-1.amazonaws.com,DNS:localhost

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -88,7 +88,7 @@ EOF
         ssh-keygen -f tasks/id_rsa -P ''
         cat <<EOF > tasks/ssh-config
 Host sink-local
-    Hostname cockpituous-images
+    Hostname cockpituous
     User user
     Port 8022
     IdentityFile /secrets/id_rsa
@@ -176,14 +176,14 @@ test_image() {
 
         for retry in $(seq 10); do
             echo "waiting for image server to initialize"
-            curl --silent --fail --head --cacert $COCKPIT_CA_PEM https://cockpituous-images:8443 && break
+            curl --silent --fail --head --cacert $COCKPIT_CA_PEM https://cockpituous:8443 && break
             sleep 5
         done
 
         # test image-upload
         cd bots
         echo world  > /cache/images/hello.txt
-        ./image-upload --store https://cockpituous-images:8443 --state hello.txt
+        ./image-upload --store https://cockpituous:8443 --state hello.txt
         '
     test "$(cat "$IMAGES/hello.txt")" = "world"
 
@@ -197,7 +197,7 @@ test_image() {
     podman exec -i cockpituous-tasks sh -exc '
         rm /cache/images/hello.txt
         cd bots
-        ./image-download --store https://cockpituous-images:8443 --state hello.txt
+        ./image-download --store https://cockpituous:8443 --state hello.txt
         grep -q "^world" /cache/images/hello.txt
         '
 


### PR DESCRIPTION
This will fix image upload/download from cockpit-11 after the DNS change.

Currently, uploading fails in CI like this:
```
❱❱❱ curl --cacert ~/upstream/bots/images/files/ca.pem https://cockpit-11.apps.cnfdb2.e2e.bos.redhat.com:8493/
curl: (60) SSL: no alternative certificate subject name matches target host name 'cockpit-11.apps.cnfdb2.e2e.bos.redhat.com'
```

I ran images/generate-image-certs.sh in our secrets git, pushed the result, and re-deployed the secrets. This first failed due to a syntax error, fixed here as well.

Now the above curl command succeeds again.