### PR TITLE
tasks: Put back libvirt storage driver

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -21,6 +21,7 @@ RUN dnf -y update && \
         jq \
         lcov \
         libappstream-glib \
+        libvirt-daemon-driver-storage-core \
         libvirt-daemon-driver-qemu \
         libvirt-client \
         libvirt-python3 \


### PR DESCRIPTION
This is necessary to run

    virt-install --os-variant fedora-rawhide --memory 2048 --noautoconsole --network none --location /tmp/fedora-rawhide-boot-*.iso

i.e. what Anaconda tests do.

---

The recent cleanup in PR #473 broke anaconda tests: [log](https://logs.cockpit-project.org/logs/pull-3959-20220315-112723-c6aa0907-fedora-rawhide-boot/log)