### PR TITLE
tasks: Give S3 secrets to OpenShift tasks container

### DIFF
--- a/tasks/build-secrets
+++ b/tasks/build-secrets
@@ -22,6 +22,20 @@ for f in $(find -maxdepth 1 -type f -o -type l); do
     printf '  %s: %s\n' "${f#./}" "$(base64 --wrap=0 $f)"
 done
 
+# S3 keys secrets
+cat <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cockpit-s3-secrets
+data:
+EOF
+cd "$BASE/tasks/s3-keys"
+for f in $(find -maxdepth 1 -type f -o -type l); do
+    printf '  %s: %s\n' "${f#./}" "$(base64 --wrap=0 $f)"
+done
+
 # webhook secrets
 cat <<EOF
 

--- a/tasks/cockpit-tasks-centosci.yaml
+++ b/tasks/cockpit-tasks-centosci.yaml
@@ -25,6 +25,8 @@ spec:
           value: '1'
         - name: COCKPIT_GITHUB_TOKEN_FILE
           value: /run/secrets/webhook/.config--github-token
+        - name: COCKPIT_S3_KEY_DIR
+          value: /run/secrets/s3-keys
         - name: COCKPIT_IMAGES_DATA_DIR
           value: /cache/images
         - name: GIT_COMMITTER_NAME
@@ -36,8 +38,11 @@ spec:
         - name: GIT_AUTHOR_EMAIL
           value: cockpituous@cockpit-project.org
         volumeMounts:
-        - name: secrets
+        - name: tasks-secrets
           mountPath: /run/secrets/tasks
+          readOnly: true
+        - name: s3-secrets
+          mountPath: /run/secrets/s3-keys
           readOnly: true
         - name: webhook-secrets
           mountPath: /run/secrets/webhook
@@ -55,9 +60,12 @@ spec:
             memory: 256Mi
             cpu: 0.2
       volumes:
-      - name: secrets
+      - name: tasks-secrets
         secret:
           secretName: cockpit-tasks-secrets
+      - name: s3-secrets
+        secret:
+          secretName: cockpit-s3-secrets
       - name: webhook-secrets
         secret:
           secretName: webhook-secrets


### PR DESCRIPTION
Commit b742b2d601c55fd4 was a thinko -- we *do* need S3 upload on our OpenShift tasks container: While we keep `test-results.db` in the local /cache/images/, we push `prometheus-stats` to S3.

----

I deployed this on OpenShift, and ran
```
./store-tests --db /cache/images/test-results.db --repo cockpit-project/cockpit-podman 84a41aa41a3abb587a44e1c44aa7615133a3bef8 && ./prometheus-stats --db /cache/images/test-results.db --s3 https://cockpit-logs.us-east-1.linodeobjects.com/prometheus
```
in the terminal. This works now. I'm afraid it's too much manual effort to try and rescue the recently landed PRs, so we'll effectively rebuild the statistics from scratch now.