### PR TITLE
Revert "Drop push-container"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,18 @@ images-container:
 	$(DOCKER) build -t quay.io/cockpit/images:$(TAG) images
 	$(DOCKER) tag quay.io/cockpit/images:$(TAG) quay.io/cockpit/images:latest
 
+images-push:
+	./push-container quay.io/cockpit/images
+
 release-shell:
 	$(DOCKER) run -ti --rm --entrypoint=/bin/bash ghcr.io/cockpit-project/release
 
 release-container:
 	$(DOCKER) build -t ghcr.io/cockpit-project/release:$(TAG) release
 	$(DOCKER) tag ghcr.io/cockpit-project/release:$(TAG) ghcr.io/cockpit-project/release:latest
+
+release-push:
+	./push-container ghcr.io/cockpit-project/release
 
 tasks-shell:
 	$(DOCKER) run -ti --rm \
@@ -52,6 +58,9 @@ tasks-shell:
 tasks-container:
 	$(DOCKER) build -t quay.io/cockpit/tasks:$(TAG) tasks
 	$(DOCKER) tag quay.io/cockpit/tasks:$(TAG) quay.io/cockpit/tasks:latest
+
+tasks-push:
+	./push-container quay.io/cockpit/tasks
 
 tasks-secrets:
 	@cd tasks && ./build-secrets $(TASK_SECRETS)

--- a/push-container
+++ b/push-container
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+IMAGE=$1
+DOCKER=$(which podman docker 2>/dev/null | head -n1)
+ID=$($DOCKER images -q $IMAGE:latest | head -n1)
+
+TAGS=$($DOCKER images --format '{{.Tag}}   {{.ID}}' $IMAGE | sort -u | grep $ID | awk '{print $1}')
+if [ $(echo "$TAGS" | wc -w) -ne "2" ]; then
+	echo "Expected exactly two tags for the image to push: latest and one other"
+	exit 1
+fi
+for PUSHTAG in $TAGS; do
+    $DOCKER push "$IMAGE:$PUSHTAG"
+done


### PR DESCRIPTION
This was totally stupid of me.. Developers don't do that, but our
workflows use exactly that.

This reverts commit 59ac7910cf7ed0749d794577b41c5e17e92fb10a.

-----

see [refresh failure](https://github.com/cockpit-project/cockpituous/runs/5394619718?check_suite_focus=true) in #469