### PR TITLE
ansible: Define "image-download" job secret

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -79,7 +79,12 @@
 
       [container.secrets]
       # these are *host* paths, this is podman-remote
+      # FIXME: Split the upload/download secrets
       image-upload=[
+          '--volume=/var/lib/cockpit-secrets/tasks/s3-keys/:/run/secrets/s3-keys:ro',
+          '--env=COCKPIT_S3_KEY_DIR=/run/secrets/s3-keys',
+      ]
+      image-download=[
           '--volume=/var/lib/cockpit-secrets/tasks/s3-keys/:/run/secrets/s3-keys:ro',
           '--env=COCKPIT_S3_KEY_DIR=/run/secrets/s3-keys',
       ]


### PR DESCRIPTION
Tests will need that to download private (RHEL) images from the stores.

For now this is the same directory as the upload secret, but at some point we should split them.

----

This goes along with https://github.com/cockpit-project/bots/pull/6062

I added the secret splitting to the pilot board as enhancement, so that we don't forget.

I did *not* roll this out yet, will do after review.