### PR TITLE
tasks: Put back python3-pyyaml

### DIFF
--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -43,6 +43,7 @@ RUN dnf -y update && \
         python3-pika \
         python3-pillow \
         python3-pip \
+        python3-pyyaml \
         python3-wheel \
         qemu-kvm-core \
         rpm-build \


### PR DESCRIPTION
This is still used by older Cockpit test APIs, for old subscription-manager branches.

---

See https://github.com/cockpit-project/bots/pull/5267

I [rebuilt the container](https://github.com/cockpit-project/cockpituous/actions/runs/6205223414) and rolled it out.