### PR TITLE
metrics: Move to official Grafana container image on docker.io

### DIFF
--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -31,7 +31,7 @@ items:
                 mountPath: /prometheus
 
           - name: grafana
-            image: quay.io/bitnami/grafana:latest
+            image: docker.io/grafana/grafana
             env:
             - name: GF_PATHS_CONFIG
               value: /grafana-config/grafana.ini


### PR DESCRIPTION
The bitnami image ceased to exist.

---

I tested this first locally, and updated https://piware.de/gitweb/?p=learn-metrics.git . I rolled this out, and https://grafana-frontdoor.apps.ocp.ci.centos.org/d/ci/cockpit-ci?orgId=1 is now a thing again :partying_face: 