### PR TITLE
tasks: Add cockpituous refs/heads/main mock API endpoint

### DIFF
--- a/tasks/mock-github
+++ b/tasks/mock-github
@@ -73,6 +73,7 @@ argparser.add_argument('--print-pr-event', action='store_true',
 argparser.add_argument('--print-image-refresh-event', action='store_true',
                        help="Print GitHub webhook issue event for an image-refresh and exit")
 argparser.add_argument('--log', metavar="PATH", help="Log requests to this file")
+argparser.add_argument('--cockpituous-sha', metavar="SHA", help="resolve cockpituous main branch to this SHA")
 argparser.add_argument('repo', metavar='USER/PROJECT', help="GitHub user/org and project name")
 argparser.add_argument('sha', help="SHA to test in repo for the mock PR")
 args = argparser.parse_args()
@@ -111,6 +112,11 @@ GITHUB_DATA = {
     },
     f'/repos/{repo}/git/ref/heads/main': {
         'object': {'sha': sha},
+    },
+    # for cross-project test; job-runner uses it to determine the clone SHA
+    '/repos/cockpit-project/cockpituous/git/refs/heads/main': {
+        # that fallback is strictly wrong, but good enough
+        'object': {'sha': args.cockpituous_sha or "main"},
     },
 }
 


### PR DESCRIPTION
job-runner needs that for cross-project testing [1]. A clean way would be to actually resolve "main" to a current SHA in the test, but as nothing actually cares, just rely on the `main` fallback for now -- nothing cares whether this is an actual SHA, as most things in git are happy with a "ref" -- and we don't use that to post statuses (and that would fail because the mock doesn't provide these paths).

[1] https://github.com/cockpit-project/bots/pull/6066

---

This unblocks https://github.com/cockpit-project/bots/pull/6066