### PR TITLE
ansible: Add maintenance script to reset NPM cache volume

### DIFF
--- a/ansible/maintenance/reset-npm-cache.yml
+++ b/ansible/maintenance/reset-npm-cache.yml
@@ -1,0 +1,13 @@
+- name: Reset the NPM cache volume after occasional corruption
+  hosts: e2e tag_ServiceComponent_Tasks openstack_tasks
+  gather_facts: false
+  tasks:
+    - name: Clear npm cache directory in all npm-cache-N volumes
+      shell: |
+        {% raw %}
+        set -ex
+        for dir in $(podman volume ls --format '{{.Name}}' | grep '^npm-cache-' | xargs -rn1 \
+                     podman volume inspect --format '{{.Mountpoint}}'); do
+            rm  -rf "$dir/_cacache"
+        done
+        {% endraw %}


### PR DESCRIPTION
Occasionally, `npm install` starts failing like this:

    npm ERR! code ETARGET
    npm ERR! notarget No matching version found for @babel/generator@^7.19.3.

This happens when its cache gets corrupted.

---

[recent example log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-3915-20220929-105522-fd5e626c-fedora-coreos-cockpit-project-cockpit-ostree/log.html)

I already ran this to test it, so retrying the failed test should work now. But this needs to be run occasionally.