### PR TITLE
Revert "tasks: Drop CentOS CI OpenShift deployment"

### DIFF
--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -1,0 +1,53 @@
+---
+# CentOS CI does not have /dev/kvm support, so this *only* processes the statistics queue
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: centosci-tasks
+spec:
+  replicas: 1
+  selector:
+    infra: cockpit-tasks
+  template:
+    metadata:
+      labels:
+        infra: cockpit-tasks
+    spec:
+      terminationGracePeriodSeconds: 3600
+      containers:
+      - name: cockpit-tasks
+        image: quay.io/cockpit/tasks
+        env:
+        - name: RUN_STATISTICS_QUEUE
+          value: '1'
+        volumeMounts:
+        - name: secrets
+          mountPath: "/secrets"
+          readOnly: true
+        - name: webhook-secrets
+          mountPath: /run/secrets/webhook
+          readOnly: true
+        - name: cache
+          mountPath: "/cache"
+        - name: prometheus-data
+          mountPath: "/cache/images"
+        resources:
+          limits:
+            memory: 1Gi
+            cpu: 1
+          requests:
+            memory: 256Mi
+            cpu: 0.2
+      volumes:
+      - name: secrets
+        secret:
+          secretName: cockpit-tasks-secrets
+      - name: webhook-secrets
+        secret:
+          secretName: webhook-secrets
+      - name: cache
+        emptyDir: {}
+      - name: prometheus-data
+        # from ./prometheus-claim.yaml; using this also to store test-results.db
+        persistentVolumeClaim:
+          claimName: prometheus-data

--- a/tasks/images-claim-centosci.yaml
+++ b/tasks/images-claim-centosci.yaml
@@ -1,0 +1,13 @@
+# persistent image cache volume for tasks containers and our test-results.db database (for CI weather)
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cockpit-images
+  namespace: frontdoor
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi


### PR DESCRIPTION
This was premature -- we *do* have an OpenShift tasks deployment on CentOS CI, with a single pod that processes the `statistics` queue.

This mostly reverts commit 2ef32979f8c7d8ad1318405c166c4088b603185c. Adjust the documentation to current reality.

----

Spotted while @allisonkarlitskaya and I talked about CI design. This is [very much alive](https://console-openshift-console.apps.ocp.cloud.ci.centos.org/k8s/ns/cockpit/pods).