### PR TITLE
ansible: Fix sync-secrets playbook to not clobber s3-keys alias symlinks

### DIFF
--- a/ansible/maintenance/sync-secrets.yml
+++ b/ansible/maintenance/sync-secrets.yml
@@ -12,3 +12,4 @@
   gather_facts: false
   roles:
     - install-secrets-dir
+    - local-s3-alias

--- a/ansible/psi/image-cache.yml
+++ b/ansible/psi/image-cache.yml
@@ -7,6 +7,7 @@
       vars:
         # we have no stable IP and no DNS, and subjectAltNames don't support IP patterns
         disable_tls: 1
+    - role: local-s3-alias
 
 - name: Configure image cache on all task runners
   hosts: openstack_tasks
@@ -18,14 +19,6 @@
         mode: 0644
         content: |
           http://{{ hostvars[groups["psi_s3"][0]].ansible_host }}/images/
-
-    - name: Create s3-keys alias
-      file:
-        src: self-hosted
-        dest: "/var/lib/cockpit-secrets/tasks/s3-keys/{{ hostvars[groups['psi_s3'][0]].ansible_host }}"
-        state: link
-        owner: cockpituous
-        group: cockpituous
 
     - name: Tell tasks containers to drain and restart
       command: pkill -ex cockpit-tasks

--- a/ansible/roles/local-s3-alias/tasks/main.yml
+++ b/ansible/roles/local-s3-alias/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Create s3-keys alias
+  file:
+    src: self-hosted
+    dest: "/var/lib/cockpit-secrets/tasks/s3-keys/{{ hostvars[groups['psi_s3'][0]].ansible_host }}"
+    state: link
+    owner: cockpituous
+    group: cockpituous


### PR DESCRIPTION
The psi/image-cache playbook installs the s3-keys/ symlink for the local S3 mirror on rhos-01-1. But sync-secrets clobbers that (as it always removes the entire existing secrets dir before re-syncing it).

Fix this by factoring out the symlink creation into a nwe "local-s3-alias" role and calling it from both places.

----

I tested this by first removing the existing symlink /var/lib/cockpit-secrets/tasks/s3-keys/10.0.203.194, then running
```
ansible-playbook -v -i inventory psi/image-cache.yml
```

which installed it everywhere. Afterwards I ran

```
ansible-playbook -v -i inventory maintenance/sync-secrets.yml  -l rhos-01-1
```
(i.e. the step which previously removed the symlink), and confirmed that it installed it correctly. In a tasks container I can now do
```
$ ./image-upload --store http://10.0.203.194/images/ cirros
Uploading to http://10.0.203.194/images/cirros-ff4ccf16a162d7d3bf86d30141bd8cfe30821dd3b09712fe2f84d201c8e948af.qcow2
```
(which previously failed with "no such key", see pilot board)