### PR TITLE
proof of concept for buildx in github actions

### DIFF
--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -2,20 +2,31 @@ name: build-tasks
 on:
   # this is meant to be run on an approved PR branch for convenience
   workflow_dispatch:
+  push:
+
 jobs:
   build:
-    runs-on: ubuntu-22.04
-    environment: quay.io
-    timeout-minutes: 30
+    runs-on: ubuntu-latest
     steps:
-      - name: Clone repository
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Checkout
         uses: actions/checkout@v4
-
-      - name: Log into container registry
-        run: podman login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
-
-      - name: Build tasks container
-        run: make tasks-container
-
-      - name: Push container to registry
-        run: make tasks-push
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ghcr.io/allisonkarlitskaya/cockpituous
+          context: tasks/container
+          file: tasks/container/Containerfile
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
this works, but wow is it slow

the biggest problem is dnf being so slow.  if we could figure out a way to get microdnf in there, it might help things, but installing it would use... dnf.    either that, or figure out a way to do the depsolving on x86 and install the result based on that...

i guess we can't rely on having the exact same package list across both platforms...

i don't think this is really workable in its current state, unfortunately