### PR TITLE
ansible: Apply "execheap" SELinux policy hack

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -5,6 +5,28 @@
     dest: /run/install-service
     mode: preserve
 
+- name: Create custom SELinux rules to fix Chromium
+  copy:
+    dest: /tmp/cockpituous.te
+    mode: 0644
+    content: |
+      module cockpituous 1.0;
+      require {
+              type container_t;
+              class process execheap;
+      }
+
+      # HACK: See https://github.com/cockpit-project/cockpituous/issues/579
+      allow container_t self:process execheap;
+  register: selinux_policy
+
+- name: Install custom SELinux rules
+  shell: |
+    checkmodule -M -m -o /tmp/cockpituous.mod /tmp/cockpituous.te
+    semodule_package -o /tmp/cockpituous.pp -m /tmp/cockpituous.mod
+    semodule -i /tmp/cockpituous.pp
+  when: selinux_policy.changed
+
 - name: Set up systemd service for cockpit/tasks
   shell: |
     export INSTANCES={{ instances | default(4) }}


### PR DESCRIPTION
With current Fedora 39, Chromium often runs into these crashes:

```
AVC avc:  denied  { execheap } for  pid=3725873 comm="ThreadPoolForeg" scontext=system_u:system_r:container_t:s0:c439,c758 tcontext=system_u:system_r:container_t:s0:c439,c758 tclass=process permissive=0
systemd-coredump[3725903]: [Process 3725873 (headless_shell) of user 1111 terminated abnormally without generating a coredump.
```

This causes the browser to hang, and the test force-killed after the timeout.

The general tone in past bug reports is that this is intended -- heap shouldn't be writable and executable at the same time. So Chromium is doing something dubious here.

This isn't something we can easily influence, so just poke a hole into the policy.

This was generated by collecting the full denial with `ausearch -c 'ThreadPoolForeg' --raw`, and feeding the result into `audit2allow`:

```
echo 'type=AVC msg=audit(1709124430.347:10808): avc:  denied  { execheap } for  pid=150495 comm="ThreadPoolForeg" scontext=system_u:system_r:container_t:s0:c114,c423 tcontext=system_u:system_r:container_t:s0:c114,c423 tclass=process permissive=1' | audit2allow -M cockpituous
```

Fixes #579

----

I rolled this out to our infra. Let's check tomorrow morning if it actually worked. **Update**: It did, and it's still necessary with Chromium 122.