### PR TITLE
tasks: Kill virtqemud harder, fix image pull failure on RHEL 8

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -7,16 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: quay.io
     timeout-minutes: 30
+    # needs to use docker, as podman-built images are not accepted to RHEL 8's docker any more
+    env:
+      DOCKER: docker
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      # use podman as root, so that it uses overlayfs; user with vfs takes too long and uses too much space
       - name: Log into container registry
-        run: sudo podman login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        run: docker login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
 
       - name: Build images container
-        run: sudo make images-container
+        run: make images-container
 
       - name: Push container to registry
-        run: sudo make images-push
+        run: make images-push

--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -7,16 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     environment: quay.io
     timeout-minutes: 30
+    # needs to use docker, as podman-built images are not accepted to RHEL 8's docker any more
+    env:
+      DOCKER: docker
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
-      # use podman as root, so that it uses overlayfs; user with vfs takes too long and uses too much space
       - name: Log into container registry
-        run: sudo podman login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        run: docker login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
 
       - name: Build tasks container
-        run: sudo make tasks-container
+        run: make tasks-container
 
       - name: Push container to registry
-        run: sudo make tasks-push
+        run: make tasks-push

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TAG := $(shell date --iso-8601)
 TASK_SECRETS := /var/lib/cockpit-secrets/tasks
 WEBHOOK_SECRETS := /var/lib/cockpit-secrets/webhook
 TASK_CACHE := /var/cache/cockpit-tasks
-DOCKER := $(shell which podman docker 2>/dev/null | head -n1)
+DOCKER ?= $(shell which podman docker 2>/dev/null | head -n1)
 
 containers: images-container release-container tests-container
 	@true

--- a/push-container
+++ b/push-container
@@ -1,7 +1,8 @@
-#!/bin/sh -e
+#!/bin/sh
+set -eu
 
 IMAGE=$1
-DOCKER=$(which podman docker 2>/dev/null | head -n1)
+[ -n "${DOCKER:-}" ] || DOCKER=$(which podman docker 2>/dev/null | head -n1)
 ID=$($DOCKER images -q $IMAGE:latest | head -n1)
 
 TAGS=$($DOCKER images --format '{{.Tag}}   {{.ID}}' $IMAGE | sort -u | grep $ID | awk '{print $1}')

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -73,7 +73,7 @@ for i in $(seq 1 30); do
 
     # avoid stale state and sockets
     virsh list --id --all | xargs --no-run-if-empty virsh destroy
-    pkill virtqemud || true
+    pkill -9 virtqemud || true
     while pgrep virtqemud >/dev/null; do sleep 0.5; done
 
     # run-queue fails on empty queues; don't poll too often


### PR DESCRIPTION
Several of our tasks containers got stuck in an endless pgrep/sleep
loop, as the running virtqemud ignored SIGTERM and even SIGQUIT.