### PR TITLE
tasks: Adjust CentOS CI tasks runner spec for statistics-only mode

### DIFF
--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -1,10 +1,11 @@
 ---
+# CentOS CI does not have /dev/kvm support, so this *only* processes the statistics queue
 apiVersion: v1
 kind: ReplicationController
 metadata:
   name: centosci-tasks
 spec:
-  replicas: 5
+  replicas: 1
   selector:
     infra: cockpit-tasks
   template:
@@ -17,8 +18,6 @@ spec:
       - name: cockpit-tasks
         image: quay.io/cockpit/tasks
         env:
-        - name: TEST_JOBS
-          value: '6'
         - name: RUN_STATISTICS_QUEUE
           value: '1'
         volumeMounts:
@@ -30,21 +29,15 @@ spec:
           readOnly: true
         - name: cache
           mountPath: "/cache"
-        - name: images
+        - name: prometheus-data
           mountPath: "/cache/images"
-        - name: shm
-          mountPath: "/dev/shm"
-        - name: tmp
-          mountPath: "/tmp"
         resources:
           limits:
-            memory: 24Gi
-            cpu: 10
-            devices.kubevirt.io/kvm: 1
+            memory: 1Gi
+            cpu: 1
           requests:
-            memory: 16Gi
-            cpu: 5
-            devices.kubevirt.io/kvm: 1
+            memory: 256Mi
+            cpu: 0.2
       volumes:
       - name: secrets
         secret:
@@ -54,13 +47,7 @@ spec:
           secretName: webhook-secrets
       - name: cache
         emptyDir: {}
-      - name: images
+      - name: prometheus-data
+        # from ./prometheus-claim.yaml; using this also to store test-results.db
         persistentVolumeClaim:
-          claimName: cockpit-images
-      - name: shm
-        emptyDir:
-          medium: Memory
-      - name: tmp
-        emptyDir:
-          medium: Memory
-          sizeLimit: 14G
+          claimName: prometheus-data


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/4162 adjusted run-queue to skip processing tasks queues in environments without /dev/kvm. That is the case on the new CentOS CI cluster. We still need a single task runner to process the statistics queue, as our `test-results.db` can only be written from CentOS CI.
    
Turn down the resource allocation, this hardly needs any CPU/RAM. Also adjust the persistent volume to re-use our "prometheus-data" PVC, which is where we store our `test-results.db`.

----

I rolled this out, and the tasks instance successfully processed the "statistics" queue backlog (we previously had about 10 items since we moved to the CentOS CI webhook yesterday). 

The last entry in the queue was this:
```json
{"command": "./store-tests --db /cache/images/test-results.db --repo cockpit-project/cockpit-podman eab0d1e165a4ca3870106610c7575f8c91f61430 && ./prometheus-stats --db /cache/images/test-results.db --s3 https://cockpit-logs.us-east-1.linodeobjects.com/prometheus"}
```

That podman PR is now in the database:
```
$ curl -O https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/test-results.db
$ sqlite3 test-results.db "SELECT * FROM TestRuns WHERE revision == 'eab0d1e165a4ca3870106610c7575f8c91f61430'"
33781|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|arch|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-arch/log.html|1670941691|0|32|667|success|
33782|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|rhel-8-7|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-rhel-8-7/log.html|1670941692|0|19|914|success|
33783|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|rhel-8-8|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-rhel-8-8/log.html|1670941692|0|20|731|success|
33784|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|rhel-9-1|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-rhel-9-1/log.html|1670941692|0|20|731|success|
33785|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|fedora-36|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-fedora-36/log.html|1670941692|0|35|791|success|
33786|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|fedora-37|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-fedora-37/log.html|1670941693|0|35|730|success|
33787|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|fedora-36/devel|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-fedora-36-devel/log.html|1670941693|0|36|793|success|
33788|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|fedora-coreos|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-fedora-coreos/log.html|1670941693|0|37|736|success|
33789|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|debian-testing|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-debian-testing/log.html|1670941694|0|37|792|success|
33790|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|ubuntu-2204|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-ubuntu-2204/log.html|1670941694|0|45|736|success|
33791|cockpit-project/cockpit-podman|eab0d1e165a4ca3870106610c7575f8c91f61430|ubuntu-stable|https://cockpit-logs.us-east-1.linodeobjects.com/pull-1157-20221213-142814-eab0d1e1-ubuntu-stable/log.html|1670941694|0|49|732|success|
```

 - [x] Land https://github.com/cockpit-project/bots/pull/4162
 - [x] Drop the second commit which changes the bots branch