### PR TITLE
Properly fix podman.socket permissions in tasks containers

### DIFF
--- a/ansible/psi/image-cache.yml
+++ b/ansible/psi/image-cache.yml
@@ -24,8 +24,8 @@
         src: self-hosted
         dest: "/var/lib/cockpit-secrets/tasks/s3-keys/{{ hostvars[groups['psi_s3'][0]].ansible_host }}"
         state: link
-        owner: 1111
-        group: 1111
+        owner: cockpituous
+        group: cockpituous
 
     - name: Tell tasks containers to drain and restart
       command: pkill -ex cockpit-tasks

--- a/ansible/roles/ci-data-cache/tasks/main.yml
+++ b/ansible/roles/ci-data-cache/tasks/main.yml
@@ -1,7 +1,19 @@
+- name: Create cockpituous group
+  group:
+    name: cockpituous
+    gid: 1111
+
+- name: Create cockpituous user
+  user:
+    name: cockpituous
+    group: cockpituous
+    create_home: false
+    uid: 1111
+
 - name: Set up Cockpit tasks cache directory
   file:
     path: /var/cache/cockpit-tasks/images
-    owner: '1111'
-    group: '1111'
+    owner: cockpituous
+    group: cockpituous
     state: directory
     setype: container_file_t

--- a/ansible/roles/install-secrets-dir/tasks/main.yml
+++ b/ansible/roles/install-secrets-dir/tasks/main.yml
@@ -13,8 +13,8 @@
  - name: Set up secrets dir
    file:
      path: /var/lib/cockpit-secrets
-     owner: '1111'
-     group: '1111'
+     owner: cockpituous
+     group: cockpituous
      state: directory
      setype: container_file_t
 
@@ -23,8 +23,8 @@
      src: /tmp/secrets.tar.gz
      remote_src: true
      dest: /var/lib/cockpit-secrets/
-     owner: '1111'
-     group: '1111'
+     owner: cockpituous
+     group: cockpituous
      mode: 'u=rwX,g=rX,o=rX'
      setype: container_file_t
 

--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -40,6 +40,20 @@
       maxsockets=3
       cafile=/run/secrets/tasks/npm-registry.crt
 
+- name: Create podman.socket drop-in directory
+  file:
+    path: /etc/systemd/system/podman.socket.d
+    state: directory
+
+# idmapped mount would be better, but did not figure out how
+- name: Allow access to podman.socket to unprivileged container user
+  copy:
+    dest: /etc/systemd/system/podman.socket.d/container-access.conf
+    mode: 0644
+    content: |
+      [Socket]
+      SocketGroup=cockpituous
+
 - name: Create job-runner configuration
   copy:
     dest: /etc/job-runner.toml

--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -5,7 +5,15 @@
     dest: /run/install-service
     mode: preserve
 
-- name: Create custom SELinux rules to fix Chromium
+- name: Create custom SELinux policy file contexts
+  copy:
+    dest: /tmp/cockpituous.fc
+    mode: 0644
+    content: |
+      /var/run/podman/podman.sock    system_u:object_r:container_file_t:s0
+  register: selinux_policy_fc
+
+- name: Create custom SELinux policy type enforcements
   copy:
     dest: /tmp/cockpituous.te
     mode: 0644
@@ -13,19 +21,30 @@
       module cockpituous 1.0;
       require {
               type container_t;
+              type container_file_t;
+              type container_runtime_t;
+              type init_t;
               class process execheap;
+              class sock_file { create unlink setattr };
+              class unix_stream_socket { connectto };
       }
+
+      # allow systemd to create the socket after changing its type
+      allow init_t container_file_t:sock_file { create unlink setattr };
+
+      # container can access that socket
+      allow container_t container_runtime_t:unix_stream_socket connectto;
 
       # HACK: See https://github.com/cockpit-project/cockpituous/issues/579
       allow container_t self:process execheap;
-  register: selinux_policy
+  register: selinux_policy_te
 
 - name: Install custom SELinux rules
   shell: |
     checkmodule -M -m -o /tmp/cockpituous.mod /tmp/cockpituous.te
-    semodule_package -o /tmp/cockpituous.pp -m /tmp/cockpituous.mod
+    semodule_package -o /tmp/cockpituous.pp -m /tmp/cockpituous.mod -f /tmp/cockpituous.fc
     semodule -i /tmp/cockpituous.pp
-  when: selinux_policy.changed
+  when: selinux_policy_fc.changed or selinux_policy_te.changed
 
 # This only applies to RH VPN; make that optional if we ever deploy to public infrastructure
 - name: Create npm configuration

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -55,8 +55,6 @@ ExecStartPre=-/usr/bin/podman network rm cockpit-tasks-%i
 ExecStartPre=/usr/bin/chcon -R -l s0 \${TEST_CACHE}/images/
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull podman pull quay.io/cockpit/tasks
 ExecStartPre=/usr/bin/podman network create cockpit-tasks-%i
-# idmapped mount would be better, but did not figure out how
-ExecStartPre=/usr/bin/chgrp cockpituous %t/podman/podman.sock
 ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOSTNAME} \
     --device=/dev/kvm --network=cockpit-tasks-%i \
     --memory=24g --pids-limit=16384 --shm-size=1024m ${TMPVOL:-} \

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -19,7 +19,7 @@ TMPVOL=${TMPVOL:-"--tmpfs /tmp:size=14g"}
 systemctl stop 'cockpit-tasks@*.service'
 
 mkdir -p $SECRETS/tasks $SECRETS/webhook $CACHE
-chown -R 1111:1111 $SECRETS $CACHE
+chown -R cockpituous:cockpituous $SECRETS $CACHE
 chcon -R -t container_file_t $SECRETS $CACHE
 
 if [ $INSTANCES -eq 1 ]; then
@@ -56,7 +56,7 @@ ExecStartPre=/usr/bin/chcon -R -l s0 \${TEST_CACHE}/images/
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull podman pull quay.io/cockpit/tasks
 ExecStartPre=/usr/bin/podman network create cockpit-tasks-%i
 # idmapped mount would be better, but did not figure out how
-ExecStartPre=/usr/bin/chgrp 1111 %t/podman/podman.sock
+ExecStartPre=/usr/bin/chgrp cockpituous %t/podman/podman.sock
 ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOSTNAME} \
     --device=/dev/kvm --network=cockpit-tasks-%i \
     --memory=24g --pids-limit=16384 --shm-size=1024m ${TMPVOL:-} \


### PR DESCRIPTION
See individual commits for details.

I rolled this out onto rhos-01-1, switched it back to `setenforce 1`, and confirmed that `sudo podman exec -it cockpit-tasks-1 podman-remote --url unix:///podman.sock ps` works and also doesn't leave any "AVC denied" in  `journalctl -f`.