### PR TITLE
tasks: Add hack for podman --device regression

### DIFF
--- a/tasks/install-service
+++ b/tasks/install-service
@@ -17,6 +17,8 @@ systemctl stop 'cockpit-tasks@*.service'
 if RUNC=$(which podman 2>/dev/null); then
     UNIT_DEPS=''
     DEVICES="--device=/dev/kvm"
+    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2074402
+    DEVICES="$DEVICES --privileged"
     NETWORK='--net=slirp4netns'  # isolate containers from each other
     NETWORK_SETUP=''
     NETWORK_TEARDOWN=''


### PR DESCRIPTION
In recent versions, `podman run --device=/dev/kvm` does not work any
more, it fails access with "Operation not permitted". Run with
`--privileged` for the time being to work around that.

---

I saw this as part of testing #477, but it's completely independent. We need this case we need to spin up AWS tasks for real due to some e2e outage.