### PR TITLE
webhook instance: auto-updates, auto-start pods

### DIFF
--- a/ansible/aws/tasks/launch-coreos.yml
+++ b/ansible/aws/tasks/launch-coreos.yml
@@ -58,6 +58,20 @@
     port: 22
   loop: "{{ ec2.instances }}"
 
+- name: Switch to stable CoreOS stream and install updates
+  raw: |
+    if ! rpm-ostree status --booted | grep -q coreos/stable; then
+        rpm-ostree rebase --bypass-driver --reboot fedora:fedora/x86_64/coreos/stable
+    fi
+  delegate_to: "{{ item.public_dns_name | default(item.private_ip_address, true) }}"
+  loop: "{{ ec2.instances }}"
+
+- name: Wait for SSH to come up after reboot
+  wait_for:
+    host: "{{ item.public_dns_name | default(item.private_ip_address, true) }}"
+    port: 22
+  loop: "{{ ec2.instances }}"
+
 - name: Install Python for Ansible
   raw: type python3 || rpm-ostree install --apply-live python3 python3-libselinux python3-pyyaml
   delegate_to: "{{ item.public_dns_name | default(item.private_ip_address, true) }}"

--- a/ansible/roles/webhook/cockpituous-webhook.service
+++ b/ansible/roles/webhook/cockpituous-webhook.service
@@ -15,6 +15,7 @@ ExecStart=/usr/bin/podman run \
 	-d \
 	--name cockpituous-rabbitmq \
 	--pod=new:cockpituous \
+	--pull=always \
 	--publish 5671:5671 \
 	--publish 80:8080 \
 	--tmpfs /var/lib/rabbitmq \
@@ -29,6 +30,7 @@ ExecStart=/usr/bin/podman run \
 	-d \
 	--name cockpituous-webhook \
 	--pod=cockpituous \
+	--pull=always \
 	-e AMQP_SERVER=localhost:5671 \
 	-v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
 	quay.io/cockpit/tasks webhook

--- a/ansible/roles/webhook/cockpituous-webhook.service
+++ b/ansible/roles/webhook/cockpituous-webhook.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=Cockpituous webhook pod
+After=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Restart=on-failure
+TimeoutStopSec=70
+
+ExecStart=/usr/bin/podman run \
+	--cgroups=no-conmon \
+	--rm \
+	--replace \
+	-d \
+	--name cockpituous-rabbitmq \
+	--pod=new:cockpituous \
+	--publish 5671:5671 \
+	--publish 80:8080 \
+	--tmpfs /var/lib/rabbitmq \
+	-v /etc/rabbitmq:/etc/rabbitmq:ro,z \
+	-v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
+	docker.io/rabbitmq
+
+ExecStart=/usr/bin/podman run \
+	--cgroups=no-conmon \
+	--rm \
+	--replace \
+	-d \
+	--name cockpituous-webhook \
+	--pod=cockpituous \
+	-e AMQP_SERVER=localhost:5671 \
+	-v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
+	quay.io/cockpit/tasks webhook
+
+ExecStop=/usr/bin/podman pod rm -f cockpituous
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/webhook/tasks/main.yml
+++ b/ansible/roles/webhook/tasks/main.yml
@@ -1,3 +1,5 @@
+# update existing instance:
+# ansible -v -i inventory -m include_role -a name=webhook  tag_Name_cockpit_webhook
 ---
 - name: Upload RabbitMQ k8s resource
   copy:
@@ -21,23 +23,17 @@
             f.write(contents)
     EOF
 
-- name: Clean up existing pod
-  shell: |
-    podman pod rm -f cockpituous || true
+- name: Install pod systemd unit
+  copy:
+    src: "{{ role_path }}/cockpituous-webhook.service"
+    dest: /etc/systemd/system/cockpituous-webhook.service
+    mode: preserve
 
-# FIXME: wrap into systemd to survive reboots, convert to YAML resource
-- name: Launch pod with RabbitMQ
-  shell: |
-    podman run -d --rm --name cockpituous-rabbitmq --pod=new:cockpituous \
-        --publish 5671:5671 --publish 80:8080 \
-        --tmpfs /var/lib/rabbitmq \
-        -v /etc/rabbitmq:/etc/rabbitmq:ro,z \
-        -v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
-        docker.io/rabbitmq
+- name: reload systemd
+  command: systemctl daemon-reload
 
-- name: Launch webhook container in pod
-  shell: |
-    podman run -d --rm --name cockpituous-webhook --pod=cockpituous \
-        -e AMQP_SERVER=localhost:5671 \
-        -v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
-        quay.io/cockpit/tasks webhook
+- name: Start pod
+  service:
+    name: cockpituous-webhook.service
+    state: restarted
+    enabled: yes


### PR DESCRIPTION
This makes our webhook instance robust for non-trivial lifetimes, as it is now our primary queue. This faces the public internet, so let's do the full treatment of automatic updates, automatic reboots, and automatic service starts.

I redeployed our webhook instance from scratch, and rebooted it to make sure that everything works. The queue is happy, and cold scanning GitHub looks as expected.

`zincati.service` is running, and `rpm-ostree status` confirms that it is armed:

```
$ sudo rpm-ostree status
State: idle
AutomaticUpdatesDriver: Zincati
  DriverState: active; periodically polling for updates (last checked Tue 2022-07-26 12:47:55 UTC)
Deployments:
  fedora:fedora/x86_64/coreos/stable
                   Version: 36.20220703.3.1 (2022-07-18T18:07:26Z)
                BaseCommit: bf8a37ea931047ef582072046414ba6e4464dd048c29af53c3202253685433a7
                    Commit: 1876d738b3a1691e6b04038d8b338f1f5651ac067e82eea7237c3b9a8e7e4585
              GPGSignature: Valid signature by 53DED2CB922D8B8D9E63FD18999F7CBF38AB71F4
                      Diff: 9 added
           LayeredPackages: python3 python3-libselinux python3-pyyaml
```