### PR TITLE
tasks: Fix RabbitMQ/webhook startup race

### DIFF
--- a/tasks/webhook
+++ b/tasks/webhook
@@ -33,9 +33,8 @@ fi
 '''
 
 
-def setup():
+def setup_home():
     '''Prepare temporary home directory from secrets'''
-    global AMQP_SERVER
 
     if os.path.isdir(HOME_DIR):
         return
@@ -56,9 +55,22 @@ def setup():
         shutil.copyfile(src, dest)
     os.umask(old_umask)
 
-    ensure_bots_checkout()
+
+def ensure_bots_checkout():
+    if not os.path.isdir(BOTS_CHECKOUT):
+        subprocess.check_call(['git', 'clone', COCKPIT_BOTS_REPO, BOTS_CHECKOUT])
+    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'fetch', 'origin'])
+    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'reset', '--hard'])
+    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'clean', '-dxff'])
+    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'checkout', 'origin/' + COCKPIT_BOTS_BRANCH])
+
+
+def scan_tasks():
+    '''scan project PRs and issues to (re)build the tasks queue'''
+
     from lib import testmap
     from task.distributed_queue import DEFAULT_AMQP_SERVER
+    global AMQP_SERVER
     AMQP_SERVER = os.getenv('AMQP_SERVER', DEFAULT_AMQP_SERVER)
 
     for project in testmap.projects():
@@ -68,15 +80,6 @@ def setup():
         subprocess.check_call([os.path.join(BOTS_CHECKOUT, 'issue-scan'), '--amqp',
                                AMQP_SERVER, '--repo', project],
                               cwd=BOTS_CHECKOUT)
-
-
-def ensure_bots_checkout():
-    if not os.path.isdir(BOTS_CHECKOUT):
-        subprocess.check_call(['git', 'clone', COCKPIT_BOTS_REPO, BOTS_CHECKOUT])
-    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'fetch', 'origin'])
-    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'reset', '--hard'])
-    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'clean', '-dxff'])
-    subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'checkout', 'origin/' + COCKPIT_BOTS_BRANCH])
 
 
 @contextlib.contextmanager
@@ -191,5 +194,8 @@ subprocess.check_call(PASSWD_ENTRY_SCRIPT, shell=True)
 
 os.environ['HOME'] = HOME_DIR
 
-setup()
+setup_home()
+ensure_bots_checkout()
+scan_tasks()
+
 http.server.HTTPServer(('', 8080), CockpituousHandler).serve_forever()

--- a/tasks/webhook
+++ b/tasks/webhook
@@ -9,6 +9,7 @@ import http.server
 import json
 import contextlib
 import ssl
+import time
 
 import pika
 
@@ -65,23 +66,6 @@ def ensure_bots_checkout():
     subprocess.check_call(['git', '-C', BOTS_CHECKOUT, 'checkout', 'origin/' + COCKPIT_BOTS_BRANCH])
 
 
-def scan_tasks():
-    '''scan project PRs and issues to (re)build the tasks queue'''
-
-    from lib import testmap
-    from task.distributed_queue import DEFAULT_AMQP_SERVER
-    global AMQP_SERVER
-    AMQP_SERVER = os.getenv('AMQP_SERVER', DEFAULT_AMQP_SERVER)
-
-    for project in testmap.projects():
-        subprocess.check_call([os.path.join(BOTS_CHECKOUT, 'tests-scan'), '--amqp',
-                               AMQP_SERVER, '--repo', project],
-                              cwd=BOTS_CHECKOUT)
-        subprocess.check_call([os.path.join(BOTS_CHECKOUT, 'issue-scan'), '--amqp',
-                               AMQP_SERVER, '--repo', project],
-                              cwd=BOTS_CHECKOUT)
-
-
 @contextlib.contextmanager
 def distributed_queue(amqp_server):
     try:
@@ -104,6 +88,32 @@ def distributed_queue(amqp_server):
     channel.queue_declare(queue='webhook', auto_delete=False)
     yield channel
     connection.close()
+
+
+def scan_tasks():
+    '''scan project PRs and issues to (re)build the tasks queue'''
+
+    from lib import testmap
+    from task.distributed_queue import DEFAULT_AMQP_SERVER
+    global AMQP_SERVER
+    AMQP_SERVER = os.getenv('AMQP_SERVER', DEFAULT_AMQP_SERVER)
+
+    # wait a bit for AMQP server to start up, on the infra it is started together with webhook
+    for retry in range(10):
+        try:
+            with distributed_queue(AMQP_SERVER):
+                break
+        except pika.exceptions.AMQPError as e:
+            logging.info(f"Failed to connect to AMQP, attempt #{retry}: {e}")
+            time.sleep(5)
+
+    for project in testmap.projects():
+        subprocess.check_call([os.path.join(BOTS_CHECKOUT, 'tests-scan'), '--amqp',
+                               AMQP_SERVER, '--repo', project],
+                              cwd=BOTS_CHECKOUT)
+        subprocess.check_call([os.path.join(BOTS_CHECKOUT, 'issue-scan'), '--amqp',
+                               AMQP_SERVER, '--repo', project],
+                              cwd=BOTS_CHECKOUT)
 
 
 def publish_to_queue(routing_key, event, request):


### PR DESCRIPTION
tasks: Fix RabbitMQ/webhook startup race

tasks/cockpit-tasks-webhook.yaml starts the webhook and the Rabbit
containers at the same time. In most cases, RabbitMQ was not fully
running yet when the webhook container got to calling `tests-scan`, so
that the startup failed immediately with an AMQP connection failure.

Mitigate this by adding a waiting loop for AMQP being ready.

Move scan_tasks() below distributed_queue() as the former now calls the
latter.

Make this reproducible in tasks/run-local.sh by starting the webhook
container in interactive mode, and hand it the `-t` provided token, if
present. This is also a nice way of testing the queue scanning.

---

This broke the redeployment pretty hard last week. It was stuck in a long container crash/back off loop. It eventually worked after umpteen retries.