### PR TITLE
ansible: Update webhook documentation

### DIFF
--- a/ansible/aws/README.md
+++ b/ansible/aws/README.md
@@ -92,8 +92,12 @@ Normally our webhook runs on [CentOS CI](../tasks/cockpit-tasks-webhook.yaml), b
        ansible-playbook -i inventory cockpituous/webhook.yml
 
 Using this deployment requires changing all the GitHub project webhooks to
-https://ec2-3-228-126-27.compute-1.amazonaws.com and changing `DEFAULT_AMQP_SERVER` in
+http://ec2-INSTANCENAME.compute-1.amazonaws.com and changing `DEFAULT_AMQP_SERVER` in
 [bots](https://github.com/cockpit-project/bots/blob/main/task/distributed_queue.py).
+
+Once you don't need this any more, revert the bots change, set the webhook back
+to http://webhook-frontdoor.apps.ocp.ci.centos.org/ and delete the webhook AWS
+instance.
 
 Cockpit demo setup
 ------------------


### PR DESCRIPTION
The webhook gets called via http, not https (messages are signed by
the shared secret).

Replace the concrete IP address with a symbolic name, to avoid tricking
operators into copy-pasting it verbatim.

Explain how to revert the change, in particular the original CentOS CI
webhook address.