### PR TITLE
ansible: Enable ntpd on e2e servers

### DIFF
--- a/ansible/e2e/ntpd.yml
+++ b/ansible/e2e/ntpd.yml
@@ -2,20 +2,6 @@
 - hosts: e2e
 
   tasks:
-  - name: Open firewall for NTP
-    iptables:
-      chain: OS_FIREWALL_ALLOW
-      protocol: udp
-      destination_port: 123
-      jump: ACCEPT
-
-  - name: Change iptables config for NTP
-    lineinfile:
-      path: /etc/sysconfig/iptables
-      regexp: 'OS_FIREWALL_ALLOW.*123'
-      insertafter: 'OS_FIREWALL_ALLOW.*443'
-      line: '-A OS_FIREWALL_ALLOW -p udp -m udp --dport 123 -j ACCEPT'
-
   - name: Setup NTP config
     template: src=ntp.conf.j2 dest=/etc/ntp.conf
     notify:

--- a/ansible/e2e/ntpd.yml
+++ b/ansible/e2e/ntpd.yml
@@ -7,6 +7,12 @@
     notify:
       restart ntpd
 
+  - name: Enable ntpd
+    service:
+      name: ntpd
+      enabled: yes
+      state: started
+
   handlers:
   - name: restart ntpd
     service: name=ntpd state=restarted


### PR DESCRIPTION
It was not running on several servers, which caused significant clock
drift. This caused S3 requests to fail, as request signature validity
is time dependent.

---

That is what caused these [RHEL image download errors](https://logs.cockpit-project.org/logs/pull-17334-20220512-071017-8ff38376-rhel-8-6/log.html)