### PR TITLE
tasks: Install ruff

### DIFF
--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -54,7 +54,8 @@ RUN dnf -y update && \
     curl -o /tmp/cockpit.spec -s https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec | \
     dnf -y builddep /tmp/cockpit.spec && \
     rm /tmp/cockpit.spec && \
-    dnf clean all
+    dnf clean all && \
+    pip install ruff
 
 COPY cockpit-tasks install-service webhook github_handler.py /usr/local/bin/
 

--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -18,7 +18,6 @@ RUN dnf -y update && \
         git \
         gnupg \
         gobject-introspection-devel \
-        golang-github-evanw-esbuild \
         google-noto-cjk-fonts-common \
         intltool \
         jq \


### PR DESCRIPTION
In our projects we have used ruff long enough to commit to it. Let's
have it in our development toolboxes by default then, so that we don't
keep sending PRs which break ruff rules.

This also enables our other projects to start using ruff in CI (which
runs in tasks, instead of a dedicated unit-tests container).

 - [x] [refresh container](https://github.com/cockpit-project/cockpituous/actions/runs/5342431309/jobs/9684247831)
 - [x] locally smoke-test it with ffox and chromium in toolbox
 - [x] deploy it
 - [x] regression check for firefox/chromium on cockpit, and pixel updates: https://github.com/cockpit-project/cockpit/pull/18990
 - [x] regression check for podman, with ruff and pixel updates: https://github.com/cockpit-project/cockpit-podman/pull/1311
 - [x] regression check for machines: [ruff updates](https://github.com/cockpit-project/cockpit-machines/pull/1114), [pixel updates](https://github.com/cockpit-project/cockpit-machines/pull/1115)
 - [x] ostree pixel update: https://github.com/cockpit-project/cockpit-ostree/pull/378