### PR TITLE
e2e S3 sink for production

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Check which containers changed
         id: containers_changed
         run: |
-          tasks=$(git diff --name-only origin/main..HEAD -- tasks/ | grep -v run-local.sh || true)
+          tasks=$(git diff --name-only origin/main..HEAD -- tasks/ | grep -Ev 'run-local.sh|openssl.cnf|README' || true)
           images=$(git diff --name-only origin/main..HEAD -- images/)
           # print for debugging
           echo "tasks: $tasks"

--- a/ansible/inventory/e2e
+++ b/ansible/inventory/e2e
@@ -11,6 +11,9 @@ ci-srv-04.e2e.bos.redhat.com ansible_user=root
 ci-srv-05.e2e.bos.redhat.com ansible_user=root
 ci-srv-06.e2e.bos.redhat.com ansible_user=root
 
+[e2e_s3]
+cockpit-11.apps.cnfdb2.e2e.bos.redhat.com ansible_user=root
+
 [e2e:vars]
 notification_mx=smtp.corp.redhat.com
 notification_to=mpitt@redhat.com,mmarusak@redhat.com,sraymaek@redhat.com

--- a/ansible/roles/s3-systemd/tasks/main.yml
+++ b/ansible/roles/s3-systemd/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: "Upload s3 service installation script"
+  copy:
+    src: "{{ role_path }}/../../../images/install-s3-service"
+    dest: /run/install-s3-service
+    mode: preserve
+
+- name: Set up systemd service for S3 service
+  command: /run/install-s3-service

--- a/images/install-s3-service
+++ b/images/install-s3-service
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+# deploy this script with:
+# ansible -i inventory -m include_role -a name=s3-systemd e2e_s3
+set -eufx
+
+CACHE=/var/cache/cockpit-tasks
+SECRETS=/var/lib/cockpit-secrets
+
+if RUNC=$(which podman 2>/dev/null); then
+    UNIT_DEPS=''
+else
+    RUNC=$(which docker)
+    UNIT_DEPS="Requires=docker.service
+After=docker.service"
+fi
+
+systemctl stop cockpit-s3.service || true
+
+cat <<EOF > /etc/systemd/system/cockpit-s3.service
+[Unit]
+Description=Cockpit S3 image server
+$UNIT_DEPS
+
+[Service]
+Restart=always
+RestartSec=60
+ExecStartPre=-$RUNC rm -f cockpit-s3
+ExecStartPre=/bin/rm -rf $CACHE/.minio.sys/
+ExecStartPre=/bin/sh -c 'dd if=/dev/urandom bs=12 count=1 status=none | base64 > /run/cockpit-s3.rootpassword.txt'
+ExecStart=/bin/sh -xc "$RUNC run --name=cockpit-s3 --publish=443:9000 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=\$(cat /run/cockpit-s3.rootpassword.txt) -v $SECRETS/tasks/server.key:/root/.minio/certs/private.key:ro -v $SECRETS/tasks/server.pem:/root/.minio/certs/public.crt:ro -v $CACHE:/data:rw quay.io/minio/minio server /data"
+ExecStartPost=/usr/local/lib/setup-s3.sh
+ExecStartPost=/bin/rm -f /run/cockpit-s3.rootpassword.txt
+ExecStop=$RUNC rm -f cockpit-s3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF > /usr/local/lib/setup-s3.sh
+#!/bin/sh
+set -eu
+read s3user s3key < "$SECRETS/tasks/s3-keys/e2e.bos.redhat.com"
+$RUNC run --interactive --rm --network=host \
+    -v "$SECRETS"/webhook/ca.pem:/etc/pki/ca-trust/source/anchors/ca.pem:ro \
+    --entrypoint /bin/sh quay.io/minio/mc <<EOC
+set -e
+update-ca-trust
+until mc alias set minio https://localhost minioadmin \$(cat /run/cockpit-s3.rootpassword.txt); do sleep 1; done
+# this fails with non-zero as the directory already exists; that's fine
+mc mb minio/images || true
+mc policy set download minio/images
+mc admin user add minio/ '\$s3user' '\$s3key'
+mc admin policy set minio/ readwrite user='\$s3user'
+EOC
+EOF
+chmod a+x /usr/local/lib/setup-s3.sh
+
+systemctl daemon-reload
+systemctl enable --now cockpit-s3.service

--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -51,4 +51,4 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 basicConstraints = CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
-subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.apps.cnfdb2.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous,DNS:*.compute-1.amazonaws.com,DNS:localhost
+subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.e2e.bos.redhat.com,DNS:*.apps.cnfdb2.e2e.bos.redhat.com,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous,DNS:*.compute-1.amazonaws.com,DNS:localhost,DNS:localhost.localdomain

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -153,11 +153,11 @@ EOF
         -e MINIO_ROOT_PASSWORD="$admin_password" \
         -v "$SECRETS"/tasks/server.key:/root/.minio/certs/private.key:ro \
         -v "$SECRETS"/tasks/server.pem:/root/.minio/certs/public.crt:ro \
