### PR TITLE
tasks: Move to Fedora 41

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:41
 LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 
 RUN dnf -y update && \


### PR DESCRIPTION
 - [x] fix https://bugzilla.redhat.com/show_bug.cgi?id=2326535 in Fedora 41
 - [x] https://github.com/cockpit-project/cockpit/pull/21410
 - [x] #633
 - [x] build and test locally with toolbox: starter-kit and cockpit image-prepare and single test: 
 - [x] [build](https://github.com/cockpit-project/cockpituous/actions/runs/12347349190)
 - [x] test `ghcr.io/cockpit-project/tasks:2024-12-14` locally with starter-kit and cockpit

Project updates to this container (worked, but not landing until this is approved):
 - [ ] https://github.com/cockpit-project/starter-kit/pull/1058
 - [ ] https://github.com/cockpit-project/cockpit-podman/pull/1939
 - [ ] https://github.com/cockpit-project/cockpit-files/pull/879
 - [ ] https://github.com/cockpit-project/cockpit-machines/pull/1950
 - [ ] https://github.com/cockpit-project/cockpit-ostree/pull/754

These need some more fixes:
 - [ ] https://github.com/cockpit-project/cockpit/pull/21440
