### PR TITLE
tasks: Switch run-local.sh to testing logs in S3

### DIFF
--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -219,6 +219,8 @@ test_image() {
 
         # test image-upload to S3
         ./image-upload --store http://localhost.localdomain:9000/images/ testimage
+        # S3 store received this
+        curl http://localhost.localdomain:9000/images/ | grep -q "testimage.*qcow"
 
         # test image-upload to cockpit/image container (htpasswd credentials setup)
         ./image-upload --store https://cockpituous:8443 testimage

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -145,7 +145,9 @@ EOF
     podman run -d --name cockpituous-s3 --pod=cockpituous \
         docker.io/minio/minio server /data --console-address :9001
     # wait until it started, create bucket
-    podman run -i --rm --entrypoint /bin/sh --network host docker.io/minio/mc <<EOF
+    podman run -d --interactive --name cockpituous-mc --pod=cockpituous \
+        --entrypoint /bin/sh docker.io/minio/mc
+    podman exec -i cockpituous-mc /bin/sh <<EOF
 set -e
 until mc alias set minio http://127.0.0.1:9000  minioadmin minioadmin; do sleep 1; done
 mc mb minio/images


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/3403 switches tests-scan
over to log to S3. Adjust run-local.sh's test_pr() for that. Create a
separate "logs" S3 bucket to mimic what happens in production.
    
Drop checking the "status" file, as the S3 stream does not do this.

-----

This should land shortly after https://github.com/cockpit-project/bots/pull/3403, and then without the XXX commit. But let's get this working first.
