### PR TITLE
tasks: Test posted statuses in mock PR and image refresh

### DIFF
--- a/tasks/mock-github
+++ b/tasks/mock-github
@@ -19,10 +19,15 @@ from task.test_mock_server import MockHandler, MockServer
 
 repo = None
 sha = None
+log = None
 
 
 class Handler(MockHandler):
     def do_GET(self):
+        if log is not None:
+            print("GET", self.path, file=log)
+            log.flush()
+
         if self.path in self.server.data:
             self.replyJson(self.server.data[self.path])
         elif self.path.startswith(f'/repos/{repo}/pulls?'):
@@ -39,6 +44,10 @@ class Handler(MockHandler):
             self.send_error(404, 'Mock Not Found: ' + self.path)
 
     def do_POST(self):
+        if log is not None:
+            print("POST", self.path, self.rfile.read1().decode(), file=log)
+            log.flush()
+
         if self.path.startswith(f'/repos/{repo}/statuses/{sha}'):
             self.replyJson({})
         # new SHA from mock-pushed PR #2 for image-refresh
@@ -63,6 +72,7 @@ argparser.add_argument('--print-pr-event', action='store_true',
                        help="Print GitHub webhook pull_request event and exit")
 argparser.add_argument('--print-image-refresh-event', action='store_true',
                        help="Print GitHub webhook issue event for an image-refresh and exit")
+argparser.add_argument('--log', metavar="PATH", help="Log requests to this file")
 argparser.add_argument('repo', metavar='USER/PROJECT', help="GitHub user/org and project name")
 argparser.add_argument('sha', help="SHA to test in repo for the mock PR")
 args = argparser.parse_args()
@@ -125,6 +135,8 @@ if args.print_image_refresh_event:
     }, indent=4))
     exit(0)
 
+if args.log:
+    log = open(args.log, 'w')
 temp = tempfile.TemporaryDirectory()
 cache_dir = os.path.join(temp.name, 'cache')
 os.environ['XDG_CACHE_HOME'] = cache_dir

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -301,19 +301,21 @@ test_image() {
 test_mock_pr() {
     podman cp "$MYDIR/mock-github" cockpituous-tasks:/work/bots/mock-github
     create_job_runner_config mock
+
+    # test mock PR against our checkout, so that cloning will work
+    SHA=$(podman exec -i cockpituous-tasks git -C bots rev-parse HEAD)
+
     podman exec -i cockpituous-tasks sh -euxc "
         cd bots
-        # test mock PR against our checkout, so that cloning will work
-        SHA=\$(git rev-parse HEAD)
 
         # start mock GH server
-        PYTHONPATH=. ./mock-github cockpit-project/bots \$SHA &
+        PYTHONPATH=. ./mock-github --log /tmp/mock.log cockpit-project/bots $SHA &
         GH_MOCK_PID=\$!
         export GITHUB_API=$GHAPI_URL_POD
         until curl --silent --fail \$GITHUB_API/repos/cockpit-project/bots; do sleep 0.1; done
 
         # simulate GitHub webhook event, put that into the webhook queue
-        PYTHONPATH=. ./mock-github --print-pr-event cockpit-project/bots \$SHA | \
+        PYTHONPATH=. ./mock-github --print-pr-event cockpit-project/bots $SHA | \
             ./publish-queue --amqp $AMQP_POD --create --queue webhook
 
         ./inspect-queue --amqp $AMQP_POD
@@ -337,6 +339,13 @@ test_mock_pr() {
     echo "--------------- mock PR test log end -------------"
     assert_in 'Test run finished, return code: 0\|Job ran successfully' "$LOG"
     assert_in 'Running on:.*cockpituous' "$LOG"
+
+    # 3 status updates posted
+    # FIXME: assert JSON more precisely once we rewrite in Python
+    GH_MOCK_LOG="$(podman  exec cockpituous-tasks cat /tmp/mock.log)"
+    assert_in "POST /repos/cockpit-project/bots/statuses/$SHA .*description.*Not yet tested" "$GH_MOCK_LOG"
+    assert_in "POST /repos/cockpit-project/bots/statuses/$SHA .*description.*In progress \\[cockpituous\\]" "$GH_MOCK_LOG"
+    assert_in "POST /repos/cockpit-project/bots/statuses/$SHA .*state.*success" "$GH_MOCK_LOG"
 }
 
 test_pr() {
@@ -400,19 +409,19 @@ test_mock_image_refresh() {
     podman cp "$MYDIR/mock-git-push" cockpituous-tasks:/usr/local/bin/git
     create_job_runner_config mock
 
+    # test mock PR against our checkout, so that cloning will work
+    SHA=$(podman exec -i cockpituous-tasks git -C bots rev-parse HEAD)
+
     podman exec -i cockpituous-tasks sh -euxc "
         cd bots
-        # test mock PR against our checkout, so that cloning will work
-        SHA=\$(git rev-parse HEAD)
-
         # start mock GH server
-        PYTHONPATH=. ./mock-github cockpit-project/bots \$SHA &
+        PYTHONPATH=. ./mock-github --log /tmp/mock.log cockpit-project/bots $SHA &
         GH_MOCK_PID=\$!
         export GITHUB_API=$GHAPI_URL_POD
         until curl --silent --fail \$GITHUB_API/repos/cockpit-project/bots; do sleep 0.1; done
 
         # simulate GitHub webhook event, put that into the webhook queue
-        PYTHONPATH=. ./mock-github --print-image-refresh-event cockpit-project/bots \$SHA | \
+        PYTHONPATH=. ./mock-github --print-image-refresh-event cockpit-project/bots $SHA | \
             ./publish-queue --amqp $AMQP_POD --create --queue webhook
 
         ./inspect-queue --amqp $AMQP_POD
@@ -460,6 +469,20 @@ test_mock_image_refresh() {
         grep "^fakeimage" /tmp/foonux.raw
         rm /tmp/foonux.raw
     '
+
+    # status updates posted to original bots SHA on which the image got triggered
+    # FIXME: assert JSON more precisely once we rewrite in Python (unpredictable JSON order)
+    GH_MOCK_LOG="$(podman  exec cockpituous-tasks cat /tmp/mock.log)"
+    assert_in "POST /repos/cockpit-project/bots/statuses/$SHA .*image-refresh/foonux" "$GH_MOCK_LOG"
+    assert_in "POST /repos/cockpit-project/bots/statuses/$SHA .*In progress \\[cockpituous\\]" "$GH_MOCK_LOG"
+    assert_in "POST /repos/cockpit-project/bots/statuses/$SHA .*success" "$GH_MOCK_LOG"
+
+    # and forwarded to the converted PR (new SHA)
+    assert_in "POST /repos/cockpit-project/bots/statuses/a1b2c3 .*success.*Forwarded status.*target_url" "$GH_MOCK_LOG"
+
+    # posts new comment with log
+    assert_in "POST /repos/cockpit-project/bots/issues/2/comments .*Success. Log: https.*" "$GH_MOCK_LOG"
+
 }
 
 test_queue() {


### PR DESCRIPTION
Teach `mock-github` to write a log of POST requests, and add some initial assertions. They are not very precise yet (that'll get cleaned up in the Python rewrite soon), but at least ensure that we post the statuses to the expected SHA.

This enables us to create an integration test for a cross-project test in a future commit.