### PR TITLE
ansible: Set correct number of task instances for e2e machines

### DIFF
--- a/ansible/e2e/setup.yml
+++ b/ansible/e2e/setup.yml
@@ -86,7 +86,9 @@
   roles:
     - ci-data-cache
     - install-secrets-dir
-    - tasks-systemd
+    - role: tasks-systemd
+      vars:
+        instances: 4
 
 - name: Set up image server
   hosts: e2e_s3


### PR DESCRIPTION
I ran this on cockpit-8, and I now see four lights^Wtask runners.