### PR TITLE
Completely remove Anaconda build dependencies

### DIFF
--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -17,13 +17,11 @@ RUN dnf -y update && \
         genisoimage \
         git \
         gnupg \
-        gobject-introspection-devel \
         google-noto-cjk-fonts-common \
         intltool \
         jq \
         lcov \
         libappstream-glib \
-        libtool \
         libvirt-daemon-driver-storage-core \
         libvirt-daemon-driver-qemu \
         libvirt-client \


### PR DESCRIPTION
We don't build anaconda-core from sources anymore. We do that for the anaconda-webui only, but this is not needed for it.

Followup for 593d3d18629adc0b0cea17e332a8c5bec6394652.