### PR TITLE
tasks: add anaconda project's build dependencies to container

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -49,6 +49,28 @@ RUN dnf -y update && \
     curl -s -o /tmp/cockpit.spec https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec && \
     sed -i 's/%{npm-version:.*}/0/' /tmp/cockpit.spec && \
     dnf -y builddep /tmp/cockpit.spec && \
+    dnf -y install \
+        audit-libs-devel \
+        libtool \
+        gettext-devel \
+        gtk3-devel \
+        gtk-doc \
+        gtk3-devel-docs \
+        glib2-doc \
+        gobject-introspection-devel \
+        glade-devel \
+        libgnomekbd-devel \
+        libxklavier-devel \
+        make \
+        pango-devel \
+        python3-devel \
+        rpm-devel \
+        libarchive-devel \
+        libtimezonemap-devel \
+        gdk-pixbuf2-devel \
+        libxml2 \
+        gsettings-desktop-schemas \
+        desktop-file-utils && \
     dnf clean all
 
 COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/


### PR DESCRIPTION
flatpak implicit build dependency, but if not installed before,
the builddep command fails to resolve it, (at least on the local toolbox
                                           cockpit container)

I tried using builddep command, but it fails resolving some of the
systemd nested deps (systemd is a build dependency of anaconda), but
since systemd is already installed, let's not try to install it again.