### PR TITLE
tasks: Drop pyflakes assumption in run-local.sh

### DIFF
--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -261,7 +261,6 @@ test_pr() {
     echo "--------------- test log end -------------"
     assert_in '<html>' "$LOG_HTML"
     assert_in 'Running on:.*cockpituous' "$LOG"
-    assert_in 'python3 -m pyflakes' "$LOG"
     assert_in 'Test run finished, return code: 0' "$LOG"
     # validate test attachment if we ran cockpituous' own tests
     if [ "${PR_REPO%/cockpituous}" != "$PR_REPO" ]; then


### PR DESCRIPTION
bots does not use pyflakes any more, and moved to flake8. It also does
not run its test with `set -x`, so the command doesn't actually appear
in the log. Just drop the assumption, it's not important and just wrong
now.

-----

test/cockpituous from https://github.com/cockpit-project/bots/pull/4129 repeatedly fails, this fixes it.