### PR TITLE
tasks: Avoid test interruption when deploying a new container

### DIFF
--- a/ansible/maintenance/deploy-tasks-container.yml
+++ b/ansible/maintenance/deploy-tasks-container.yml
@@ -20,5 +20,5 @@
     # avoid docker_image module, that requires python-docker
     command: docker pull quay.io/cockpit/tasks
 
-  - name: Restart systemd controlled tasks containers
-    command: systemctl restart cockpit-tasks@*
+  - name: Tell tasks containers to drain and restart
+    command: pkill -ex cockpit-tasks

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -12,6 +12,7 @@ spec:
       labels:
         infra: cockpit-tasks
     spec:
+      terminationGracePeriodSeconds: 3600
       containers:
       - name: cockpit-tasks
         image: quay.io/cockpit/tasks


### PR DESCRIPTION
Our cockpit-tasks script already listens to SIGTERM for a graceful
shutdown, i.e. finish the current task and then stop the main loop.

Make use of this when we deploy a new container, instead of bluntly
killing them:

 - For OpenShift, `oc delete` already SIGTERMs the container, but the
   default grace period of 30s is way too short. Bump it to one hour,
   which is our agreed-upon maximum test runtime.

 - For systemd, signal cockpit-tasks instances (which we can see from
   the host)

There is no big downside: After running the deploy script, the existing
running containers will not de-queue new tasks, i. e. all
subsequent tests will run on the new image. But we stop interrupting
running tests, having to re-start them and running our test stats.

----

I tested this both on OpenShift (config change rolled out already) and on e2e. Given how simple this is, why didn't we do this years ago already? :shrug: 