### PR TITLE
tasks: Add local mock PR run to run-local.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ tasks-shell:
 	$(DOCKER) run -ti --rm \
 		--shm-size=1024m \
 		--volume=$(CURDIR)/tasks:/usr/local/bin \
-		--volume=$(TASK_SECRETS):/secrets:ro \
+		--volume=$(TASK_SECRETS):/run/secrets/tasks/:ro \
 		--volume=$(WEBHOOK_SECRETS):/run/secrets/webhook/:ro \
 		--volume=$(TASK_CACHE):/cache:rw \
 		--entrypoint=/bin/bash \

--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -86,4 +86,3 @@ VOLUME /cache/images
 
 USER user
 WORKDIR /work
-CMD ["/usr/local/bin/cockpit-tasks", "--verbose"]

--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -68,13 +68,11 @@ COPY setup-tasks cockpit-tasks install-service webhook github_handler.py /usr/lo
 
 RUN groupadd -g 1111 -r user && useradd -r -g user -u 1111 user --home-dir /work && \
     groupadd -g 1001 -r github && useradd -r --no-create-home -g github -u 1001 github && \
-    mkdir -p /usr/local/bin /secrets /cache/images /cache/github && \
+    mkdir -p /usr/local/bin /cache/images /cache/github && \
     mkdir -p /work/.config /work/.config/cockpit-dev /work/.ssh /work/.cache /work/.rhel && \
     printf '[user]\n\t\nemail = cockpituous@cockpit-project.org\n\tname = Cockpituous\n[cockpit "bots"]\n\timages-data-dir = /cache/images\n' >/work/.gitconfig && \
-    ln -snf /secrets/s3-keys /work/.config/cockpit-dev/s3-keys && \
-    ln -snf /run/secrets/webhook/.config--github-token /work/.config/github-token && \
     chmod g=u /etc/passwd && \
-    chmod -R ugo+w /cache /secrets /cache /work && \
+    chmod -R ugo+w /cache /work && \
     chown -R user:user /cache /work && \
     printf '[libdefaults]\ndefault_ccache_name = FILE:/tmp/krb5.ccache\n' > /etc/krb5.conf.d/0_file_ccache && \
     echo 'user ALL=NOPASSWD: /usr/bin/chmod 666 /dev/kvm' > /etc/sudoers.d/user-fix-kvm

--- a/tasks/cockpit-tasks
+++ b/tasks/cockpit-tasks
@@ -4,9 +4,6 @@ set -eux
 
 setup-tasks
 
