### PR TITLE
tasks: Update to split libvirt daemon, wait for process

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -73,7 +73,8 @@ for i in $(seq 1 30); do
 
     # avoid stale state and sockets
     virsh list --id --all | xargs --no-run-if-empty virsh destroy
-    pkill libvirtd || true
+    pkill virtqemud || true
+    while pgrep virtqemud >/dev/null; do sleep 0.5; done
 
     # run-queue fails on empty queues; don't poll too often
     timeout 12h ./run-queue ${AMQP_SERVER:+--amqp} ${AMQP_SERVER:-} || slumber


### PR DESCRIPTION
Commit db56f3bda introduced the killing of libvirtd after every test
run, to ensure to start from a clean slate and avoid race conditions.
Howver, in Fedora 35 (commit 864b51b06d), libvirtd got split into
multiple components.

Adjust to `virtqemud` and actually wait until the process is gone, to
avoid a race condition with accessing the socket.

---

We are currently [getting](https://logs.cockpit-project.org/logs/pull-16884-20220128-125225-d023f048-fedora-35-mobile/log) this test failure quite often:

    libvirt: XML-RPC error : Failed to connect socket to '/work/.cache/libvirt/virtqemud-sock': No such file or directory

I have no idea why that happens. However, our original approach in commit db56f3bda stopped working with the upgrade to Fedora 35, and it was racy anyway.