### PR TITLE
ansible: Terminate AWS instances on shutdown

### DIFF
--- a/ansible/aws/tasks/launch-coreos.yml
+++ b/ansible/aws/tasks/launch-coreos.yml
@@ -30,6 +30,7 @@
       id: "{{ ami_coreos.image_id }}"
     instance_type: "{{ instance_type | default('t2.small') }}"
     detailed_monitoring: yes
+    instance_initiated_shutdown_behavior: terminate
     network: "{{ network | default(omit) }}"
     vpc_subnet_id: "{{ vpc_subnet_id | default(omit) }}"
     volumes: "{{ volumes | default(omit) }}"


### PR DESCRIPTION
This avoids hidden costs or accidentally blocked volume/IP resources,
and allows us to move to an elastic model especially for the tasks
runners -- then they can decide on their own for how long they want to
run.

---

Split out from PR #477 -- I did comprehensive testing there.