### PR TITLE
metrics: Pull prometheus data from S3

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,6 +1,6 @@
 # Cockpit CI metrics
 
-Our CI system regularly [builds](https://github.com/cockpit-project/bots/blob/main/prometheus-stats) a [metrics file](https://prometheus.io/docs/instrumenting/exposition_formats/) which is stored on CentOS CI's [logs web server](../sink/sink-centosci.yaml): https://logs-https-frontdoor.apps.ocp.ci.centos.org/prometheus
+Our CI system regularly [builds](https://github.com/cockpit-project/bots/blob/main/prometheus-stats) a [metrics file](https://prometheus.io/docs/instrumenting/exposition_formats/) which is stored on our log S3 bucket]: https://cockpit-logs.us-east-1.linodeobjects.com/prometheus
 
 These kubernetes resources deploy [Prometheus](https://prometheus.io/) to
 regularly read these metrics and store them in a database, and [Grafana](https://grafana.com/) to visualize these metrics as graphs.

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -103,9 +103,9 @@ items:
         - job_name: ci
           honor_timestamps: true
           metrics_path: /prometheus
-          scheme: http
+          scheme: https
           static_configs:
-          - targets: ['sink-http.frontdoor.svc.cluster.local:8080']
+          - targets: ['cockpit-logs.us-east-1.linodeobjects.com']
 
   - kind: ConfigMap
     apiVersion: v1


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/3511 moved the prometheus
export to our S3 bucket. Update our deployment accordingly.

 - [x] Requires https://github.com/cockpit-project/bots/pull/3511
 - [x] Roll this out and test