### PR TITLE
images: Use private data volume for minio image store

### DIFF
--- a/images/install-s3-service
+++ b/images/install-s3-service
@@ -4,7 +4,6 @@
 # ansible -i inventory -m include_role -a name=s3-systemd e2e_s3
 set -eufx
 
-CACHE=/var/cache/cockpit-tasks
 SECRETS=/var/lib/cockpit-secrets
 
 if RUNC=$(which podman 2>/dev/null); then
@@ -26,9 +25,8 @@ $UNIT_DEPS
 Restart=always
 RestartSec=60
 ExecStartPre=-$RUNC rm -f cockpit-s3
-ExecStartPre=/bin/rm -rf $CACHE/.minio.sys/
 ExecStartPre=/bin/sh -c 'dd if=/dev/urandom bs=12 count=1 status=none | base64 > /run/cockpit-s3.rootpassword.txt'
-ExecStart=/bin/sh -xc "$RUNC run --name=cockpit-s3 --publish=443:9000 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=\$(cat /run/cockpit-s3.rootpassword.txt) -v $SECRETS/tasks/server.key:/root/.minio/certs/private.key:ro -v $SECRETS/tasks/server.pem:/root/.minio/certs/public.crt:ro -v $CACHE:/data:rw quay.io/minio/minio server /data"
+ExecStart=/bin/sh -xc "$RUNC run --name=cockpit-s3 --publish=443:9000 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=\$(cat /run/cockpit-s3.rootpassword.txt) -v $SECRETS/tasks/server.key:/root/.minio/certs/private.key:ro -v $SECRETS/tasks/server.pem:/root/.minio/certs/public.crt:ro -v images-minio-data:/data:rw quay.io/minio/minio server /data"
 ExecStartPost=/usr/local/lib/setup-s3.sh
 ExecStartPost=/bin/rm -f /run/cockpit-s3.rootpassword.txt
 ExecStop=$RUNC rm -f cockpit-s3


### PR DESCRIPTION
We previously handed the bare image cache directory to minio as data
volume. While this works fine for reading existing files through the S3
bucket, it doesn't for writing: Uploaded files get created as directory,
with some metadata and data possibly even split between multiple files.

Untangle that by using a persistent private volume for minio. With that,
the data volume file layout and also their permissions don't matter.
This causes some duplication between the volume and the cache directory
on the host, but we have tons of unused space on cockpit-11, so this
does not matter.

---

This fixes the systematic image download failures like [this one](https://cockpit-logs.us-east-1.linodeobjects.com/pull-3530-20220621-053636-ef3b8226-rhel-9-0-candlepin-subscription-manager/log.html) that happened on images from recent refreshes.

I rolled this out and tested this pretty thoroughly: I primed the store with most of our existing images (with image-upload), stopped and restarted the container, and downloaded the images again.

```
# df -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda3       1.1T   83G  1.1T   8% /
```