### PR TITLE
tasks: Move to Fedora 37, drop container script labels

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -7,15 +7,12 @@ jobs:
     runs-on: ubuntu-22.04
     environment: quay.io
     timeout-minutes: 30
-    # needs to use docker, as podman-built images are not accepted to RHEL 8's docker any more
-    env:
-      DOCKER: docker
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
 
       - name: Log into container registry
-        run: docker login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        run: podman login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
 
       - name: Build images container
         run: make images-container

--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -7,15 +7,12 @@ jobs:
     runs-on: ubuntu-22.04
     environment: quay.io
     timeout-minutes: 30
-    # needs to use docker, as podman-built images are not accepted to RHEL 8's docker any more
-    env:
-      DOCKER: docker
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
 
       - name: Log into container registry
-        run: docker login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        run: podman login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
 
       - name: Build tasks container
         run: make tasks-container

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -45,9 +45,3 @@ USER user
 EXPOSE 8080 8443
 STOPSIGNAL SIGQUIT
 CMD /usr/sbin/nginx -g "daemon off;"
-
-# We execute the script in the host, but it doesn't exist on the host. So pipe it in
-LABEL INSTALL /usr/bin/docker run -ti --rm --privileged --volume=/:/host:rw --user=root IMAGE /bin/bash -c \"/usr/sbin/chroot /host /bin/sh -s < /usr/local/bin/install-service\"
-
-# Run a simple interactive instance of the tasks container
-LABEL RUN /usr/bin/docker run -ti --rm --publish=80:8080 --publish=8493:8443 --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE /bin/bash -i

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:36
+FROM fedora:37
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
 RUN dnf -y update && \
@@ -71,10 +71,6 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user --home-dir /work
     chown -R user:user /cache /work && \
     printf '[libdefaults]\ndefault_ccache_name = FILE:/tmp/krb5.ccache\n' > /etc/krb5.conf.d/0_file_ccache && \
     echo 'user ALL=NOPASSWD: /usr/bin/chmod 666 /dev/kvm' > /etc/sudoers.d/user-fix-kvm
-
-# HACK: apply https://gitlab.com/libosinfo/osinfo-db/-/merge_requests/481 until
-# it lands in Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=2103835
-RUN sed -i 's_isolinux/_images/pxeboot/_' /usr/share/osinfo/os/fedoraproject.org/fedora-rawhide.xml
 
 ENV LANG=C.UTF-8 \
     TEST_OVERLAY_DIR=/tmp

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -84,12 +84,3 @@ VOLUME /cache/images
 USER user
 WORKDIR /work
 CMD ["/usr/local/bin/cockpit-tasks", "--publish", "$TEST_PUBLISH", "--verbose"]
-
-# We execute the script in the host, but it doesn't exist on the host. So pipe it in
-LABEL INSTALL /usr/bin/docker run -ti --rm --privileged --volume=/:/host:rw --user=root IMAGE /bin/bash -c \"/usr/sbin/chroot /host /bin/sh -s < /usr/local/bin/install-service\"
-
-# Run a simple interactive instance of the tests container
-LABEL RUN /usr/bin/docker run -ti --rm --volume=/var/lib/cockpit-secrets/tasks:/secrets:ro --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE /bin/bash -i
-
-# Start a container in the background; attach to it with "docker exec -it <name> byobu"
-LABEL DEV /usr/bin/docker run -d --volume=/var/cache/cockpit-tasks/images:/cache/images:rw IMAGE sleep infinity


### PR DESCRIPTION
I built this locally and verified that I can build and test cockpit with chromium and firefox.

  - [x] [build](https://github.com/cockpit-project/cockpituous/actions/runs/3326429810) and deploy
  - [x] test with anaconda: https://github.com/rhinstaller/anaconda/pull/4399
  - [x] test with c-machines: https://github.com/cockpit-project/cockpit-machines/pull/838
  - [x] https://github.com/cockpit-project/cockpit/pull/17847