### PR TITLE
tasks: Clean up libvirt files between runs

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -81,6 +81,7 @@ for i in $(seq 1 30); do
     virsh list --id --all | xargs --no-run-if-empty virsh destroy
     pkill -9 virtqemud || true
     while pgrep virtqemud >/dev/null; do sleep 0.5; done
+    rm -rf ~/.config/libvirt ~/.cache/libvirt
 
     # run-queue fails on empty queues; don't poll too often
     timeout 12h ./run-queue ${AMQP_SERVER:+--amqp} ${AMQP_SERVER:-} || slumber


### PR DESCRIPTION
Containers sometimes got into a state where each libvirt invocation failed like this:

    libvirt: XML-RPC error : Failed to connect socket to '/work/.cache/libvirt/virtqemud-sock':
    No such file or directory

This was because we killed virtqemud, but it didn't clean up its state in ~/.cache/libvirt/run. Make sure that this happens.

----

This is a common infra-like failure. Equally importantly, it's time to refresh our tasks container to the current browser versions.

 - [x] [build new tasks container](https://github.com/cockpit-project/cockpituous/actions/runs/4679978778)
 - [x] test it locally with firefox and chromium
 - [x] deploy it
 - [x] test on our infra with [chromium](https://github.com/cockpit-project/cockpit-podman/pull/1265) and [firefox](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18626-20230412-154411-13297e9c-fedora-37-firefox/log.html)