### PR TITLE
tasks: add python3-mypy, pytest modules

### DIFF
--- a/tasks/Containerfile
+++ b/tasks/Containerfile
@@ -50,6 +50,7 @@ RUN dnf -y update && \
         python3-pytest-asyncio \
         python3-pytest-timeout \
         python3-pyyaml \
+        python3-vulture \
         python3-wheel \
         qemu-kvm-core \
         rpm-build \


### PR DESCRIPTION
We're going to stop using toxbox to run our static checks against a venv and start depending on the run from the tasks container instead.  We need mypy in the tasks container for that, of course.

While we're at it, add python3-pytest.  Something else we're already using (probably aioresponses) is pulling that in implicitly, but it's pretty important for us, so make sure we have it explicitly.

Add a couple of more useful pytest modules as well...

 - [x] container refresh: ~https://github.com/cockpit-project/cockpituous/actions/runs/8231372303/job/22506531777~ https://github.com/cockpit-project/cockpituous/actions/runs/8231519767