### PR TITLE
Drop Anaconda build-deps from task container

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -51,28 +51,6 @@ RUN dnf -y update && \
     curl -o /tmp/cockpit.spec -s https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec | \
     dnf -y builddep /tmp/cockpit.spec && \
     rm /tmp/cockpit.spec && \
-    dnf -y install \
-        audit-libs-devel \
-        libtool \
-        gettext-devel \
-        gtk3-devel \
-        gtk-doc \
-        gtk3-devel-docs \
-        glib2-doc \
-        gobject-introspection-devel \
-        glade-devel \
-        libgnomekbd-devel \
-        libxklavier-devel \
-        make \
-        pango-devel \
-        python3-devel \
-        rpm-devel \
-        libarchive-devel \
-        libtimezonemap-devel \
-        gdk-pixbuf2-devel \
-        libxml2 \
-        gsettings-desktop-schemas \
-        desktop-file-utils && \
     dnf clean all
 
 COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/


### PR DESCRIPTION
This reverts commit e3afeb4f6a6308c8df1a653b50e116666b08f30b.

Since https://github.com/rhinstaller/anaconda/pull/4287 has been merged, the Anaconda RPMs are now built in a VM. This has been working well, so I think we can drop the Anaconda build deps from the task container.