### PR TITLE
tasks: Avoid unnecessary qemu-kvm desktop/storage/network dependencies

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -21,7 +21,7 @@ RUN dnf -y update && \
         jq \
         lcov \
         libappstream-glib \
-        libvirt-daemon-kvm \
+        libvirt-daemon-driver-qemu \
         libvirt-client \
         libvirt-python3 \
         libXt \
@@ -37,6 +37,7 @@ RUN dnf -y update && \
         python3-pycodestyle \
         python3-pika \
         python3-pillow \
+        qemu-kvm-core \
         rpm-build \
         rpmdevtools \
         rsync \


### PR DESCRIPTION
libvirt-daemon-kvm is a meta-package that pulls in the qemu-kvm
metapackage (which has tons of desktop-only dependencies), plus all of
the storage/network libvirt drivers which we also don't need for
testing. This reduces the image size from 2.55 to 2.22 GB.

See https://libvirt.org/kbase/rpm-deployment.html

-----

 - Depends on https://github.com/cockpit-project/bots/pull/3064

I locally built a container from this and ran a Firefox and Chromium test.