### PR TITLE
tasks: Drop /dev/kvm from cockpit-tasks containers

### DIFF
--- a/tasks/install-service
+++ b/tasks/install-service
@@ -47,9 +47,7 @@ ExecStartPre=-/usr/bin/podman rm -f cockpit-tasks-%i
 ExecStartPre=/usr/bin/chcon -R -l s0 ${CACHE}/images/
 ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull podman pull quay.io/cockpit/tasks
 # job-runner doesn't need /images, but we still need it for the run-queue store-tests task
-# FIXME: /dev/kvm should be dropped, but fix bots run-queue for that (indication of whether to run kvm tasks)
 ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOSTNAME} \
-    --device=/dev/kvm \
     --volume=${CACHE}/images:/cache/images:rw \
     --volume=${SECRETS}/tasks:/run/secrets/tasks:ro \
     --volume=${SECRETS}/webhook:/run/secrets/webhook:ro \


### PR DESCRIPTION
With the run-queue fix [1] landed, we don't need this as indicator for "capable of running tests" any more.

https://github.com/cockpit-project/bots/pull/6080

----

I deployed this already, as it seemed straightforward enough to me. I sent another image trigger to validate: https://github.com/cockpit-project/bots/issues/6081 (it failed for unrelated reasons, but it did pick up the job).