### PR TITLE
workflows: move tasks container to ghcr.io

### DIFF
--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -8,8 +8,8 @@ on:
 # where different runners pick different tags (eg: for builds near midnight, or
 # in different time zones).  The manifest job picks the final name.
 env:
-  tag: quay.io/cockpit/tasks
-  tmptag: quay.io/cockpit/tasks-tmp:${{ github.run_id }}.${{ github.run_attempt }}
+  tag: ghcr.io/${{ github.repository_owner }}/tasks
+  tmptag: ghcr.io/${{ github.repository_owner }}/tasks-tmp:${{ github.run_id }}.${{ github.run_attempt }}
 
 jobs:
   build:
@@ -17,12 +17,11 @@ jobs:
       matrix:
         build:
           - label: amd64
-            runner: buildjet-2vcpu-ubuntu-2204
+            runner: ubuntu-22.04
           - label: arm64
             runner: buildjet-2vcpu-ubuntu-2204-arm
 
     runs-on: ${{ matrix.build.runner }}
-    environment: quay.io
     timeout-minutes: 10
 
     steps:
@@ -31,9 +30,9 @@ jobs:
         name: Log in to container registry
         uses: docker/login-action@v3
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_BOTUSER }}
-          password: ${{ secrets.QUAY_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Checkout
         uses: actions/checkout@v4
@@ -49,14 +48,13 @@ jobs:
   manifest:
     needs: build
 
-    runs-on: buildjet-2vcpu-ubuntu-2204
-    environment: quay.io
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
 
     steps:
       -
         name: Login in to container registry
-        run: podman login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        run: podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
       -
         name: Create manifest
         run: podman manifest create tasks '${{ env.tmptag }}'-{amd,arm}64

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ containers: tasks-container
 	@true
 
 tasks-container:
-	$(DOCKER) build -t quay.io/cockpit/tasks:$(TAG) tasks/container
-	$(DOCKER) tag quay.io/cockpit/tasks:$(TAG) quay.io/cockpit/tasks:latest
+	$(DOCKER) build -t ghcr.io/cockpit-project/tasks:$(TAG) tasks/container
+	$(DOCKER) tag ghcr.io/cockpit-project/tasks:$(TAG) ghcr.io/cockpit-project/tasks:latest
 
 tasks-secrets:
 	@cd tasks && ./build-secrets $(TASK_SECRETS)

--- a/ansible/maintenance/deploy-tasks-container.yml
+++ b/ansible/maintenance/deploy-tasks-container.yml
@@ -17,7 +17,7 @@
     shell: podman rmi --all || true
 
   - name: Pre-pull current container image to avoid long downtime
-    command: podman pull quay.io/cockpit/tasks
+    command: podman pull ghcr.io/cockpit-project/tasks
 
   - name: Tell tasks containers to drain and restart
     command: pkill -ex cockpit-tasks
@@ -30,7 +30,7 @@
     shell: podman rmi --all || true
 
   - name: Pre-pull current container image to avoid long downtime
-    command: podman pull quay.io/cockpit/tasks
+    command: podman pull ghcr.io/cockpit-project/tasks
 
   - name: Restart webhook pod
     command: systemctl restart cockpituous-webhook.service

--- a/ansible/roles/webhook/cockpituous-webhook.service
+++ b/ansible/roles/webhook/cockpituous-webhook.service
@@ -33,7 +33,7 @@ ExecStart=/usr/bin/podman run \
     --pull=always \
     -e AMQP_SERVER=localhost:5671 \
     -v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
-    quay.io/cockpit/tasks webhook
+    ghcr.io/cockpit-project/tasks webhook
 
 ExecStop=/usr/bin/podman pod rm -f cockpituous
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -69,7 +69,7 @@ Without arguments this will run some purely local integration tests:
 
 This will also generate the secrets in a temporary directory, unless they
 already exist in `tasks/credentials/`. By default this will use the
-[`quay.io/cockpit/tasks:latest`](https://quay.io/repository/cockpit/tasks?tab=tags)
+[`ghcr.io/cockpit-project/tasks:latest`](https://ghcr.io/cockpit-project/tasks)
 container, but you can run a different tag by setting `$TASKS_TAG`.
 
 You can also test the whole GitHub → webhook → tasks → GitHub status workflow
@@ -94,7 +94,7 @@ This container can also be used for local development with
 development environment that's independent from the host:
 
 ```sh
-toolbox create --image quay.io/cockpit/tasks cockpit
+toolbox create --image ghcr.io/cockpit-project/tasks cockpit
 toolbox enter cockpit
 ```
 
@@ -122,7 +122,7 @@ container like this:
 ```sh
 podman run -it --rm --device=/dev/kvm --memory=6g --pids-limit=4096 --shm-size=256m \
     --security-opt label=disable -v ~/.cache/cockpit-images:/cache/images \
-    -e TEST_JOBS=2 quay.io/cockpit/tasks bash
+    -e TEST_JOBS=2 ghcr.io/cockpit-project/tasks bash
 ```
 
 Inside, you can then run a test, for example

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -16,7 +16,7 @@ spec:
       terminationGracePeriodSeconds: 3600
       containers:
       - name: cockpit-tasks
-        image: quay.io/cockpit/tasks
+        image: ghcr.io/cockpit-project/tasks
         env:
         # containers run as random user ID without passwd entry
         - name: HOME

--- a/tasks/cockpit-tasks-webhook.yaml
+++ b/tasks/cockpit-tasks-webhook.yaml
@@ -35,7 +35,7 @@ spec:
               memory: 300M
               cpu: 200m
         - name: webhook
-          image: quay.io/cockpit/tasks
+          image: ghcr.io/cockpit-project/tasks
           ports:
             - containerPort: 8080
               protocol: TCP

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -45,7 +45,7 @@ TimeoutStartSec=10min
 ExecStartPre=-/usr/bin/podman rm -f cockpit-tasks-%i
 # HACK: sometimes images get an MCS category which makes them undeletable by the container
 ExecStartPre=/usr/bin/chcon -R -l s0 ${CACHE}/images/
-ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull podman pull quay.io/cockpit/tasks
+ExecStartPre=/usr/bin/flock /tmp/cockpit-image-pull podman pull ghcr.io/cockpit-project/tasks
 # job-runner doesn't need /images, but we still need it for the run-queue store-tests task
 ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOSTNAME} \
     --volume=${CACHE}/images:/cache/images:rw \
@@ -63,7 +63,7 @@ ExecStart=/usr/bin/podman run --name=cockpit-tasks-%i --hostname=${CONTAINER_HOS
     --env=GIT_AUTHOR_EMAIL=cockpituous@cockpit-project.org \
     --env=TEST_NOTIFICATION_MX=${TEST_NOTIFICATION_MX} \
     --env=TEST_NOTIFICATION_TO=${TEST_NOTIFICATION_TO} \
-    quay.io/cockpit/tasks cockpit-tasks --verbose
+    ghcr.io/cockpit-project/tasks cockpit-tasks --verbose
 ExecStop=/usr/bin/podman rm -f cockpit-tasks-%i
 
 [Install]

--- a/tasks/mock-github
+++ b/tasks/mock-github
@@ -39,7 +39,7 @@ class Handler(MockHandler):
                 "head": {"sha": "a1b2c3"},
             })
         elif self.path == f'/{repo}/{sha}/.cockpit-ci/container':
-            self.replyData('quay.io/cockpit/tasks')
+            self.replyData('ghcr.io/cockpit-project/tasks')
         else:
             self.send_error(404, 'Mock Not Found: ' + self.path)
 

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -226,7 +226,7 @@ EOF
             --env=AMQP_SERVER=$AMQP_POD \
             --env=COCKPIT_GITHUB_TOKEN_FILE=/run/secrets/webhook/.config--github-token \
             --env=COCKPIT_GITHUB_WEBHOOK_TOKEN_FILE=/run/secrets/webhook/.config--github-webhook-token \
-            quay.io/cockpit/tasks:${TASKS_TAG:-latest} webhook
+            ghcr.io/cockpit-project/tasks:${TASKS_TAG:-latest} webhook
     fi
 
     # wait until AMQP initialized
@@ -260,7 +260,7 @@ EOF
         --env=GIT_AUTHOR_NAME=Cockpituous \
         --env=GIT_AUTHOR_EMAIL=cockpituous@cockpit-project.org \
         --env=SKIP_STATIC_CHECK=1 \
-        quay.io/cockpit/tasks:${TASKS_TAG:-latest} bash
+        ghcr.io/cockpit-project/tasks:${TASKS_TAG:-latest} bash
 
     # check out the correct bots, as part of what cockpit-tasks would usually do
     podman exec -i cockpituous-tasks sh -euc \
@@ -578,7 +578,7 @@ test_podman() {
     # this will be covered implicitly by job-runner, but as a more basal plumbing test this is easier to debug
     out="$(podman exec -i cockpituous-tasks podman-remote --url unix:///podman.sock ps)"
     assert_in 'cockpituous-tasks' "$out"
-    out="$(podman exec -i cockpituous-tasks podman-remote --url unix:///podman.sock run -it --rm quay.io/cockpit/tasks:latest whoami)"
+    out="$(podman exec -i cockpituous-tasks podman-remote --url unix:///podman.sock run -it --rm ghcr.io/cockpit-project/tasks:latest whoami)"
     assert_in '^user' "$out"
 }
 


### PR DESCRIPTION
This speeds things up (due to having the runner closer to the registry) and simplifies credentials management: we'll be able to drop our quay.io environment after this.

Move the amd64 and manifest jobs back to GitHub so they can run on GitHub infra, closer to the container registry.

I already did a run of this and it worked nicely.  See https://github.com/cockpit-project/cockpituous/actions/runs/8307247489 and https://github.com/orgs/cockpit-project/packages

I also started to try porting the container-file-updater-script to GitHub's API.  That was fairly straight-forward, but with an important caveat: in its first iteration, it was not possible to use ghcr at all without a GitHub token, even on public repos.  Since then, they've carved out enough of an exception to allow `podman pull` to function, but iterating over available tags via the REST API (or the docker protocol one) is still not possible without a token... :(