### PR TITLE
ansible: Temporarily disable RH internal NPM mirror

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -116,8 +116,9 @@
           '--volume=/var/lib/cockpit-secrets/tasks/npm-registry.crt:/run/secrets/tasks/npm-registry.crt:ro',
 
           # various configuration
-          '--volume=/etc/npmrc:/etc/npmrc:ro',
-          '--env=NODE_EXTRA_CA_CERTS=/run/secrets/tasks/npm-registry.crt',
+          # https://issues.redhat.com/browse/SPRE-880
+          # '--volume=/etc/npmrc:/etc/npmrc:ro',
+          # '--env=NODE_EXTRA_CA_CERTS=/run/secrets/tasks/npm-registry.crt',
           '--env=TEST_JOBS={{ TEST_JOBS | default(8) }}',
           # copy git settings from main tasks container
           '--env=GIT_COMMITTER_*',


### PR DESCRIPTION
It's been down since yesterday, see https://issues.redhat.com/browse/SPRE-880

---

See https://github.com/cockpit-project/cockpit-ostree/pull/738 and https://github.com/cockpit-project/bots/pull/7136 

We don't necessarily have to land this, I am just filing this for transparency. I rolled this out.