### PR TITLE
tasks: Install chromedriver

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -6,6 +6,7 @@ RUN dnf -y update && \
         'dnf-command(builddep)' \
         adobe-source-code-pro-fonts \
         byobu \
+        chromedriver \
         chromium-headless \
         curl \
         dbus-daemon \


### PR DESCRIPTION
This is required for talking to Chromium through the webdriver (classic and BiDi) protocol. Getting this from the distribution ensures a matching version to chromium-headless.

---

See https://github.com/cockpit-project/starter-kit/pull/934 . This is at most 13 MB of dead weight, but it enables projects to talk webdriver/bidi directly, or use e.g. [webdriver from npm](https://www.npmjs.com/package/webdriver)