### PR TITLE
release: Adjust container build to changed cockpit spec file

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -34,7 +34,8 @@ which \
 dnf-utils \
     && \
     dnf -y install 'dnf-command(builddep)' && \
-    curl https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec | sed 's/%{npm-version:.*}/0/' > /tmp/cockpit.spec && \
+    curl -s https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec.in | \
+    sed 's/@[A-Z_]*@/0/g' > /tmp/cockpit.spec && \
     dnf -y builddep /tmp/cockpit.spec && \
     dnf clean all
 


### PR DESCRIPTION
https://github.com/cockpit-project/cockpit/pull/16853
changed cockpit's template spec format and location. Adjust Dockerfile
accordingly.

Exactly the same fix as for the tasks container in commit 1d2baf3d99c8a7.