### PR TITLE
Add CJK fonts to task container

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -18,6 +18,7 @@ RUN dnf -y update && \
         git \
         git-lfs \
         gnupg \
+        google-noto-cjk-fonts-common \
         intltool \
         jq \
         lcov \


### PR DESCRIPTION
This way, we should be able to see CJK fonts instead of boxes in pixel test images, making it more likely to spot various issues involving non-latin languages.