### PR TITLE
tasks: Bind the host's podman API socket

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,14 @@ jobs:
           git config user.email github-actions@github.com
           git rebase origin/main
 
+      # HACK: Ubuntu 22.04 has podman 3.4, which isn't compatible with podman-remote 4 in our tasks container
+      # This PPA is a backport of podman 4.3 from Debian 12; drop this when moving `runs-on:` to ubuntu-24.04
+      - name: Update to newer podman
+        run: |
+          sudo add-apt-repository -y ppa:quarckster/containers
+          sudo apt install -y podman
+          systemctl --user daemon-reload
+
       - name: Check which containers changed
         id: containers_changed
         run: |

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -36,6 +36,8 @@ touch "$IMAGE_STORES"
 cat <<EOF > /etc/systemd/system/cockpit-tasks@.service
 [Unit]
 Description=Cockpit Tasks %i
+Requires=podman.socket
+After=podman.socket
 
 [Service]
 Environment="TEST_JOBS=${TEST_JOBS:-8}"
@@ -53,6 +55,8 @@ ExecStartPre=-/usr/bin/podman network rm cockpit-tasks-%i
 ExecStartPre=/usr/bin/chcon -R -l s0 \${TEST_CACHE}/images/
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull podman pull quay.io/cockpit/tasks
 ExecStartPre=/usr/bin/podman network create cockpit-tasks-%i
+# idmapped mount would be better, but did not figure out how
+ExecStartPre=/usr/bin/chgrp 1111 %t/podman/podman.sock
 ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOSTNAME} \
     --device=/dev/kvm --network=cockpit-tasks-%i \
     --memory=24g --pids-limit=16384 --shm-size=1024m ${TMPVOL:-} \
@@ -61,8 +65,10 @@ ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOS
     --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro \
     --volume=${IMAGE_STORES}:/work/.config/cockpit-dev/image-stores:ro \
     --volume=/etc/npmrc:/etc/npmrc:ro \
+    --volume=%t/podman/podman.sock:/podman.sock:rw \
     --env=COCKPIT_GITHUB_TOKEN_FILE=/run/secrets/webhook/.config--github-token \
     --env=COCKPIT_S3_KEY_DIR=/run/secrets/tasks/s3-keys \
+    --env=CONTAINER_HOST=unix:///podman.sock \
     --env=TEST_JOBS=\${TEST_JOBS} \
     --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} \
     --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} \


### PR DESCRIPTION
tasks: Bind the host's podman API socket

This paves the way for spawning per-job tasks containers from the
container (via `job-runner`).

Getting the permissions right is unfortunately annoyingly complicated, as the
host's socket has 660 permissions, but the tasks container runs as uid 1111.
Ideally we could use something like

    -v "${XDG_RUNTIME_DIR:-/run}/podman/podman.sock:/podman.sock:idmap=gids=$(id -g)-1111-1"

but that fails with "invalid mappings", and is generally not well documented.
`--mount=type=bind,[...],idmap --uidmap [...]` does not work either.

So resort to file permissions for the host's `podman.sock`:
 - For local developers in `run-local.sh`, make the socket world
   writable. This does not actually hurt for a human developer: Its
   directory (/run/user/uid) is not accessible for any other user.

 - For production, set the socket group to `1111`. That doesn't matter
   much, the secrets are all already chmod'ed to the container user, and
   these machines don't do anything else. `setfacl` would be more
   targeted, but it isn't installed in Fedora IoT/CoreOS.


-----

I rolled this out to one production machine:

    ansible -i inventory -m include_role -a name=tasks-systemd -e instances=1 -l rhos-01-1 openstack_tasks

Et voilà:
```
❱❱❱ ssh rhos-01-1 sudo podman exec -it cockpit-tasks-1 podman-remote ps
Warning: Permanently added '10.0.203.194' (ED25519) to the list of known hosts.
CONTAINER ID  IMAGE                         COMMAND               CREATED        STATUS        PORTS                 NAMES
51ef06c0f09c  quay.io/minio/minio:latest    server /data          4 days ago     Up 4 days     0.0.0.0:80->9000/tcp  cockpit-s3
ea0bd1fbcc99  quay.io/cockpit/tasks:latest  /usr/local/bin/co...  5 minutes ago  Up 5 minutes                        cockpit-tasks-1
```

Once this lands, I'll apply it to all our production machines.