### PR TITLE
ansible: Include console.redhat.com password in image-upload secrets

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -79,12 +79,17 @@
 
       [container.secrets]
       # these are *host* paths, this is podman-remote
-      # FIXME: Split the upload/download secrets
+      # secret from issue-scan for image refreshes
       image-upload=[
           '--volume=/var/lib/cockpit-secrets/tasks/s3-keys/:/run/secrets/s3-keys:ro',
           '--env=COCKPIT_S3_KEY_DIR=/run/secrets/s3-keys',
+          # password for console.redhat.com when image-create'ing rhel4edge
+          '--volume=/var/lib/cockpit-secrets/tasks/crc_passwd:/run/secrets/crc_passwd:ro',
+          '--env=COCKPIT_CRC_PASSWORD=/run/secrets/crc_passwd',
       ]
+      # secret from tests-scan for downloading RHEL images
       image-download=[
+          # FIXME: create a new "download only" S3 token
           '--volume=/var/lib/cockpit-secrets/tasks/s3-keys/:/run/secrets/s3-keys:ro',
           '--env=COCKPIT_S3_KEY_DIR=/run/secrets/s3-keys',
       ]


### PR DESCRIPTION
This is necessary for rhel4edge refreshes. Add a new `$COCKPIT_CRC_PASSWORD` env variable for it so that we can stop hardcoding the path in bots rhel4edge.bootstrap.

Also clarify the comments a bit.

---

see https://github.com/cockpit-project/bots/issues/6053