### PR TITLE
ansible: Use Fedora CoreOS for tasks

### DIFF
--- a/ansible/aws/launch-tasks.yml
+++ b/ansible/aws/launch-tasks.yml
@@ -5,51 +5,28 @@
   vars_files: aws_defaults.yml
 
   tasks:
-    - name: Create EC2 instance
-      ec2:
-        key_name: "{{ aws_key_name }}"
-        region: "{{ aws_region }}"
-        image: "{{ aws_rhel_ami }}"
+    - import_tasks: tasks/launch-coreos.yml
+      vars:
+        tag_name: "{{ hostname | default('cockpit-aws-tasks') }}"
+        tag_service_component: Tasks
         instance_type: c5.metal
-        monitoring: true
         # ARR-US-East-1 (Red Hat internal VPN) InternalB
         vpc_subnet_id: subnet-05dd25fba5582bb6a
         volumes:
-          - device_name: /dev/sda1
-            volume_size: 800
-            delete_on_termination: true
-        wait: true
-        instance_tags:
-          Name: "{{ hostname | default('cockpit-aws-tasks') }}"
-          ServiceOwner: FrontDoorSST
-          ServiceName: FrontDoorCI
-          ServiceComponent: Tasks
-          ServicePhase: Prod
-          AppCode: ARR-001
-      register: ec2
-
-    - name: Add new instance to host group
-      add_host:
-        hostname: "{{ item.private_ip }}"
-        groupname: launched
-      loop: "{{ ec2.instances }}"
-
-    - name: Wait for SSH to come up
-      delegate_to: "{{ item.private_ip }}"
-      wait_for_connection:
-      loop: "{{ ec2.instances }}"
+          - device_name: /dev/xvda
+            ebs:
+              volume_size: 800
+              delete_on_termination: true
 
 - name: Configure instances
   hosts: launched
-  become: true
-  gather_facts: true
+  vars_files: aws_defaults.yml
   roles:
     - role: users
       vars:
-        user: ec2-user
+        user: "{{ aws_coreos_defaultuser }}"
     - ci-data-cache
     - nested-kvm
-    - required-packages
     - install-secrets-dir
     - role: tasks-systemd
       vars:

--- a/ansible/aws/tasks/launch-coreos.yml
+++ b/ansible/aws/tasks/launch-coreos.yml
@@ -40,7 +40,7 @@
 
 - name: Add new instance to host group
   add_host:
-    hostname: "{{ item.public_dns_name }}"
+    hostname: "{{ item.public_dns_name | default(item.private_ip_address, true) }}"
     groupname: launched
     ansible_user: "{{ aws_coreos_defaultuser }}"
     ansible_become: true
@@ -49,11 +49,11 @@
 # we can't run Ansible yet (no Python!), so just ping port
 - name: Wait for SSH to come up
   wait_for:
-    host: "{{ item.public_dns_name }}"
+    host: "{{ item.public_dns_name | default(item.private_ip_address, true) }}"
     port: 22
   loop: "{{ ec2.instances }}"
 
 - name: Install Python for Ansible
   raw: rpm-ostree install --apply-live python3 python3-libselinux python3-pyyaml
-  delegate_to: "{{ item.public_dns_name }}"
+  delegate_to: "{{ item.public_dns_name | default(item.private_ip_address, true) }}"
   loop: "{{ ec2.instances }}"

--- a/ansible/aws/tasks/launch-coreos.yml
+++ b/ansible/aws/tasks/launch-coreos.yml
@@ -6,6 +6,8 @@
 # Optional variables:
 # - instance_type
 # - network
+# - vpc_subnet_id
+# - volumes
 
 - name: Get all matching AMIs
   ec2_ami_info:
@@ -29,6 +31,8 @@
     instance_type: "{{ instance_type | default('t2.small') }}"
     detailed_monitoring: yes
     network: "{{ network | default(omit) }}"
+    vpc_subnet_id: "{{ vpc_subnet_id | default(omit) }}"
+    volumes: "{{ volumes | default(omit) }}"
     tags:
       Name: "{{ tag_name }}"
       ServiceOwner: FrontDoorSST


### PR DESCRIPTION
Similarly to commit 9cccfd9, move launch-tasks.yml to launch-coreos.

Adjust the device name, as the root volume is now called /dev/xvda instead of
/dev/sda1 with CoreOS and the new ec2_instance API.

---

 - Builds on top of PR #461 

I launched this, it started and immediately grabbed some work, for example [this](https://logs.cockpit-project.org/logs/pull-17035-20220223-084238-42d9c17e-fedora-35-devel/log.html) or [this run](https://logs.cockpit-project.org/logs/pull-17035-20220223-084238-42d9c17e-fedora-35-devel/log.html)