### PR TITLE
tasks: Fix OpenShift instances

### DIFF
--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -11,6 +11,11 @@ COCKPIT_BOTS_BRANCH=${COCKPIT_BOTS_BRANCH:-main}
 WORKDIR="$PWD"
 BOTS_DIR="$WORKDIR"/bots
 
+# OpenShift instances with their random user don't set $HOME
+if [ -z "${HOME:-}" ] || [ "$HOME" = / ]; then
+    export HOME=/work
+fi
+
 echo "Starting testing"
 
 function update_bots() {


### PR DESCRIPTION
Commit 93523ff684b15e broke OpenShift deployments: The `export HOME` from `setup-tasks` isn't visible in the main `cockpit-tasks` loop, so the GitHub API fails to resolve the user's home dir.

Put it back for now. This is far from elegant, but we need to unbreak the statistics queue quickly.

----

http://webhook-cockpit.apps.ocp.cloud.ci.centos.org/inspect-queue is building up a lot of pending `statistics` requests, it fails with
```
Traceback (most recent call last):
File "/work/bots/./run-queue", line 36, in <module>
from task import distributed_queue
File "/work/bots/task/__init__.py", line 51, in <module>
api = github.GitHub()
^^^^^^^^^^^^^^^
File "/work/bots/task/github.py", line 157, in __init__
self.log = Logger(self.cache.directory)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/work/bots/task/github.py", line 71, in __init__
os.makedirs(directory, exist_ok=True)
File "<frozen os>", line 215, in makedirs
File "<frozen os>", line 225, in makedirs
PermissionError: [Errno 13] Permission denied: '/.cache'
```