### PR TITLE
ansible: Clean up old container images in deploy-tasks-container.yml

### DIFF
--- a/ansible/maintenance/deploy-tasks-container.yml
+++ b/ansible/maintenance/deploy-tasks-container.yml
@@ -12,6 +12,10 @@
   gather_facts: false
 
   tasks:
+  - name: Clean up old container images
+    # this will fail due to at least one used image, but it's opportunistic anyway
+    shell: podman rmi --all || true
+
   - name: Pre-pull current container image to avoid long downtime
     command: podman pull quay.io/cockpit/tasks
 
@@ -22,6 +26,9 @@
   gather_facts: false
 
   tasks:
+  - name: Clean up old container images
+    shell: podman rmi --all || true
+
   - name: Pre-pull current container image to avoid long downtime
     command: podman pull quay.io/cockpit/tasks
 


### PR DESCRIPTION
Our machines have piled up a few dozen GB of old tasks containers. This will keep the current and the new image, and get rid of all older ones.

----

I validated that this works while deploying the new tasks container for https://github.com/cockpit-project/cockpit/pull/20107#issuecomment-1970732087