### PR TITLE
tasks: Drop codecov-token link

### DIFF
--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -64,7 +64,6 @@ RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user --home-dir /work
     mkdir -p /usr/local/bin /secrets /cache/images /cache/github && \
     mkdir -p /work/.config /work/.config/cockpit-dev /work/.ssh /work/.cache /work/.rhel && \
     printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpituous\n[cockpit "bots"]\n\timages-data-dir = /cache/images\n' >/work/.gitconfig && \
-    ln -snf /secrets/codecov-token /work/.config/codecov-token && \
     ln -snf /secrets/s3-keys /work/.config/cockpit-dev/s3-keys && \
     ln -snf /run/secrets/webhook/.config--github-token /work/.config/github-token && \
     chmod g=u /etc/passwd && \


### PR DESCRIPTION
This hasn't been used in two years [1], removed from our secrets git repo, and generally does not belong into our infrastructure -- things like code coverage reports should be generated and uploaded through GitHub workflows these days.

[1] https://github.com/osbuild/cockpit-composer/issues/1631