### PR TITLE
tasks: add podman-remote

### DIFF
--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -22,20 +22,21 @@ RUN dnf -y update && \
         intltool \
         jq \
         lcov \
-        libappstream-glib \
-        libvirt-daemon-driver-storage-core \
-        libvirt-daemon-driver-qemu \
-        libvirt-client \
-        libvirt-python3 \
         libXt \
+        libappstream-glib \
+        libvirt-client \
+        libvirt-daemon-driver-qemu \
+        libvirt-daemon-driver-storage-core \
+        libvirt-python3 \
         nc \
         net-tools \
         nodejs-devel \
         npm \
         passwd \
         pigz \
-        psmisc \
+        podman-remote \
         procps-ng \
+        psmisc \
         python3 \
         python3-build \
         python3-flake8 \
@@ -53,7 +54,8 @@ RUN dnf -y update && \
         tar \
         valgrind \
         vim-enhanced \
-        virt-install && \
+        virt-install \
+	&& \
     curl -o /tmp/cockpit.spec -s https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec && \
     dnf -y builddep --setopt=install_weak_deps=False /tmp/cockpit.spec && \
     rm /tmp/cockpit.spec && \


### PR DESCRIPTION
This is equivalent to `podman --remote` and sends commands to a running daemon.  We can use this to communicate with a podman daemon running outside of the container with its socket bind-mounted in.

Also, sort!