### PR TITLE
tasks: add python3-{build,wheel}

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -38,9 +38,11 @@ RUN dnf -y update && \
         psmisc \
         procps-ng \
         python3 \
+        python3-build \
         python3-flake8 \
         python3-pika \
         python3-pillow \
+        python3-wheel \
         qemu-kvm-core \
         rpm-build \
         rpmdevtools \


### PR DESCRIPTION
There are required to build the binary package (wheel) for the pybridge scenario.

Required for cockpit-project/cockpit#17922.