### PR TITLE
tasks: Reset SELinux level of images on startup

### DIFF
--- a/tasks/install-service
+++ b/tasks/install-service
@@ -50,6 +50,8 @@ RestartSec=60
 TimeoutStartSec=10min
 ExecStartPre=-/usr/bin/podman rm -f cockpit-tasks-%i
 ExecStartPre=-/usr/bin/podman network rm cockpit-tasks-%i
+# HACK: sometimes images get an MCS category which makes them undeletable by the container
+ExecStartPre=/usr/bin/chcon -R -l s0 \${TEST_CACHE}/images/
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull podman pull quay.io/cockpit/tasks
 ExecStartPre=/usr/bin/podman network create cockpit-tasks-%i
 ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOSTNAME} \


### PR DESCRIPTION
In some situations (in particular the fedora-rawhide-boot and -payload images) gain an extra SELinux "Multi-category range" context like this:

    system_u:object_r:container_file_t:s0:c220,c230  fedora-rawhide-boot-ba19e37f2b38f6578574275b7eb209e5b1850bceb9eb671cb366db16e4bf78fc.iso

This makes them undeletable by `image-prune`, `rm`, or anything else that the container could do. This causes old images to pile up, and the host eventually fails with ENOSPC.

There is nothing that the container can do to fix these files, and it's not clear what causes this in the first place. To mitigate, reset the context level in the system unit at startup.

----

Our bots have ran into ENOSPC quite frequently, but so far I had always only quick-fixed this by mass-deleting the image cache. This should fix it more permanently.

I rolled this out to all our bots. I confirmed it fixed the broken contexts on cockpit-10, so by tomorrow, cockpit-10 should do an image-prune run and clean up its current 501 GB in /var/cache/cockpit-tasks/images/