### PR TITLE
tasks: Install full chromium

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -7,7 +7,7 @@ RUN dnf -y update && \
         adobe-source-code-pro-fonts \
         byobu \
         chromedriver \
-        chromium-headless \
+        chromium \
         curl \
         dbus-daemon \
         dbus-glib \


### PR DESCRIPTION
The headless version has several bugs, at least [1] and [2]. Also, headless and full Chromium render texts slightly differently, so we can't debug/fix pixel tests with `TEST_SHOW_BROWSER=pixels`.

This is a net 100 MB size increase of the tasks container, and will break all pixel tests once, but long-term it is a better browser.

[1] https://issues.redhat.com/browse/COCKPIT-1159
[2] https://github.com/cockpit-project/cockpit-files/pull/911#issuecomment-2602064380