### PR TITLE
tasks: Stop reacting to opened issue

### DIFF
--- a/tasks/container/webhook
+++ b/tasks/container/webhook
@@ -159,7 +159,7 @@ class CockpituousHandler(github_handler.GithubHandler):
 
     def handle_issues_event(self, event, request):
         action = request['action']
-        if event == 'issues' and action not in ['opened', 'edited', 'labeled']:
+        if event == 'issues' and action not in ['edited', 'labeled']:
             logging.info("action %s unknown, skipping issues event" % action)
             return None
 


### PR DESCRIPTION
This causes a duplicate image-refresh job for auto-generated image refresh issues. These generate both an "opened" and "labelled" event at the same tme, so that we'll get two `issues-scan` webhook queue entries, and the API query in `issue-scan` will see a "bot" labeled issue for both responses.

It is enough to react to the "labeled" event.