### PR TITLE
tasks: npm install robustification

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -21,6 +21,10 @@ if [ -r /secrets/npm-registry.crt ]; then
     export NODE_EXTRA_CA_CERTS=/secrets/npm-registry.crt
 fi
 
+# prone to timeouts and errors with lots of parallel containers
+npm config set fetch-retries 6
+npm config set fetch-timeout 600000
+
 # set up S3 keys for OpenShift secrets volume
 if [ ! -d /secrets/s3-keys ]; then
     # then our container symlink will point into the void, replace it with a directory and set up all files that we can find

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -58,7 +58,7 @@ TimeoutStartSec=10min
 ExecStartPre=-$RUNC rm -f cockpit-tasks-%i
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull $RUNC pull quay.io/cockpit/tasks
 $NETWORK_SETUP
-ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK $STORAGE --memory=24g --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} quay.io/cockpit/tasks
+ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK $STORAGE --memory=24g --volume=npm-cache:/work/.npm --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} quay.io/cockpit/tasks
 ExecStop=$RUNC rm -f cockpit-tasks-%i
 $NETWORK_TEARDOWN
 


### PR DESCRIPTION
We are currently getting an awful lot of [npm install failures](https://logs.cockpit-project.org/logs/pull-3277-20220426-052741-a5434ecf-fedora-rawhide-boot-rhinstaller-anaconda/log.html) on our CI. Let's try to improve this.

 - [x] Deploy [tasks refresh](https://github.com/cockpit-project/cockpituous/actions/runs/2224947474)
 - [x] test run with new container: https://github.com/cockpit-project/bots/pull/3299 (including lots of `npm install` runs wit chromium), and a [cockpit firefox run](https://logs.cockpit-project.org/logs/pull-17281-20220426-071312-9cfbfa09-fedora-35-firefox/log.html)