### PR TITLE
tasks: Fix image cache in local podman container, fix ruff 0.7 errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,7 @@ select = [
     "W",       # warnings (mostly whitespace)
     "YTT",     # flake8-2020
 ]
+
+ignore = [
+    "PT001", "PT023", # different versions can't make up their mind how to write decorators
+]

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -123,7 +123,7 @@ container like this:
 ```sh
 podman run -it --rm --device=/dev/kvm --memory=6g --pids-limit=4096 --shm-size=256m \
     --security-opt label=disable -v ~/.cache/cockpit-images:/cache/images \
-    -e TEST_JOBS=2 ghcr.io/cockpit-project/tasks bash
+    -e COCKPIT_IMAGES_DATA_DIR=/cache/images -e TEST_JOBS=2 ghcr.io/cockpit-project/tasks
 ```
 
 Inside, you can then run a test, for example


### PR DESCRIPTION
These days we have to explicitly set `$COCKPIT_IMAGES_DATA_DIR`.

Drop the explicit "bash" command, it's not necessary any more.