### PR TITLE
ansible: Restart webhook container on secrets rollouts

### DIFF
--- a/ansible/roles/install-secrets-dir/tasks/main.yml
+++ b/ansible/roles/install-secrets-dir/tasks/main.yml
@@ -40,9 +40,9 @@
      state: absent
 
  # the above empties the /secrets volume for running containers
- - name: Restart image containers to pick up changed secrets
+ - name: Restart webhook and image containers to pick up changed secrets
    # The glob avoids failure on machines which are not running cockpit-images
-   command: systemctl restart cockpit-images*.service
+   command: systemctl restart cockpituous-webhook*.service cockpit-images*.service
 
  - name: Restart systemd controlled tasks containers to pick up changed secrets
    command: systemctl restart cockpit-tasks@*


### PR DESCRIPTION
Previously, rolling out new secrets left the programs in the webhook
container crashing, as the secrets ceased to exist.