### PR TITLE
tasks: Use long git option [broken PR for demo]

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -46,7 +46,7 @@ function update_bots() {
     if [ -d "$BOTS_DIR" ]; then
         git -C "$BOTS_DIR" pull --rebase
     else
-        git clone --quiet -b "$COCKPIT_BOTS_BRANCH" "$COCKPIT_BOTS_REPO" "$BOTS_DIR"
+        git clone --quiet ---branch "$COCKPIT_BOTS_BRANCH" "$COCKPIT_BOTS_REPO" "$BOTS_DIR"
     fi
 }
 


### PR DESCRIPTION
Scripts should use long options whenever possible, to make them easier to read and understand.

---

This is a broken PR for a demo. Please keep this around until 2022-02-16.