### PR TITLE
tasks: Install genisoimage

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf -y update && \
         firefox \
         fpaste \
         gcc-c++ \
+        genisoimage \
         git \
         git-lfs \
         gnupg \


### PR DESCRIPTION
This got lost when updating to Fedora 36, as it is not installed by
transient dependencies any more. But at least cirros.bootstrap needs it.

----

Spotted in https://github.com/cockpit-project/bots/pull/3670 in a cirros test refresh, which [failed](https://logs.cockpit-project.org/logs/image-refresh-3670-20220729-065050/log):
```
+ genisoimage -input-charset utf-8 -output cloud-init.iso -volid cidata -joliet -rock user-data meta-data
/work/bots/make-checkout-workdir/images/scripts/cirros.bootstrap: line 24: genisoimage: command not found
```

 - [x] [Refresh](https://github.com/cockpit-project/cockpituous/actions/runs/2758971352) and roll out
 - [x] Run a Cockpit PR to validate new container image: https://github.com/cockpit-project/cockpit/pull/17601