### PR TITLE
ansible: Fix OpenStack setup for Fedora 38

### DIFF
--- a/ansible/psi/README.md
+++ b/ansible/psi/README.md
@@ -12,7 +12,7 @@ The only change that was, and currently needs to be done manually is to add SSH,
 Automation setup
 ----------------
 
-You need to install the OpenStack SDK, either with `sudo dnf install python3-openstacksdk` (on Fedora), or `pip install openstacksdk`.
+You need to install the OpenStack SDK, either with `sudo dnf install python3-openstacksdk` (on Fedora), or `pip install openstacksdk`. If you run on Fedora 38, you also need to install the `ansible-collections-openstack` package (see [bz#2218141](https://bugzilla.redhat.com/show_bug.cgi?id=2218141)).
 
 After that, you need to set up `~/.config/openstack/clouds.yml`. If you don't already have one, copy or symlink [clouds.yml](./clouds.yml), otherwise merge it with your existing one. You need to create a file `~/.config/openstack/secure.yaml` for your credentials, see the comment in [clouds.yml](./clouds.yml) for how to do that.
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2218141

----

@marusak , @allisonkarlitskaya : This works fine for me (I upped https://bodhi.fedoraproject.org/updates/FEDORA-2023-88df046168). Until it lands, you must grab the version from bodhi, I used 

    sudo dnf install https://kojipkgs.fedoraproject.org//packages/ansible-collections-openstack/2.1.0/1.fc38/noarch/ansible-collections-openstack-2.1.0-1.fc38.noarch.rpm