### PR TITLE
tasks: Introduce elastic cloud runner mode

### DIFF
--- a/ansible/aws/README.md
+++ b/ansible/aws/README.md
@@ -59,6 +59,8 @@ Create and configure the instance:
 
 If you run more than one at a time, set a custom host name with `-e hostname=cockpit-aws-tasks-2` or similar, so that GitHub test statuses remain useful to identify where a test runs.
 
+There is also an "elastic" mode where the tasks bots keep running until they all run out of work (i.e. all iterations had an empty queue). Use that for situations where AWS instances act as extra high-demand capacity instead of being the primary runners. Enable that mode with `-e idle_poweroff=1`.
+
 Public log sink/server setup
 ----------------------------
 

--- a/ansible/aws/tasks/launch-coreos.yml
+++ b/ansible/aws/tasks/launch-coreos.yml
@@ -30,6 +30,7 @@
       id: "{{ ami_coreos.image_id }}"
     instance_type: "{{ instance_type | default('t2.small') }}"
     detailed_monitoring: yes
+    instance_initiated_shutdown_behavior: terminate
     network: "{{ network | default(omit) }}"
     vpc_subnet_id: "{{ vpc_subnet_id | default(omit) }}"
     volumes: "{{ volumes | default(omit) }}"

--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -11,4 +11,5 @@
     export NPM_REGISTRY=https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/
     export TEST_NOTIFICATION_MX={{ notification_mx | default('') }}
     export TEST_NOTIFICATION_TO={{ notification_to | default('') }}
+    export IDLE_POWEROFF={{ idle_poweroff | default('') }}
     /run/install-service

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -62,6 +62,8 @@ function slumber() {
 # on mass deployment, avoid GitHub stampede
 slumber 0-120
 
+work_done=
+
 # Consume from queue 30 times, then restart; listen to SIGTERM for orderly shutdown
 shutdown=
 trap "echo 'received SIGTERM, stopping main loop'; shutdown=1" TERM
@@ -76,8 +78,12 @@ for i in $(seq 1 30); do
     pkill -9 virtqemud || true
     while pgrep virtqemud >/dev/null; do sleep 0.5; done
 
-    # run-queue fails on empty queues; don't poll too often
-    timeout 12h ./run-queue ${AMQP_SERVER:+--amqp} ${AMQP_SERVER:-} || slumber
+    if timeout 12h ./run-queue ${AMQP_SERVER:+--amqp} ${AMQP_SERVER:-}; then
+       work_done=1
+    else
+        # run-queue fails on empty queues; don't poll too often
+        slumber
+    fi
     # clean up after tests, in particular large qcow overlays
     rm -rf /tmp/* || true
 done
@@ -90,3 +96,6 @@ update_bots
 for region in eu-central-1 us-east-1; do
     ./image-prune --s3 "https://cockpit-images.${region}.linodeobjects.com/" || true
 done
+
+# no work done at all? signal that to our systemd unit
+[ -n "$work_done" ] || exit 100

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -17,6 +17,8 @@ systemctl stop 'cockpit-tasks@*.service'
 if RUNC=$(which podman 2>/dev/null); then
     UNIT_DEPS=''
     DEVICES="--device=/dev/kvm"
+    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2074402
+    DEVICES="$DEVICES --privileged"
     NETWORK='--net=slirp4netns'  # isolate containers from each other
     NETWORK_SETUP=''
     NETWORK_TEARDOWN=''

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -44,6 +44,7 @@ Description=Cockpit Tasks %i
 $UNIT_DEPS
 
 [Service]
+Slice=idle-poweroff.slice
 Environment="TEST_JOBS=${TEST_JOBS:-8}"
 Environment="TEST_CACHE=$CACHE"
 Environment="TEST_SECRETS=$SECRETS"
@@ -52,6 +53,10 @@ Environment="TEST_NOTIFICATION_MX=${TEST_NOTIFICATION_MX:-}"
 Environment="TEST_NOTIFICATION_TO=${TEST_NOTIFICATION_TO:-}"
 Environment="NPM_REGISTRY=${NPM_REGISTRY:-}"
 Restart=always
+# 100 means "all iterations were idle, no work done"
+SuccessExitStatus=100
+# with IDLE_POWEROFF, don't auto-restart idle services
+${IDLE_POWEROFF:+RestartPreventExitStatus=100}
 RestartSec=60
 # give image pull enough time
 TimeoutStartSec=10min
@@ -65,6 +70,16 @@ $NETWORK_TEARDOWN
 [Install]
 WantedBy=multi-user.target
 EOF
+
+# mode for elastic cloud runners; all cockpit-tasks*@.service run in this slice
+if [ -n "${IDLE_POWEROFF:-}" ]; then
+    mkdir -p /etc/systemd/system/idle-poweroff.slice.d
+    cat <<EOF > /etc/systemd/system/idle-poweroff.slice.d/poweroff.conf
+    [Unit]
+    StopWhenUnneeded=yes
+    SuccessAction=poweroff-immediate
+EOF
+fi
 
 systemctl daemon-reload
 


### PR DESCRIPTION
Let the cockpit-tasks main runner keep track of whether `run-queue` ever
succeeded (i.e. picked something from the queue and ran it), and
otherwise exit with 100. Tell the systemd unit that 100 is a successful
exit code, to avoid confusing log noise.

Let all cockpit-tasks@*.service run in a specific (instead of the
automatic anonymous) `idle-poweroff.slice`, so that we can react to all
tasks containers shutting down.

When calling the installation script with `$IDLE_POWEROFF`, configure
the slice to automatically power off the machine once all cockpit-tasks
instances exited cleanly (we don't want this on failures, so that we can
ssh in and examine them). Use the `poweroff-immediate` heavy hammer
there, to avoid potential hangs on shutdown -- there is nothing to
rescue from the instance anyway.

Plumb that through the AWS Ansible role and document it.

----

 - [x] [Refresh container](https://github.com/cockpit-project/cockpituous/actions/runs/2153138538) and deploy it to infra
 - [x] Test refreshed container: [initial run](https://logs.cockpit-project.org/logs/pull-17236-20220412-072642-ad7de160-arch/log.html), more thoroughly in https://github.com/cockpit-project/cockpit/pull/17238
 - [x] Work around `podman --device` regression: https://bugzilla.redhat.com/show_bug.cgi?id=2074402
 - [x] Full end-to-end test
 - [ ] Rework idle detection work to cooperate across containers
 - Requires #478 
 - Follow-up: Investigate setting up an auto-terminate cloud alarm, to shorten the 15 mins it takes EC2 to recognize the shutdown