### PR TITLE
workflows: Run tasks integration test as user

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: quay.io
     timeout-minutes: 30
     # needs to use docker, as podman-built images are not accepted to RHEL 8's docker any more

--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: quay.io
     timeout-minutes: 30
     # needs to use docker, as podman-built images are not accepted to RHEL 8's docker any more

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 on: [pull_request]
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -16,7 +16,7 @@ jobs:
         run: make check
 
   tasks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       # enough permissions for tests-scan to work
       pull-requests: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,15 +48,14 @@ jobs:
 
       - name: Build tasks container if it changed
         if: steps.containers_changed.outputs.tasks
-        # Run podman as root, as podman is missing slirp4netns by default, and does not have overlayfs by default
-        run: sudo make tasks-container
+        run: make tasks-container
 
       - name: Build images container if it changed
         if: steps.containers_changed.outputs.images
-        run: sudo make images-container
+        run: make images-container
 
       - name: Test local deployment
         run: |
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
           PRN=$(echo "$GITHUB_REF" | cut -f3 -d '/')
-          sudo tasks/run-local.sh -p $PRN -t ~/.config/github-token
+          tasks/run-local.sh -p $PRN -t ~/.config/github-token

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -42,7 +42,6 @@ RUN dnf -y update && \
         rpm-build \
         rpmdevtools \
         rsync \
-        sassc \
         socat \
         strace \
         tar \


### PR DESCRIPTION
Trying to build a Fedora container as root has started to fail in a
"funny" way: dnf immediately crashes with "sd-bus call: Connection reset
by peer".

Building and running the container as user has worked fine for a while,
and we do this everywhere else. It was originally introduced for a
missing slirp4netns package, but that got fixed in Ubuntu long ago.

----

Fixes [this failure](https://github.com/cockpit-project/cockpituous/runs/7337179255?check_suite_focus=true), which spontaneously broke around last week. I saw a similar effect in my [debugging saga with the unit-tests container](https://github.com/cockpit-project/cockpit/pull/17549#issuecomment-1182741018).

Tested all commits separately:
 - [without tasks changes](https://github.com/cockpit-project/cockpituous/runs/7341492159?check_suite_focus=true) (first commit only)
 - [with tasks changes, Ubuntu 20.04](https://github.com/cockpit-project/cockpituous/runs/7341582673?check_suite_focus=true) (second commit)
 - [with tasks changes, Ubuntu 22.04](https://github.com/cockpit-project/cockpituous/runs/7341817551?check_suite_focus=true) (third commit)