### PR TITLE
tasks: Regularly clean up leftover containers and outdated images

### DIFF
--- a/ansible/aws/README.md
+++ b/ansible/aws/README.md
@@ -59,7 +59,8 @@ If you run more than one at a time, set a custom host name with `-e hostname=coc
 
 Webhook setup
 -------------
-AWS runs our primary webhook. Deploy or update it with:
+Our primary webhook runs in CentOS CI. If that goes down, we can bring up a
+fallback in AWS. Deploy or update it with:
 
     ansible-playbook -i inventory aws/launch-webhook.yml
 

--- a/ansible/roles/tasks-systemd/cockpituous-janitor.service
+++ b/ansible/roles/tasks-systemd/cockpituous-janitor.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Clean up cockpituous cruft
+
+[Service]
+Type=oneshot
+# remove leftover containers
+ExecStart=/bin/sh -ec 'podman ps -q --filter status=exited | xargs -r podman rm'
+# remove old task images
+ExecStart=/usr/bin/podman image prune --all --force

--- a/ansible/roles/tasks-systemd/cockpituous-janitor.timer
+++ b/ansible/roles/tasks-systemd/cockpituous-janitor.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=Regularly clean up cockpituous cruft
+
+[Timer]
+OnBootSec=1h
+OnUnitActiveSec=24h
+AccuracySec=15min

--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -145,6 +145,18 @@
           '--env=COCKPIT_GITHUB_TOKEN_FILE=/run/secrets/github-token',
       ]
 
+- name: Create janitor service
+  copy:
+    src: "{{ role_path }}/cockpituous-janitor.service"
+    dest: /etc/systemd/system/cockpituous-janitor.service
+    mode: preserve
+
+- name: Create janitor timer
+  copy:
+    src: "{{ role_path }}/cockpituous-janitor.timer"
+    dest: /etc/systemd/system/cockpituous-janitor.timer
+    mode: preserve
+
 - name: Set up systemd service for cockpit/tasks
   shell: |
     export INSTANCES={{ instances | default(1) }}

--- a/tasks/install-service
+++ b/tasks/install-service
@@ -35,6 +35,7 @@ cat <<EOF > /etc/systemd/system/cockpit-tasks@.service
 Description=Cockpit Tasks %i
 Requires=podman.socket
 After=podman.socket
+Wants=cockpituous-janitor.timer
 
 [Service]
 Restart=always


### PR DESCRIPTION
Our bots accumulate outdated task containers which eat a lot of space over time. This will become worse now with automated tasks updates from commit 482418852d.

Our machinery also sometimes leaks exited/failed containers, clean them up as well.

----

Our bot instances tend to look like this:

```
$ sudo podman ps -a
CONTAINER ID  IMAGE                                     COMMAND               CREATED       STATUS                   PORTS       NAMES
94a5d1418d0e  ghcr.io/cockpit-project/tasks:2024-10-07  python3 -c #!/usr...  11 days ago   Exited (1) 11 days ago               serene_lewin
c4aa8e31eaeb  ghcr.io/cockpit-project/tasks:2024-10-07  python3 -c #!/usr...  31 hours ago  Exited (2) 31 hours ago              funny_solomon
fb7bad7a6718  ghcr.io/cockpit-project/tasks:2024-10-07  python3 -c #!/usr...  19 hours ago  Exited (2) 19 hours ago              pensive_sanderson
81b917609411  ghcr.io/cockpit-project/tasks:latest      cockpit-tasks --v...  2 hours ago   Up 2 hours                           cockpit-tasks-1

$ sudo podman images
REPOSITORY                     TAG         IMAGE ID      CREATED       SIZE
ghcr.io/cockpit-project/tasks  latest      838edb5f6014  8 weeks ago   2.13 GB
ghcr.io/cockpit-project/tasks  2024-10-07  838edb5f6014  8 weeks ago   2.13 GB
ghcr.io/cockpit-project/tasks  2024-08-19  8effe37221cc  3 months ago  2.05 GB
ghcr.io/cockpit-project/tasks  2024-07-24  806c4c43e01b  4 months ago  2.02 GB
ghcr.io/cockpit-project/tasks  2024-07-04  8e16bff291ef  5 months ago  1.99 GB
quay.io/cockpit/tasks          2024-03-15  d63ae344d9ef  8 months ago  1.89 GB
```

I rolled this out, the timer started, and cleaned up all that cruft.