### PR TITLE
ansible: Fix Python installation

### DIFF
--- a/ansible/aws/tasks/launch-coreos.yml
+++ b/ansible/aws/tasks/launch-coreos.yml
@@ -73,6 +73,6 @@
   loop: "{{ ec2.instances }}"
 
 - name: Install Python for Ansible
-  raw: type python3 || rpm-ostree install --apply-live python3 python3-libselinux python3-pyyaml
+  raw: type python3 || rpm-ostree install -y --apply-live python3 python3-libselinux python3-pyyaml
   delegate_to: "{{ item.public_dns_name | default(item.private_ip_address, true) }}"
   loop: "{{ ec2.instances }}"


### PR DESCRIPTION
`rpm-ostree install` now asks for confirmation, which caused the playbook to hang indefinitely. Add missing `-y` option.

----

I just re-deployed our webhook EC2 instance, mostly to make sure this still works. Can't hurt to refresh it occasionally. And voilà, it didn't..