-COCKPIT_BOTS_REPO=${COCKPIT_BOTS_REPO:-https://github.com/cockpit-project/bots}
-COCKPIT_BOTS_BRANCH=${COCKPIT_BOTS_BRANCH:-main}
-
 # let's just do our work in the current directory
 WORKDIR="$PWD"
 BOTS_DIR="$WORKDIR"/bots
@@ -19,11 +16,7 @@ fi
 echo "Starting testing"
 
 function update_bots() {
-    if [ -d "$BOTS_DIR" ]; then
-        git -C "$BOTS_DIR" pull --rebase
-    else
-        git clone --quiet -b "$COCKPIT_BOTS_BRANCH" "$COCKPIT_BOTS_REPO" "$BOTS_DIR"
-    fi
+    git -C "$BOTS_DIR" pull --rebase
 }
 
 # wait between 1 and 10 minutes, but not in an interactive terminal (annoying for debugging)

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -22,7 +22,7 @@ spec:
           value: '1'
         volumeMounts:
         - name: secrets
-          mountPath: "/secrets"
+          mountPath: /run/secrets/tasks
           readOnly: true
         - name: webhook-secrets
           mountPath: /run/secrets/webhook

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -70,7 +70,7 @@ ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOS
     --env=TEST_JOBS=\${TEST_JOBS} \
     --env=TEST_NOTIFICATION_MX=\${TEST_NOTIFICATION_MX} \
     --env=TEST_NOTIFICATION_TO=\${TEST_NOTIFICATION_TO} \
-    quay.io/cockpit/tasks
+    quay.io/cockpit/tasks cockpit-tasks --verbose
 ExecStop=/usr/bin/podman rm -f cockpit-tasks-%i
 ExecStop=/usr/bin/podman network rm cockpit-tasks-%i
 

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -23,7 +23,7 @@ chown -R 1111:1111 $SECRETS $CACHE
 chcon -R -t container_file_t $SECRETS $CACHE
 
 if [ -e "${SECRETS}/tasks/npm-registry.crt" ]; then
-    NODE_EXTRA_CA_CERTS=/secrets/npm-registry.crt
+    NODE_EXTRA_CA_CERTS=/run/secrets/tasks/npm-registry.crt
 fi
 
 if [ $INSTANCES -eq 1 ]; then
@@ -62,7 +62,7 @@ ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOS
     --device=/dev/kvm --network=cockpit-tasks-%i \
     --memory=24g --pids-limit=16384 --shm-size=1024m ${TMPVOL:-} \
     --volume=\${TEST_CACHE}/images:/cache/images:rw \
-    --volume=\${TEST_SECRETS}/tasks:/secrets:ro \
+    --volume=\${TEST_SECRETS}/tasks:/run/secrets/tasks:ro \
     --volume=\${TEST_SECRETS}/webhook:/run/secrets/webhook:ro \
     --volume=${IMAGE_STORES}:/work/.config/cockpit-dev/image-stores:ro \
     --env=NPM_REGISTRY=\${NPM_REGISTRY} \

--- a/tasks/mock-github-pr
+++ b/tasks/mock-github-pr
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Mock GitHub API server for testing an opened PR
+# You can run this manually in `tasks/run-local.sh -i` with `podman cp` and running
+# cd bots
+# PYTHONPATH=. ./mock-github-pr cockpit-project/bots $(git rev-parse HEAD) &
+# export GITHUB_API=http://127.0.0.7:8443
+# PYTHONPATH=. ./mock-github-pr --print-event cockpit-project/bots $(git rev-parse HEAD) | \
+#     ./publish-queue --amqp localhost:5671 --queue webhook
+#
+# and then two `./run-queue --amqp localhost:5671`
+# first to process webhook → tests-scan → public, second to actually run it
+
+import argparse
+import json
+import os
+import tempfile
+
+from task.test_mock_server import MockHandler, MockServer
+
+repo = None
+sha = None
+
+
+class Handler(MockHandler):
+    def do_GET(self):
+        if self.path in self.server.data:
+            self.replyJson(self.server.data[self.path])
+        elif self.path.startswith(f'/repos/{repo}/pulls?'):
+            self.replyJson([self.server.data[f'/repos/{repo}/pulls/1']])
+        elif self.path == f'/{repo}/{sha}/.cockpit-ci/container':
+            self.replyData('quay.io/cockpit/tasks')
+        else:
+            self.send_error(404, 'Mock Not Found: ' + self.path)
+
+    def do_POST(self):
+        if self.path.startswith(f'/repos/{repo}/statuses/{sha}'):
+            self.replyJson({})
+        else:
+            self.send_error(405, 'Method not allowed: ' + self.path)
+
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--port', type=int, default=8443, help="Port to listen on (default: %(default)s)")
+argparser.add_argument('--print-event', action='store_true', help="Print GitHub webhook pull_request event and exit")
+argparser.add_argument('repo', metavar='USER/PROJECT', help="GitHub user/org and project name")
+argparser.add_argument('sha', help="SHA to test in repo for the mock PR")
+args = argparser.parse_args()
+repo = args.repo
+sha = args.sha
+
+ADDRESS = ('127.0.0.7', args.port)
+
+GITHUB_DATA = {
+    f'/repos/{repo}/pulls/1': {
+        'title': 'mock PR',
+        'number': 1,
+        'state': 'open',
+        'body': "This is the body",
+        'base': {'repo': {'full_name': repo}, 'ref': 'main'},
+        'head': {'sha': args.sha, 'user': {'login': repo.split('/')[0]}},
+        'labels': [],
+        'updated_at': 0,
+    },
+    f'/repos/{repo}/commits/{args.sha}/status?page=1&per_page=100': {
+        'state': 'pending',
+        'statuses': [],
+        'sha': sha,
+    },
+}
+
+if args.print_event:
+    print(json.dumps({
+        'event': 'pull_request',
+        'request': {
+            'action': 'opened',
+            'pull_request': GITHUB_DATA[f'/repos/{repo}/pulls/1']
+        }
+    }, indent=4))
+    exit(0)
+
+temp = tempfile.TemporaryDirectory()
+cache_dir = os.path.join(temp.name, 'cache')
+os.environ['XDG_CACHE_HOME'] = cache_dir
+server = MockServer(ADDRESS, Handler, GITHUB_DATA)
+server.start()
+print(f'export GITHUB_API=http://{ADDRESS[0]}:{ADDRESS[1]}')

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -167,7 +167,7 @@ EOF
 
     # Run tasks container in the backgroud
     podman run -d -it --name cockpituous-tasks --pod=cockpituous \
-        -v "$SECRETS"/tasks:/secrets:ro,z \
+        -v "$SECRETS"/tasks:/run/secrets/tasks:ro,z \
         -v "$SECRETS"/webhook:/run/secrets/webhook:ro,z \
         -e COCKPIT_CA_PEM=/run/secrets/webhook/ca.pem \
         -e COCKPIT_BOTS_REPO=${COCKPIT_BOTS_REPO:-} \

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -232,6 +232,45 @@ test_image() {
     '
 }
 
+test_mock_pr() {
+    podman cp "$MYDIR/mock-github-pr" cockpituous-tasks:/work/bots/mock-github-pr
+    podman exec -i cockpituous-tasks sh -euxc "
+        cd bots
+        # test mock PR against our checkout, so that cloning will work
+        SHA=\$(git rev-parse HEAD)
+
+        # start mock GH server
+        PYTHONPATH=. ./mock-github-pr cockpit-project/bots \$SHA &
+        GH_MOCK_PID=\$!
+        export GITHUB_API=http://127.0.0.7:8443
+        until curl --silent \$GITHUB_API; do sleep 0.1; done
+
+        # simulate GitHub webhook event, put that into the webhook queue
+        PYTHONPATH=. ./mock-github-pr --print-event cockpit-project/bots \$SHA | \
+            ./publish-queue --amqp $AMQP_POD --create --queue webhook
+
+        ./inspect-queue --amqp $AMQP_POD
+
+        # first run-queue processes webhook → tests-scan → public queue
+        ./run-queue --amqp $AMQP_POD
+        ./inspect-queue --amqp $AMQP_POD
+
+        # second run-queue actually runs the test
+        ./run-queue --amqp $AMQP_POD
+
+        kill \$GH_MOCK_PID
+    "
+
+    LOGS_URL="$S3_URL_HOST/logs/"
+    CURL="curl --cacert $SECRETS/ca.pem --silent --fail --show-error"
+    LOG_MATCH="$($CURL $LOGS_URL| grep -o "pull-1-[[:alnum:]-]*-unit-tests/log<")"
+    LOG="$($CURL "${LOGS_URL}${LOG_MATCH%<}")"
+    echo "--------------- mock PR test log -----------------"
+    echo  "$LOG"
+    echo "--------------- mock PR test log end -------------"
+    assert_in 'Test run finished' "$LOG"
+}
+
 test_pr() {
     # need to use real GitHub token for this
     [ -z "$TOKEN" ] || cp -fv "$TOKEN" "$SECRETS"/webhook/.config--github-token
@@ -311,6 +350,8 @@ else
     # tests which don't need GitHub interaction
     test_image
     test_queue
+    # "almost" end-to-end, starting with GitHub webhook JSON payload injection; fully localy, no privs
+    test_mock_pr
     # if we have a PR number, run a unit test inside local deployment, and update PR status
     [ -z "$PR" ] || test_pr
 fi

--- a/tasks/setup-tasks
+++ b/tasks/setup-tasks
@@ -21,20 +21,25 @@ npm config set fetch-timeout 600000
 npm config set fetch-retry-mintimeout 60000
 npm config set maxsockets 3
 
-# set up S3 keys for OpenShift secrets volume
-if [ ! -d /secrets/s3-keys ] && [ ! -d ~/.config/cockpit-dev/s3-keys ]; then
-    # then our container symlink will point into the void, replace it with a directory and set up all files that we can find
-    rm ~/.config/cockpit-dev/s3-keys
-    mkdir ~/.config/cockpit-dev/s3-keys
-    for f in /secrets/s3-keys--*; do
-        [ -e "$f" ] || continue # non-matching glob
-        ln -s "$f" ~/.config/cockpit-dev/s3-keys/"${f#*--}"
-    done
-fi
+# Set up secrets
+if [ -d /run/secrets/tasks ]; then
+    ls -l ~/.config/cockpit-dev/
+    ln -snf /run/secrets/tasks/s3-keys ~/.config/cockpit-dev/s3-keys
+    ln -snf /run/secrets/webhook/.config--github-token ~/.config/github-token
+    git config --global credential.helper store
+    echo "https://cockpituous:$(cat ~/.config/github-token)@github.com" > ~/.git-credentials
 
-# Set up github user and token
-git config --global credential.helper store
-echo "https://cockpituous:$(cat ~/.config/github-token)@github.com" > ~/.git-credentials
+    # set up S3 keys for OpenShift secrets volume, where there is just a flat hierarchy with "--" encoding
+    if [ ! -d /run/secrets/tasks/s3-keys ] && [ ! -d ~/.config/cockpit-dev/s3-keys ]; then
+        # then our container symlink will point into the void, replace it with a directory and set up all files that we can find
+        rm ~/.config/cockpit-dev/s3-keys
+        mkdir ~/.config/cockpit-dev/s3-keys
+        for f in /run/secrets/tasks/s3-keys--*; do
+            [ -e "$f" ] || continue # non-matching glob
+            ln -s "$f" ~/.config/cockpit-dev/s3-keys/"${f#*--}"
+        done
+    fi
+fi
 
 # Get bots
 if [ ! -d ~/bots ]; then

--- a/tasks/setup-tasks
+++ b/tasks/setup-tasks
@@ -35,3 +35,8 @@ fi
 # Set up github user and token
 git config --global credential.helper store
 echo "https://cockpituous:$(cat ~/.config/github-token)@github.com" > ~/.git-credentials
+
+# Get bots
+if [ ! -d ~/bots ]; then
+    git clone --quiet -b "${COCKPIT_BOTS_BRANCH:-main}" "${COCKPIT_BOTS_REPO:-https://github.com/cockpit-project/bots}" ~/bots
+fi

--- a/tasks/setup-tasks
+++ b/tasks/setup-tasks
@@ -22,7 +22,7 @@ npm config set fetch-retry-mintimeout 60000
 npm config set maxsockets 3
 
 # set up S3 keys for OpenShift secrets volume
-if [ ! -d /secrets/s3-keys ]; then
+if [ ! -d /secrets/s3-keys ] && [ ! -d ~/.config/cockpit-dev/s3-keys ]; then
     # then our container symlink will point into the void, replace it with a directory and set up all files that we can find
     rm ~/.config/cockpit-dev/s3-keys
     mkdir ~/.config/cockpit-dev/s3-keys


### PR DESCRIPTION
This is an "almost end to end" test which runs fully locally and requires no
GitHub interaction or token. Add a little mock GitHub server (utilizing bots'
`task.test_mock_server`) to respond to the required GitHub APIs for handling an
"opened PR" webhook event.

This is useful for playing around with our AMQP queue/job execution engine
locally (when using the mock GH server in interactive mode), or
validating changes to run-queue/AMQP structure.

 - [ ] Requires #585
