### PR TITLE
metrics: Move to new CentOS CI OCP

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -19,7 +19,7 @@ regularly read these metrics and store them in a database, and [Grafana](https:/
 
        metrics/deploy.sh
 
-   After that, Grafana should be available at https://grafana-frontdoor.apps.ocp.ci.centos.org and show the Cockpit CI dashboard at https://grafana-frontdoor.apps.ocp.ci.centos.org/d/ci/cockpit-ci
+   After that, Grafana should be available at https://grafana-cockpit.apps.ocp.cloud.ci.centos.org and show the Cockpit CI dashboard at https://grafana-cockpit.apps.ocp.cloud.ci.centos.org/d/ci/cockpit-ci
 
 
 ## Dashboard maintenance
@@ -31,3 +31,7 @@ The metrics are meant to implement and measure our [Service Level objectives](ht
 Whenever you change the dashboard, use the "Dashboard settings" button (cog
 icon at the top right) → JSON model, copy&paste it to
 [cockpit.ci-json](./cockpit-ci.json), and send a pull request to update it.
+
+## CI weather
+
+We also have a [static viewer](https://github.com/cockpit-project/bots/blob/main/tests.html) for the test result database. It is *really* slow, but still has features which Grafana doesn't -- in particular, showing example log URLs for failures. This is deployed as a separate [centosci-ci-weather.yaml](./centosci-ci-weather.yaml) resource and accessible here: https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html

--- a/metrics/centosci-ci-weather.yaml
+++ b/metrics/centosci-ci-weather.yaml
@@ -23,7 +23,7 @@ spec:
               protocol: TCP
               name: http
           volumeMounts:
-          - name: images
+          - name: prometheus-data
             mountPath: /usr/share/nginx/html/
             readOnly: true
           resources:
@@ -34,9 +34,9 @@ spec:
               memory: 200M
               cpu: 100m
       volumes:
-      - name: images
+      - name: prometheus-data
         persistentVolumeClaim:
-          claimName: cockpit-images
+          claimName: prometheus-data
 
 ---
 kind: Service
@@ -58,8 +58,7 @@ spec:
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  # backwards compatible name
-  name: logs-https
+  name: ci-weather
 spec:
   to:
     kind: Service

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -24,7 +24,7 @@ spec:
           - name: prometheus-config
             mountPath: /etc/prometheus/
             readOnly: true
-          - name: prometheus-db
+          - name: prometheus-data
             mountPath: /prometheus
 
       - name: grafana
@@ -61,10 +61,10 @@ spec:
         - name: prometheus-config
           configMap:
             name: prometheus-config
-        - name: prometheus-db
+        - name: prometheus-data
           # from ./prometheus-claim.yaml
           persistentVolumeClaim:
-            claimName: prometheus-db
+            claimName: prometheus-data
         - name: grafana-config
           configMap:
             name: grafana-config

--- a/metrics/prometheus-claim.yaml
+++ b/metrics/prometheus-claim.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: prometheus-db
-  namespace: frontdoor
+  name: prometheus-data
+  namespace: cockpit
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 5Gi


### PR DESCRIPTION
The project name on the new OpenShift cluster is now "cockpit". The
PVC name changed, and the claim now only guarantees 5 GiB.

Add a paragraph about the CI weather to README.

---

I rolled this out to validate our [onboarding request](https://pagure.io/centos-infra/issue/991#comment-831950), and it works. I also copied over our `test-results.db`. Of course the [Grafana board](https://grafana-cockpit.apps.ocp.cloud.ci.centos.org/d/ci/cockpit-ci) is still rather empty, as the prometheus database was reset.

The weather report also works.

Currently, prometheus is not being updated, and the [statistics queue](http://webhook-cockpit.apps.ocp.cloud.ci.centos.org/inspect-queue) is growing. This is because the old CentOS CI cluster cannot talk to the webhook/AMQP queue on the new CentOS CI cluster, so I just shut down the tasks container there. I will soon replace this with some stripped down tasks container which *only* processes the statistics queue (see https://github.com/cockpit-project/bots/pull/4162). But let's land these other two pieces for now.
