### PR TITLE
tasks: add python3-aiohttp and aioresponses

### DIFF
--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -38,6 +38,8 @@ RUN dnf -y update && \
         procps-ng \
         psmisc \
         python3 \
+        python3-aiohttp+speedups \
+        python3-aioresponses \
         python3-build \
         python3-flake8 \
         python3-pika \


### PR DESCRIPTION
This seems to be the standard Python asyncio HTTP library. python3-aioresponses is a useful mocking framework for use with pytest.

We're going to be using these soon.