### PR TITLE
Fix webhook EC2 deployment, move primary webhook to EC2

### DIFF
--- a/ansible/aws/README.md
+++ b/ansible/aws/README.md
@@ -77,17 +77,16 @@ points to the stable IP 54.89.13.31 of that instance.
 
 Webhook setup
 -------------
-Normally our webhook runs on [CentOS CI](../tasks/cockpit-tasks-webhook.yaml), but for times when this is down we can spin up a webhook in AWS:
+AWS runs our primary webhook. Deploy or update it with:
 
     ansible-playbook -i inventory aws/launch-webhook.yml
 
-Using this deployment requires changing all the GitHub project webhooks to
-http://ec2-3-228-126-27.compute-1.amazonaws.com and changing `DEFAULT_AMQP_SERVER` in
-[bots](https://github.com/cockpit-project/bots/blob/main/task/distributed_queue.py).
+Set project webhooks to point to http://ec2-3-228-126-27.compute-1.amazonaws.com
+and the shared password found in our CI secrets (`webhook/.config/github-webhook-token`).
 
-Once you don't need this any more, revert the bots change, set the webhook back
-to http://webhook-frontdoor.apps.ocp.ci.centos.org/ and delete the webhook AWS
-instance.
+If you deploy this somewhere else, you need to change `DEFAULT_AMQP_SERVER` in
+[bots](https://github.com/cockpit-project/bots/blob/main/task/distributed_queue.py)
+and change all GitHub project webhooks accordingly.
 
 Cockpit demo setup
 ------------------

--- a/ansible/aws/tasks/launch-coreos.yml
+++ b/ansible/aws/tasks/launch-coreos.yml
@@ -59,6 +59,6 @@
   loop: "{{ ec2.instances }}"
 
 - name: Install Python for Ansible
-  raw: rpm-ostree install --apply-live python3 python3-libselinux python3-pyyaml
+  raw: type python3 || rpm-ostree install --apply-live python3 python3-libselinux python3-pyyaml
   delegate_to: "{{ item.public_dns_name | default(item.private_ip_address, true) }}"
   loop: "{{ ec2.instances }}"

--- a/ansible/roles/webhook/tasks/main.yml
+++ b/ansible/roles/webhook/tasks/main.yml
@@ -14,7 +14,7 @@
     import os.path
     import yaml
     with open("/run/cockpit-tasks-webhook.yaml") as f:
-        y = yaml.load(f)
+        y = yaml.full_load(f)
     files = [item for item in y["items"] if item["metadata"]["name"] == "amqp-config"][0]["data"]
     for name, contents in files.items():
         with open(os.path.join('/etc/rabbitmq', name), 'w') as f:

--- a/ansible/roles/webhook/tasks/main.yml
+++ b/ansible/roles/webhook/tasks/main.yml
@@ -8,7 +8,7 @@
 # keep this in sync with tasks/run-local.sh
 - name: Generate flat files from RabbitMQ config map
   shell: |
-    rm -r /etc/rabbitmq
+    rm -rf /etc/rabbitmq
     mkdir -p /etc/rabbitmq
     python3 - <<EOF
     import os.path


### PR DESCRIPTION
Our CentOS CI project will go away soon, so let's move to an EC2 instance as our primary webhook/queue. I deployed this already ([hello](http://ec2-3-228-126-27.compute-1.amazonaws.com/inspect-queue)), but didn't activate it yet in bots nor our projects.

 - [x] Coordinate switchover time with @ptoscano, when to move bots + sub-man project settings.
 - [x] Land https://github.com/cockpit-project/bots/pull/3660 after this