### PR TITLE
ansible: Configure persistent git cache volume for job containers

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -104,6 +104,10 @@
           '--env=COCKPIT_IMAGES_DATA_DIR=/cache/images',
           '--volume=/var/cache/cockpit-tasks/images:/cache/images:rw',
 
+          # persistent git-utils.sh cache
+          '--env=XDG_CACHE_HOME=/cache/',
+          '--volume=cockpituous-git-cache:/cache/cockpit-dev:rw',
+
           # local image stores
           '--env=COCKPIT_IMAGE_STORES_FILE=/config/image-stores',
           '--volume=/var/cache/cockpit-tasks/image-stores:/config/image-stores:ro',


### PR DESCRIPTION
Define a `cockpituous-git-cache` persistent volume so that the expensive and big node-cache.git (plus the much less expensive bots.git) get re-used between jobs.

Note that we don't want to keep *all* of `$XDG_CACHE_HOME`, in particular not the libvirt/ directory. So restrict that to the
`cockpit-dev/` subdirectory, which is handled by cockpit's `git-utils.sh`.

Fixes #611

----

I applied this to rhos-01-1, started a local test [log](https://cockpit-logs.us-east-1.linodeobjects.com/cockpit-podman-cache-test-2/log.html), and inspected the resulting volume from the outside:
```
$ sudo ls -l /var/lib/containers/storage/volumes/cockpituous-git-cache/_data/cockpit-project
total 0
drwxr-xr-x. 1 cockpituous cockpituous 62 Apr  6 08:57 bots.git
drwxr-xr-x. 1 cockpituous cockpituous 62 Apr  6 08:57 node-cache.git
```