### PR TITLE
e2e: add "reboot" racadm fragment

### DIFF
--- a/e2e/idrac/fragments/reboot.racadm
+++ b/e2e/idrac/fragments/reboot.racadm
@@ -1,0 +1,1 @@
+racadm serveraction powercycle


### PR DESCRIPTION
I used this today.  Maybe I'll use it again. :)

For the record, these get used like this:

```
./run-fragment idrac-cockpit-9 fragments/reboot.racadm
```