### PR TITLE
tasks: Hardcode github.com IP address

### DIFF
--- a/tasks/install-service
+++ b/tasks/install-service
@@ -56,6 +56,7 @@ ExecStartPre=/usr/bin/podman network create cockpit-tasks-%i
 ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOSTNAME} \
     --device=/dev/kvm --network=cockpit-tasks-%i \
     --memory=24g --pids-limit=16384 --shm-size=1024m ${TMPVOL:-} \
+    --add-host 'github.com:140.82.121.3' \
     --volume=npm-cache-%i:/work/.npm \
     --volume=\${TEST_CACHE}/images:/cache/images:rw \
     --volume=\${TEST_SECRETS}/tasks:/secrets:ro \


### PR DESCRIPTION
DNS servers in e2e are rather flaky, and tests often fail on resolving github.com. Its IP does not seem to change that often, so hardcode it into tasks container's /etc/hosts.

---

As per discussion with @jelly . I rolled this out on e2e. If we go with this, we should limit it to e2e.