### PR TITLE
Split s3 server certificate out of tasks secrets

### DIFF
--- a/ansible/roles/local-secrets-archive/tasks/main.yml
+++ b/ansible/roles/local-secrets-archive/tasks/main.yml
@@ -17,4 +17,4 @@
    become: false
    run_once: yes
    shell: |
-     tar -C $XDG_RUNTIME_DIR/ci-secrets  -hz --hard-dereference -c webhook s3-keys tasks > $XDG_RUNTIME_DIR/ci-secrets.tar.gz
+     tar -C $XDG_RUNTIME_DIR/ci-secrets  -hz --hard-dereference -c webhook s3-keys s3-server tasks > $XDG_RUNTIME_DIR/ci-secrets.tar.gz

--- a/local-s3/install-s3-service
+++ b/local-s3/install-s3-service
@@ -11,7 +11,7 @@ systemctl stop cockpit-s3.service || true
 
 if [ -z "${DISABLE_TLS:-}" ]; then
 
-    CERT_VOLS="-v $SECRETS/tasks/s3-server.key:/root/.minio/certs/private.key:ro -v $SECRETS/tasks/s3-server.pem:/root/.minio/certs/public.crt:ro"
+    CERT_VOLS="-v $SECRETS/s3-server/s3-server.key:/root/.minio/certs/private.key:ro -v $SECRETS/s3-server/s3-server.pem:/root/.minio/certs/public.crt:ro"
     PORT=443
     PROTOCOL=https
 else

--- a/tasks/build-secrets
+++ b/tasks/build-secrets
@@ -36,6 +36,20 @@ for f in $(find -maxdepth 1 -type f -o -type l); do
     printf '  %s: %s\n' "${f#./}" "$(base64 --wrap=0 $f)"
 done
 
+# local S3 image cache server secrets
+cat <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cockpit-s3-server-secrets
+data:
+EOF
+cd "$BASE/s3-server"
+for f in $(find -maxdepth 1 -type f -o -type l); do
+    printf '  %s: %s\n' "${f#./}" "$(base64 --wrap=0 $f)"
+done
+
 # webhook secrets
 cat <<EOF
 


### PR DESCRIPTION
Tasks containers don't need, and therefore should not have, the local minio S3 server certificate.

Our ci-secrets.git repo already moved the S3 certificate out of `tasks/` into the top level `s3-server/` directory. Adjust the deployment scripts and integration test accordingly.