### PR TITLE
tasks: skip flake8/mypy for bots

### DIFF
--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -166,6 +166,7 @@ EOF
         -e AMQP_SERVER=localhost:5671 \
         -e TEST_PUBLISH=sink-local \
         -e S3_LOGS_URL=$S3_URL_POD/logs/ \
+	-e SKIP_STATIC_CHECK=1 \
         quay.io/cockpit/tasks:${TASKS_TAG:-latest} ${INTERACTIVE:+sleep infinity}
 }
 


### PR DESCRIPTION
When testing test/run we are not interested in flake8 or mypy errors, but want to run `test-bots`. This allows us to skip installing mypy in the tasks container.

https://github.com/cockpit-project/bots/pull/3735/commits/e1fc3e8bc9a7a38a6404762481ae8b65faa4b4a6