### PR TITLE
tasks: Speed up test_pr()

### DIFF
--- a/tasks/container/cockpit-tasks
+++ b/tasks/container/cockpit-tasks
@@ -19,10 +19,10 @@ function update_bots() {
     fi
 }
 
-# wait between 1 and 10 minutes, but not in an interactive terminal (annoying for debugging)
+# wait between 1 and 10 minutes, with an override to speed up tests
 function slumber() {
-    if [ -t 0 ]; then
-        sleep 10
+    if [ -n "${SLUMBER:-}" ]; then
+        sleep "$SLUMBER"
     else
         sleep $(shuf -i ${1:-60-600} -n 1)
     fi

--- a/tasks/run-local.sh
+++ b/tasks/run-local.sh
@@ -435,7 +435,7 @@ test_pr() {
 
     # run the main loop in the background; we could do this with a single run-queue invocation,
     # but we want to test the cockpit-tasks script
-    podman exec -i cockpituous-tasks cockpit-tasks &
+    podman exec -i --env=SLUMBER=1 cockpituous-tasks cockpit-tasks &
     TASKS_PID=$!
 
     podman exec -i cockpituous-tasks sh -euxc "


### PR DESCRIPTION
The `[ -t 0 ]` check in `cockpit-tasks` doesn't do anything any more, as the integration tests now run that script with `podman exec`, without an attached tty. This is also a bit awkward for the upcoming pytest rewrite, so replace it with an environment variable.