### PR TITLE
tasks: Increase PID limit

### DIFF
--- a/tasks/install-service
+++ b/tasks/install-service
@@ -58,7 +58,7 @@ TimeoutStartSec=10min
 ExecStartPre=-$RUNC rm -f cockpit-tasks-%i
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull $RUNC pull quay.io/cockpit/tasks
 $NETWORK_SETUP
-ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK $STORAGE --memory=24g --volume=npm-cache:/work/.npm --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} quay.io/cockpit/tasks
+ExecStart=$RUNC run --name=cockpit-tasks-%i --hostname=%i-%H $DEVICES $NETWORK $STORAGE --memory=24g --pids-limit=16384 --volume=npm-cache:/work/.npm --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} quay.io/cockpit/tasks
 ExecStop=$RUNC rm -f cockpit-tasks-%i
 $NETWORK_TEARDOWN
 


### PR DESCRIPTION
With our high parallelism, tests tend to run into a lot of errors like
this:
```
  File "bots/machine/machine_core/ssh_connection.py", line 109, in wait_user_login
    return self.execute("! test -f /run/nologin && cat /proc/sys/kernel/random/boot_id", direct=True)
  File "bots/machine/machine_core/ssh_connection.py", line 332, in execute
    proc = subprocess.Popen(command_line, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib64/python3.10/subprocess.py", line 966, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.10/subprocess.py", line 1775, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
BlockingIOError: [Errno 11] Resource temporarily unavailable
```

in particular with Firefox tests (as Firefox tends to create a lot more
threads than Chromium). Increase the podman PID limit from the default
4096 to 16384 to avoid that.

Unfortunately we can't do that on CentOS CI, as kubernetes defines this
on the node, not by pod. So for now we'll have to keep banning firefox
on CentOS CI.

----

Since we switched to AWS fallback yesterday, we had an awful lot of [messy failures like this](https://logs.cockpit-project.org/logs/pull-17279-20220425-144015-53a4f0dd-fedora-35-firefox/log.html) [or this](https://logs.cockpit-project.org/logs/pull-17279-20220425-130003-53a4f0dd-fedora-35-firefox/log.html#46), whose primary cause is this fork() failure. I rolled this out, let's see if that actually works. [This](https://logs.cockpit-project.org/logs/pull-17281-20220426-071312-9cfbfa09-fedora-35-firefox/log.html) and [this](https://logs.cockpit-project.org/logs/pull-17192-20220426-072334-3f057ae1-fedora-35-firefox/log.html) are Firefox runs with this change, and so far look promising.

In a currently running firefox test:
```
$ cat /sys/fs/cgroup/pids.current 
1871
```
This is still quite far away from the previous 4096 limit, but I can't imagine what else it would be. The [manpage](https://www.man7.org/linux/man-pages/man2/fork.2.html#ERRORS) lists the possible causes of `EAGAIN`. Aside from the cgroup limit, /proc/sys/kernel/pid_max, /proc/sys/kernel/threads-max, and `ulimit -u` are ginormous values in the order of a million or more.

 - Builds on top of PR #482 (due to changing the same line of code)
 - [x] Confirm that this holds up for the whole day