### PR TITLE
tasks: Install flake8

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -34,9 +34,8 @@ RUN dnf -y update && \
         origin-clients \
         psmisc \
         procps-ng \
-        python3-pyflakes \
         python3 \
-        python3-pycodestyle \
+        python3-flake8 \
         python3-pika \
         python3-pillow \
         qemu-kvm-core \


### PR DESCRIPTION
cockpit-machines recently moved to using flake8 by way of cockpit's
static-code. But that runs in the tasks container, and thus is currently
skipped. Let's make sure it runs again.

 - Blocks on https://github.com/cockpit-project/cockpit-machines/pull/788
 - [x] [refresh](https://github.com/cockpit-project/cockpituous/actions/runs/2816767772) and deploy
 - [x] Run cockpit and cockpit-machines chromium and firefox tests to validate new container: https://github.com/cockpit-project/bots/pull/3708