### PR TITLE
ansible: Document how to run a playbook against a local VM

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -7,3 +7,14 @@ Setup/maintenance Ansible playbooks for Front Door CI
  * [e2e](./e2e/): Playbooks for configuring CI on e2e machines
  * [roles](./roles/): Ansible roles for common setup steps
  * [maintenance](./maintenance/): Ansible playbooks for maintenance tasks on all CI machines
+
+Testing against a local VM
+---------------------------
+
+You can run the Ansible playbooks or roles against a local VM for development.
+There is an example [localvm inventory](./inventory/localvm) which adds the
+[standard cockpit](https://github.com/cockpit-project/cockpit/blob/main/test/README.md#convenient-test-vm-ssh-access)
+`c` SSH machine. Start e.g. a `fedora-coreos` or `fedora-39` VM, and locally
+adjust the `hosts:` playbook you are working on from e.g. `e2e` to `localvm`
+(the playbooks don't do that by default to avoid errors about unreachable
+host).

--- a/ansible/e2e/setup.yml
+++ b/ansible/e2e/setup.yml
@@ -18,16 +18,11 @@
     command: passwd -l root
 
   - name: Disable zezere service
-    service:
-      name: zezere_ignition.timer
-      state: stopped
-      enabled: no
-
-  - name: Disable zezere banner
-    service:
-      name: zezere_ignition_banner.service
-      state: stopped
-      enabled: no
+    shell: |
+      if systemctl list-unit-files zezere_ignition.timer; then
+        systemctl disable --now zezere_ignition.timer
+        systemctl disable --now zezere_ignition_banner.service
+      fi
 
   - name: Disable unconnected network interfaces to avoid NM-wait-online timeout
     copy:

--- a/ansible/inventory/localvm
+++ b/ansible/inventory/localvm
@@ -1,0 +1,3 @@
+[localvm]
+# standard cockpit test VM from bots
+c


### PR DESCRIPTION
Add an example inventory for our standard cockpit bots `c` machine. It should be obvious from there how to extend it.