### PR TITLE
Add fedora-logos in the Dockerfile

### DIFF
--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -11,6 +11,7 @@ RUN dnf -y update && \
         dbus-glib \
         diffstat \
         expect \
+        fedora-logos \
         firefox \
         fpaste \
         gcc-c++ \


### PR DESCRIPTION
Needed by anaconda-webui RPM.