### PR TITLE
tasks: Use "podman network"

### DIFF
--- a/ansible/e2e/setup.yml
+++ b/ansible/e2e/setup.yml
@@ -86,9 +86,7 @@
   roles:
     - ci-data-cache
     - install-secrets-dir
-    - role: tasks-systemd
-      vars:
-        instances: 4
+    - tasks-systemd
 
 - name: Set up image server
   hosts: e2e_s3

--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Set up systemd service for cockpit/tasks
   shell: |
-    export INSTANCES={{ instances | default(3) }}
+    export INSTANCES={{ instances | default(4) }}
     export NPM_REGISTRY=https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/
     export TEST_NOTIFICATION_MX={{ notification_mx | default('') }}
     export TEST_NOTIFICATION_TO={{ notification_to | default('') }}

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -49,9 +49,9 @@ RUN dnf -y update && \
         vim-enhanced \
         virt-install \
         wget && \
-    curl -s https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec.in | \
-    sed 's/@[A-Z_]*@/0/g' > /tmp/cockpit.spec && \
+    curl -o /tmp/cockpit.spec -s https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec | \
     dnf -y builddep /tmp/cockpit.spec && \
+    rm /tmp/cockpit.spec && \
     dnf -y install \
         audit-libs-devel \
         libtool \

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -35,9 +35,12 @@ RestartSec=60
 # give image pull enough time
 TimeoutStartSec=10min
 ExecStartPre=-/usr/bin/podman rm -f cockpit-tasks-%i
+ExecStartPre=-/usr/bin/podman network rm cockpit-tasks-%i
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull podman pull quay.io/cockpit/tasks
-ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=%i-%l --device=/dev/kvm --net=slirp4netns --memory=24g --pids-limit=16384 --volume=npm-cache-%i:/work/.npm --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} quay.io/cockpit/tasks
+ExecStartPre=/usr/bin/podman network create cockpit-tasks-%i
+ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=%i-%l --device=/dev/kvm --network=cockpit-tasks-%i --memory=24g --pids-limit=16384 --volume=npm-cache-%i:/work/.npm --volume=\${TEST_CACHE}/images:/cache/images:rw --volume=\${TEST_SECRETS}/tasks:/secrets:ro --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro ${TMPVOL:-} --shm-size=1024m --user=1111 --env=NPM_REGISTRY=\${NPM_REGISTRY} --env=TEST_JOBS=\${TEST_JOBS} --env=TEST_PUBLISH=\${TEST_PUBLISH} --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} quay.io/cockpit/tasks
 ExecStop=/usr/bin/podman rm -f cockpit-tasks-%i
+ExecStop=/usr/bin/podman network rm cockpit-tasks-%i
 
 [Install]
 WantedBy=multi-user.target

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -8,7 +8,7 @@ set -eufx
 
 SECRETS=/var/lib/cockpit-secrets
 CACHE=/var/cache/cockpit-tasks
-INSTANCES=${INSTANCES:-3}
+INSTANCES=${INSTANCES:-4}
 # assume the host has plenty of RAM, use a tmpfs for /tmp for getting less IO contention; this can be overridden
 TMPVOL=${TMPVOL:-"--tmpfs /tmp:size=14g"}
 


### PR DESCRIPTION
All our tasks machines run RHEL ≥ 8.6 or Fedora CoreOS now, so we can
rely on `podman network`. Use a bridge instead of slirp for more
performance.

----

This is the approch that we had used with docker for years. But our initial EC2 instances ran RHEL 8.4 or earlier, which did not have `podman network` yet, so I resorted to slirp.

I had this sitting on my disk for 2½ years, and just spotted this again when reviewing local branches. I rolled this out to e2e, and so far it seems happy. But let's give it a day or two of field evaluation.