### PR TITLE
workflows: Move to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         build:
           - label: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
           - label: arm64
             runner: buildjet-2vcpu-ubuntu-2204-arm
 
@@ -50,7 +50,7 @@ jobs:
   manifest:
     needs: build
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 on: [pull_request]
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -11,14 +11,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y make python3-pyflakes python3-pycodestyle python3-pip python3-pytest
-          # `pip install .[test]` does not work properly on Ubuntu 22.04
-          sudo pip install ruff mypy types-PyYAML
+          sudo pip install .[test]
 
       - name: Run lint tests
         run: make check
 
   tasks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       # enough permissions for tests-scan to work
       pull-requests: read
@@ -41,14 +40,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y make python3-pytest
-
-      # HACK: Ubuntu 22.04 has podman 3.4, which isn't compatible with podman-remote 4 in our tasks container
-      # This PPA is a backport of podman 4.3 from Debian 12; drop this when moving `runs-on:` to ubuntu-24.04
-      - name: Update to newer podman
-        run: |
-          sudo add-apt-repository -y ppa:quarckster/containers
-          sudo apt install -y podman
-          systemctl --user daemon-reload
 
       - name: Check which containers changed
         id: containers_changed

--- a/tasks/credentials/openssl.cnf
+++ b/tasks/credentials/openssl.cnf
@@ -25,7 +25,7 @@ organizationalUnitName = optional
 domainComponent = optional
 
 [ certificate_extensions ]
-basicConstraints = CA:false
+basicConstraints = critical, CA:false
 
 [ req ]
 default_bits = 2048
@@ -39,16 +39,16 @@ x509_extensions = root_ca_extensions
 commonName = hostname
 
 [ root_ca_extensions ]
-basicConstraints = CA:true
+basicConstraints = critical, CA:true
 keyUsage = keyCertSign, cRLSign
 
 [ client_ca_extensions ]
-basicConstraints = CA:false
+basicConstraints = critical, CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 
 [ server_ca_extensions ]
-basicConstraints = CA:false
+basicConstraints = critical, CA:false
 keyUsage = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
 subjectAltName=DNS:*.apps.ocp.ci.centos.org,DNS:*.cockpit-project.org,DNS:cockpit-tests,DNS:cockpituous,DNS:*.compute-1.amazonaws.com,DNS:localhost,DNS:localhost.localdomain


### PR DESCRIPTION
This gets rid of the podman backport PPA, and thus finally runs the integration test on the *exact* same machinery as the production build (which previously has led to problems like in #628).

We can now also stop repeating the test dependencies.