### PR TITLE
release: Fix undefined variable in release-github

### DIFF
--- a/release/release-github
+++ b/release/release-github
@@ -98,7 +98,7 @@ run_curl()
         fi
         message "github api call attempt #$retry failed, retrying in $retrysleep seconds"
         sleep $retrysleep
-        retrysleep=$((sleep*2))
+        retrysleep=$((retrysleep*2))
     done
     message "github api call failed repeatedly, aborting"
     exit 1


### PR DESCRIPTION
Commit d12ec62f97 added a retry loop around uploading tarballs to
GitHub. I renamed `$sleep` to `$retrysleep` after the first version to
avoid a naming collision/confusion with the `sleep` command, but forgot
a spot.

---

This [broke my release](https://github.com/cockpit-project/cockpit/runs/5403993979?check_suite_focus=true).