### PR TITLE
ansible: Adjust to Openstack SDK 1.0 Ansible API changes, update PSI workers to Fedora 39

### DIFF
--- a/ansible/psi/deploy-all.sh
+++ b/ansible/psi/deploy-all.sh
@@ -6,7 +6,7 @@ set -eu
 cd "$(dirname $(dirname $(realpath $0)))"
 
 # number of instances; limited by quota
-NUM=16
+NUM=35
 
 seq $NUM | parallel --line-buffer -j4 ansible-playbook -i inventory/ -e instance_name='rhos-01-{}' psi/launch-tasks.yml
 

--- a/ansible/psi/psi_defaults.yml
+++ b/ansible/psi/psi_defaults.yml
@@ -1,6 +1,6 @@
 ---
 psi_cloud: "rhos-01"
-psi_image: "Fedora-Cloud-Base-37-latest"
+psi_image: "Fedora-Cloud-Base-39-latest"
 psi_user: "fedora"
 # 16 VCPUs, 32 GiB RAM, 160 GB disk
 psi_flavor: "ci.standard.xxxl"

--- a/ansible/roles/launch-openstack-instance/tasks/main.yml
+++ b/ansible/roles/launch-openstack-instance/tasks/main.yml
@@ -38,7 +38,7 @@
   copy:
     dest: '{{ deployment_key_path }}'
     mode: 0600
-    content: '{{ ssh_key.key.private_key }}'
+    content: '{{ ssh_key.keypair.private_key }}'
 
 - name: Launch instance
   os_server:
@@ -66,18 +66,17 @@
 
 - name: Add instance to temporary 'launched' inventory group
   add_host:
-    hostname: '{{ instance.openstack.interface_ip }}'
+    hostname: '{{ instance.server.addresses[network][0].addr }}'
     ansible_ssh_user: '{{ deployment_ssh_user }}'
     ansible_become: true
     ansible_ssh_private_key_file: '{{ deployment_key_path }}'
     ansible_python_interpreter: python3
     # unfortunately the host FP is not part of the os_server result; but *shrug*, we just created this instance, there is no way to know
     ansible_ssh_extra_args: -o StrictHostKeyChecking=no
-    openstack: '{{ instance.openstack }}'
     groupname: launched
 
 # we can't run Ansible yet with CoreOS (no Python!), so just ping port
 - name: Wait for SSH to come up
   wait_for:
-    host: '{{ instance.openstack.interface_ip }}'
+    host: '{{ instance.server.addresses[network][0].addr }}'
     port: 22


### PR DESCRIPTION
To debug some ongoing network issue, I'm redeploying a few (or soon, all) rhos workers.