### PR TITLE
tasks: Increase parallel jobs

### DIFF
--- a/ansible/aws/launch-tasks.yml
+++ b/ansible/aws/launch-tasks.yml
@@ -31,7 +31,7 @@
     - role: tasks-systemd
       vars:
         # fill up the 96 CPUs/188 GiB RAM
-        instances: 18
+        instances: 12
   tasks:
     - name: Set useful host name
       hostname:

--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Set up systemd service for cockpit/tasks
   shell: |
-    export INSTANCES={{ instances | default(4) }}
+    export INSTANCES={{ instances | default(3) }}
     export NPM_REGISTRY=https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/
     export TEST_NOTIFICATION_MX={{ notification_mx | default('') }}
     export TEST_NOTIFICATION_TO={{ notification_to | default('') }}

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -4,7 +4,7 @@ kind: ReplicationController
 metadata:
   name: centosci-tasks
 spec:
-  replicas: 1
+  replicas: 5
   selector:
     infra: cockpit-tasks
   template:

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -17,7 +17,7 @@ spec:
         image: quay.io/cockpit/tasks
         env:
         - name: TEST_JOBS
-          value: '5'
+          value: '6'
         - name: TEST_PUBLISH
           value: sink-local-4
         - name: RUN_STATISTICS_QUEUE

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # deploy changes to this script with:
-# ansible -v -i inventory -m include_role -a name=tasks-systemd e2e tag_ServiceComponent_Tasks
+# ansible -i inventory -m include_role -a name=tasks-systemd e2e
+# ansible -i inventory -m include_role -a name=tasks-systemd tag_ServiceComponent_Tasks
 
 set -eufx
 

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -44,7 +44,7 @@ Description=Cockpit Tasks %i
 $UNIT_DEPS
 
 [Service]
-Environment="TEST_JOBS=${TEST_JOBS:-5}"
+Environment="TEST_JOBS=${TEST_JOBS:-8}"
 Environment="TEST_CACHE=$CACHE"
 Environment="TEST_SECRETS=$SECRETS"
 Environment="TEST_PUBLISH=${TEST_PUBLISH:-sink}"


### PR DESCRIPTION
With 5 parallel tests, cockpit tests often require more than an hour to
run, which exceeds our Service Level Objective [1]. Increase it to 8.
This reduces the number of running bots, and thus increase the queue
time when there is a lot of demand -- but while there isn't, we'll get 
feedback much faster.

Don't increase /tmp tmpfs size - 14 GiB should still be enough even for 
~ 15 VM overlays (for tests which start multiple VMs); they are not that
big, and projects which do produce a lot of data (such as
cockpit-composer) need to set `$TEST_OVERLAY_DIR` anyway.

Reduce the number of instances on the e2e and AWS machines to compensate
for increasing the test jobs.

Test on CentOS CI fail a lot with TEST_JOBS > 6, due to timeouts, fork()
failures, and VM boot timeouts, so only marginally increase parallelism
from 5 to 6 there. This should at least be enough to push us below one 
hour again. Keep the memory limits, as the requirements were recently
reduced [2].

[1] https://github.com/cockpit-project/cockpit/wiki/DevelopmentPrinciples#our-testsci-error-budget
[2] https://github.com/cockpit-project/cockpit/pull/17122

---

See [Grafana](https://grafana-frontdoor.apps.ocp.ci.centos.org/d/ci/cockpit-ci?orgId=1&viewPanel=25). We recently did *lots* of optimizations and fixes (see https://issues.redhat.com/browse/COCKPIT-840), but  it's still not enough.