### PR TITLE
Fix webhook container

### DIFF
--- a/ansible/aws/launch-webhook.yml
+++ b/ansible/aws/launch-webhook.yml
@@ -13,6 +13,12 @@
         network:
           interfaces:
             - eni-004f5b4f714f3fda9
+        volumes:
+          # default 10 GB are not enough for two rpm-ostree deployments and tasks container
+          - device_name: /dev/xvda
+            ebs:
+              volume_size: 20
+              delete_on_termination: true
 
 - name: Configure instances
   hosts: launched

--- a/ansible/roles/webhook/cockpituous-webhook.service
+++ b/ansible/roles/webhook/cockpituous-webhook.service
@@ -8,10 +8,11 @@ RemainAfterExit=yes
 Restart=on-failure
 TimeoutStopSec=70
 
+ExecStart=-/usr/bin/podman pod rm -f cockpituous
+
 ExecStart=/usr/bin/podman run \
 	--cgroups=no-conmon \
 	--rm \
-	--replace \
 	-d \
 	--name cockpituous-rabbitmq \
 	--pod=new:cockpituous \
@@ -26,7 +27,6 @@ ExecStart=/usr/bin/podman run \
 ExecStart=/usr/bin/podman run \
 	--cgroups=no-conmon \
 	--rm \
-	--replace \
 	-d \
 	--name cockpituous-webhook \
 	--pod=cockpituous \


### PR DESCRIPTION
It was broken again this morning, and already was brittle once last week. Trying to start the tasks container made podman crazy (spinning at 100% CPU) and filled up the disk. Day 2 operation lessons.. :grin:

I deployed this, and it has enough breathing room now.

    /dev/xvda4       20G  2.7G   17G  14% /sysroot
