### PR TITLE
tasks: Install lorax

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -29,6 +29,7 @@ RUN dnf -y update && \
         libvirt-daemon-driver-qemu \
         libvirt-daemon-driver-storage-core \
         libvirt-python3 \
+        lorax \
         nc \
         net-tools \
         nodejs-devel \


### PR DESCRIPTION
This is required by anaconda tests as they are using `mkksiso` to adjust the test ISO file. [1]

[1]: https://github.com/rhinstaller/anaconda-webui/pull/462