### PR TITLE
tasks: Explicitly install python3-pytest-cov

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -51,6 +51,7 @@ RUN dnf -y update && \
         python3-pip \
         python3-pytest \
         python3-pytest-asyncio \
+        python3-pytest-cov \
         python3-pytest-timeout \
         python3-pyyaml \
         python3-types-pyyaml \


### PR DESCRIPTION
Our tests need it, but it doesn't get installed as transient recommends any more.

---

The [12-07 tasks container refresh](https://github.com/cockpit-project/cockpituous/pkgs/container/tasks) lost this package, so that at least bots tests now fail:

```
❱❱ pytest -vv
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --cov-config=pyproject.toml
  inifile: /var/home/martin/upstream/bots/pyproject.toml
  rootdir: /var/home/martin/upstream/bots
```

Which can also be seen [in this failure](https://github.com/cockpit-project/bots/actions/runs/12218266517/job/34083524776?pr=7196) of https://github.com/cockpit-project/bots/pull/7196 which ran against  2024-12-07.

I [triggered a build](https://github.com/cockpit-project/cockpituous/actions/runs/12218280621) against this branch to unblock both PRs.