-        docker.io/minio/minio server /data --console-address :9001
+        quay.io/minio/minio server /data --console-address :9001
     # wait until it started, create bucket
     podman run -d --interactive --name cockpituous-mc --pod=cockpituous \
         -v "$SECRETS"/ca.pem:/etc/pki/ca-trust/source/anchors/ca.pem:ro \
-        --entrypoint /bin/sh docker.io/minio/mc
+        --entrypoint /bin/sh quay.io/minio/mc
     read s3user s3key < "$SECRETS/tasks/..data/s3-keys--localhost.localdomain"
     podman exec -i cockpituous-mc /bin/sh <<EOF
 set -e

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -209,7 +209,7 @@ cleanup_containers() {
 
 test_image() {
     # test image upload
-    podman exec -i cockpituous-tasks timeout 30 sh -exc '
+    podman exec -i cockpituous-tasks timeout 30 sh -euxc '
         # wait until tasks container has set up itself and checked out bots
         until [ -f bots/tests-trigger ]; do echo "waiting for tasks to initialize"; sleep 5; done
 
@@ -245,7 +245,7 @@ test_image() {
     test "$R2" = "id34 shhht"
 
     # validate cockpit/image downloading
-    podman exec -i cockpituous-tasks sh -exc '
+    podman exec -i cockpituous-tasks sh -euxc '
         rm --verbose /cache/images/testimage*
         cd bots
         ./image-download --store https://cockpituous:8443 testimage
@@ -264,7 +264,7 @@ test_pr() {
     # need to use real GitHub token for this
     [ -z "$TOKEN" ] || cp -fv "$TOKEN" "$SECRETS"/webhook/.config--github-token
 
-    podman exec -i cockpituous-tasks sh -exc "
+    podman exec -i cockpituous-tasks sh -euxc "
     cd bots;
     ./tests-scan -p $PR --amqp 'localhost:5671' --repo $PR_REPO;
     for retry in \$(seq 10); do
@@ -323,7 +323,7 @@ podman logs -f cockpituous-tasks &
 
 if [ -n "$INTERACTIVE" ]; then
     # check out the correct bots, as part of what cockpit-tasks would usually do
-    podman exec cockpituous-tasks sh -ec \
+    podman exec cockpituous-tasks sh -euc \
         'git clone --quiet --depth=1 -b "${COCKPIT_BOTS_BRANCH:-main}" "${COCKPIT_BOTS_REPO:-https://github.com/cockpit-project/bots}"'
 
     echo "Starting a tasks container shell; exit it to clean up the deployment"

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -281,7 +281,6 @@ test_pr() {
 
     # spot-checks that it produced sensible logs in S3
     LOG_URL="$LOGS_URL$LOG_PATH"
-    # download the log from the images server instead of the file system, to validate that the former works properly
     LOG="$(curl $LOG_URL)"
     LOG_HTML="$(curl ${LOG_URL}.html)"
     echo "--------------- test log -----------------"

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -209,7 +209,7 @@ cleanup_containers() {
 
 test_image() {
     # test image upload
-    podman exec -i cockpituous-tasks timeout 30 sh -ec '
+    podman exec -i cockpituous-tasks timeout 30 sh -exc '
         # wait until tasks container has set up itself and checked out bots
         until [ -f bots/tests-trigger ]; do echo "waiting for tasks to initialize"; sleep 5; done
 
@@ -245,7 +245,7 @@ test_image() {
     test "$R2" = "id34 shhht"
 
     # validate cockpit/image downloading
-    podman exec -i cockpituous-tasks sh -ec '
+    podman exec -i cockpituous-tasks sh -exc '
         rm --verbose /cache/images/testimage*
         cd bots
         ./image-download --store https://cockpituous:8443 testimage


### PR DESCRIPTION
Configure/test `run-local.sh`'s S3 store to be suitable for production, and add scripts/Ansible to set up a production S3 on cockpit-11. I already deployed that. However, to use it, we still need some bots changes.

We also still need to keep the old images container until we move image refresh logs to S3 as well. After that, the prize money is [this commit](https://github.com/cockpit-project/cockpituous/commit/af43988407951b64e3da03e670bccf12f5148461) which removes all the images/sink stuff.

 - [x]  Fix bots to use our CA for self-hosted S3 stores, and declare S3 store on cockpit-11: https://github.com/cockpit-project/bots/pull/3417

~After that lands, I'll drop the XXX commit and squash the fixup.~ **done**