### PR TITLE
tasks: Default to using tmpfs for /tmp everywhere

### DIFF
--- a/tasks/install-service
+++ b/tasks/install-service
@@ -5,15 +5,10 @@ set -eufx
 SECRETS=/var/lib/cockpit-secrets
 CACHE=/var/cache/cockpit-tasks
 INSTANCES=${INSTANCES:-3}
-TMPFS_GB=14
+# assume the host has plenty of RAM, use a tmpfs for /tmp for getting less IO contention; this can be overridden
+TMPVOL=${TMPVOL:-"--tmpfs /tmp:size=14g"}
 
 systemctl stop 'cockpit-tasks@*.service'
-
-# if the host has plenty of RAM, use a tmpfs for /tmp for getting less IO contention;
-# note the *2 as the containers also need actual RAM for themselves
-if awk "/MemAvailable:/ { exit (\$2 > ${TMPFS_GB}*1048576*2*${INSTANCES}) ? 0 : 1  }" /proc/meminfo; then
-    TMPVOL="--tmpfs /tmp:size=${TMPFS_GB}g"
-fi
 
 if RUNC=$(which podman 2>/dev/null); then
     UNIT_DEPS=''


### PR DESCRIPTION
About half of our e2e machines ended up with tasks containers having
/tmp (where the QEMU overlays go) on spinning Rust, due to the "enough
memory available?" heuristic being tuned slightly wrongly. This led to
tests running very slowly and failing due to all kinds of timeouts due
to I/O contention.

Drop that heuristic, and run containers with a tmpfs on /tmp everywhere.
Both e2e and AWS machines have enough RAM, and if we run them anywhere
else we'll have to make sure to pick an adequate `$INSTANCES` for the
available RAM.

---

I rolled this out to our e2e machines:

    ansible -i inventory/ -m include_role -a name=tasks-systemd e2e

and verified that all containers have a tmpfs /tmp. Let's see how tests perform now!