### PR TITLE
Mostly revert "tasks: add anaconda project's build dependencies to container"

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -18,11 +18,13 @@ RUN dnf -y update && \
         git \
         git-lfs \
         gnupg \
+        gobject-introspection-devel \
         google-noto-cjk-fonts-common \
         intltool \
         jq \
         lcov \
         libappstream-glib \
+        libtool \
         libvirt-daemon-driver-storage-core \
         libvirt-daemon-driver-qemu \
         libvirt-client \
@@ -52,28 +54,6 @@ RUN dnf -y update && \
     curl -o /tmp/cockpit.spec -s https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec | \
     dnf -y builddep /tmp/cockpit.spec && \
     rm /tmp/cockpit.spec && \
-    dnf -y install \
-        audit-libs-devel \
-        libtool \
-        gettext-devel \
-        gtk3-devel \
-        gtk-doc \
-        gtk3-devel-docs \
-        glib2-doc \
-        gobject-introspection-devel \
-        glade-devel \
-        libgnomekbd-devel \
-        libxklavier-devel \
-        make \
-        pango-devel \
-        python3-devel \
-        rpm-devel \
-        libarchive-devel \
-        libtimezonemap-devel \
-        gdk-pixbuf2-devel \
-        libxml2 \
-        gsettings-desktop-schemas \
-        desktop-file-utils && \
     dnf clean all
 
 COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/


### PR DESCRIPTION
Since https://github.com/rhinstaller/anaconda/pull/4287 , Anaconda RPMs
are built inside the test VM, not in the container. Just keep libtool
and gobject-introspection-devel, as anaconda needs them for running
`./configure`.

This mostly reverts commit e3afeb4f6a6308c8df1a653b50e116666b08f30b.

-----

This reduces the [compressed container size](https://quay.io/repository/cockpit/tasks?tab=tags) from 777 MB to 723 MB, and the uncompressed size from 2.3 GB to 2.1 GB.

 - [x] [Build](https://github.com/cockpit-project/cockpituous/actions/runs/3319836314) and deploy
 - [x] Test anaconda against new container: https://github.com/rhinstaller/anaconda/pull/4396
 - [x] Test cockpit PR against new container to check for regressions: https://github.com/cockpit-project/cockpit/pull/17839