### PR TITLE
Fight against npm install failures

### DIFF
--- a/ansible/maintenance/deploy-tasks-container.yml
+++ b/ansible/maintenance/deploy-tasks-container.yml
@@ -17,8 +17,7 @@
 
   tasks:
   - name: Pre-pull current container image to avoid long downtime
-    # avoid docker_image module, that requires python-docker
-    command: docker pull quay.io/cockpit/tasks
+    command: podman pull quay.io/cockpit/tasks
 
   - name: Tell tasks containers to drain and restart
     command: pkill -ex cockpit-tasks

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -24,6 +24,8 @@ fi
 # prone to timeouts and errors with lots of parallel containers
 npm config set fetch-retries 6
 npm config set fetch-timeout 600000
+npm config set fetch-retry-mintimeout 60000
+npm config set maxsockets 3
 
 # set up S3 keys for OpenShift secrets volume
 if [ ! -d /secrets/s3-keys ]; then

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -36,7 +36,7 @@ RestartSec=60
 TimeoutStartSec=10min
 ExecStartPre=-/usr/bin/podman rm -f cockpit-tasks-%i
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull podman pull quay.io/cockpit/tasks
-ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=%i-%l --device=/dev/kvm --net=slirp4netns --memory=24g --pids-limit=16384 --volume=npm-cache:/work/.npm --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} quay.io/cockpit/tasks
+ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=%i-%l --device=/dev/kvm --net=slirp4netns --memory=24g --pids-limit=16384 --volume=npm-cache-%i:/work/.npm --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} quay.io/cockpit/tasks
 ExecStop=/usr/bin/podman rm -f cockpit-tasks-%i
 
 [Install]


### PR DESCRIPTION
[example for corrupted NPM cache](https://cockpit-logs.us-east-1.linodeobjects.com/pull-585-20220613-053118-1f73e5dd-centos-8-stream/log.html), [example for socket timeout](https://cockpit-logs.us-east-1.linodeobjects.com/pull-584-20220613-055931-651370f8-centos-8-stream/log.html)

This addresses both issues. I've been deleting the npm caches quite often recently. I can't guarantee that per-task cache will help with that, but let's at least try. If not, I'll have to disable the persistent cache again, but it does greatly help with the timeouts.

I can reliably reproduce the socket timeout:
```
export NODE_EXTRA_CA_CERTS=/secrets/npm-registry.crt
git clone https://github.com/cockpit-project/starter-kit
cd starter-kit
git clean -ffdx; npm cache clean --force; time npm install
```

With the two extra options, this now seems to work reliably.

 - [x] [Deploy](https://github.com/cockpit-project/cockpituous/actions/runs/2486520581)
 - [x] Retry https://github.com/rhinstaller/anaconda/pull/4189 , https://github.com/rhinstaller/anaconda/pull/4190 , https://github.com/cockpit-project/cockpit-ostree/pull/266 and confirm that they work now
 - [x] Run a full Cockpit PR to check for browser/OS regressions: https://github.com/cockpit-project/cockpit/pull/17447