### PR TITLE
ansible: Fix podman socket SELinux context on AWS

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -10,7 +10,7 @@
     dest: /tmp/cockpituous.fc
     mode: 0644
     content: |
-      /var/run/podman/podman.sock    system_u:object_r:container_file_t:s0
+      /run/podman/podman.sock    system_u:object_r:container_file_t:s0
   register: selinux_policy_fc
 
 - name: Create custom SELinux policy type enforcements
@@ -43,7 +43,8 @@
   shell: |
     checkmodule -M -m -o /tmp/cockpituous.mod /tmp/cockpituous.te
     semodule_package -o /tmp/cockpituous.pp -m /tmp/cockpituous.mod -f /tmp/cockpituous.fc
-    semodule -i /tmp/cockpituous.pp
+    # needs to be higher than extra_varrun
+    semodule -v --priority=500 -i /tmp/cockpituous.pp
   when: selinux_policy_fc.changed or selinux_policy_te.changed
 
 # This only applies to RH VPN; make that optional if we ever deploy to public infrastructure


### PR DESCRIPTION
On Fedora CoreOS, SELinux wants the socket path in /run, while on Fedora
40 (on our PSI runners) it wants to go via /var/run, due to the
conflicting "extra_varrun" custom policy that Fedora installs for
migration.
    
Adjust the policy for /run (see [1] and bump priority to avoid
conflicting with extra_varrun.
    
[1] https://discussion.fedoraproject.org/t/f40-change-proposal-move-var-run-selinux-policy-entries-to-run-self-contained/100171

---

See https://github.com/orgs/cockpit-project/projects/4/?pane=issue&itemId=69115598 . Tested on PSI and AWS.