### PR TITLE
ansible: Fix openstack inventory for move to CoreOS

### DIFF
--- a/ansible/inventory/openstack.yml
+++ b/ansible/inventory/openstack.yml
@@ -8,7 +8,7 @@ only_clouds:
   - "rhos-01"
 fail_on_erros: true
 compose:
-  ansible_user: "'fedora'"
+  ansible_user: "'core'"
   ansible_become: true
   # avoid deprecation warning
   ansible_python_interpreter: "'python3'"


### PR DESCRIPTION
Commit 232d5fca5 moved our OpenStack instances to CoreOS, but forgot to
adjust the inventory for existing instances. The default user on CoreOS
is `core`, not `fedora`.

----

This fixes running `deploy-tasks-container.yml` and other playbooks, which currently fail with SSH connection failures. Sorry for the hiccup!