### PR TITLE
ansible: Move npm CA file back to env variable

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -57,7 +57,6 @@
       fetch-timeout=600000
       fetch-retry-mintimeout=60000
       maxsockets=3
-      cafile=/run/secrets/tasks/npm-registry.crt
 
 - name: Create podman.socket drop-in directory
   file:
@@ -114,6 +113,7 @@
 
           # various configuration
           '--volume=/etc/npmrc:/etc/npmrc:ro',
+          '--env=NODE_EXTRA_CA_CERTS=/run/secrets/tasks/npm-registry.crt',
           '--env=TEST_JOBS={{ TEST_JOBS | default(8) }}',
           # copy git settings from main tasks container
           '--env=GIT_COMMITTER_*',


### PR DESCRIPTION
Commit dbd7643e5c958 caused a regression: The `cafile` npmrc option *only* uses the given CA, while `$NODE_EXTRA_CA_CERTS` uses the given CA *in addition*. That broke fetching npm modules directly from github.com, which needs the system default CA lists.

---

Blocks https://github.com/cockpit-project/bots/pull/6148 and also https://github.com/cockpit-project/bots/pull/6160. See the former for debugging notes.