### PR TITLE
Move to official RabbitMQ container image on Dockerhub

### DIFF
--- a/ansible/roles/webhook/tasks/main.yml
+++ b/ansible/roles/webhook/tasks/main.yml
@@ -33,7 +33,7 @@
         --tmpfs /var/lib/rabbitmq \
         -v /etc/rabbitmq:/etc/rabbitmq:ro,z \
         -v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
-        quay.io/cockpit/rabbitmq-server
+        docker.io/rabbitmq
 
 - name: Launch webhook container in pod
   shell: |

--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -18,7 +18,7 @@ items:
       spec:
         containers:
           - name: amqp
-            image: quay.io/cockpit/rabbitmq-server
+            image: docker.io/rabbitmq
             ports:
             - containerPort: 5671
               protocol: TCP

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -121,7 +121,7 @@ launch_containers() {
         --tmpfs /var/lib/rabbitmq \
         -v "$RABBITMQ_CONFIG":/etc/rabbitmq:ro,z \
         -v "$SECRETS"/webhook:/run/secrets/webhook:ro,z \
-        quay.io/cockpit/rabbitmq-server
+        docker.io/rabbitmq
 
     # start image+sink in the background; see sink/sink-centosci.yaml
     mkdir -p "$IMAGES"


### PR DESCRIPTION
The webhook container can't and doesn't run behind the Red Hat VPN, so
the pull rate limits don't matter.

Our copy on quay.io is over a year old has several pending security
issues. Let's get rid of that.

 - [ ]  Delete https://quay.io/repository/cockpit/rabbitmq-server after this lands