### PR TITLE
workflows: Auto-refresh tasks container every week

### DIFF
--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -26,18 +26,17 @@ jobs:
 
     steps:
       # NB: no podman on buildjet arm runners
-      -
-        name: Log in to container registry
+      - name: Log in to container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Checkout
+
+      - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
@@ -52,15 +51,14 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      -
-        name: Login in to container registry
+      - name: Login in to container registry
         run: podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-      -
-        name: Create manifest
+
+      - name: Create manifest
         run: podman manifest create tasks '${{ env.tmptag }}'-{amd,arm}64
-      -
-        name: Push with versioned tag
+
+      - name: Push with versioned tag
         run: podman manifest push tasks "${{ env.tag }}:$(date --iso-8601)"
-      -
-        name: Push :latest tag
+
+      - name: Push :latest tag
         run: podman manifest push tasks "${{ env.tag }}:latest"

--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -3,6 +3,9 @@ name: build-tasks
 on:
   # this is meant to be run on an approved PR branch for convenience
   workflow_dispatch:
+  # Run this on Saturday early morning (UTC), our projects try to update Sunday night
+  schedule:
+    - cron: '3 00 * * 6'
 
 # We derive a unique ID here to make sure that we don't get into a situation
 # where different runners pick different tags (eg: for builds near midnight, or


### PR DESCRIPTION
We tend to forget about refreshing the tasks container, and thus fall
behind on browser and toolchain updates.

Run these every Saturday, so that they are ready for the Sunday night
runs of our projects' tasks-container-update workflows.