### PR TITLE
Add weak dependency of wikitcms needed by anaconda-webui infra

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -45,6 +45,7 @@ RUN dnf -y update && \
         python3-flake8 \
         python3-mypy \
         python3-mwclient \
+        python-openidc-client \
         python3-pcp \
         python3-pika \
         python3-pillow \


### PR DESCRIPTION
This is recommened package for wikitcms needed for authentication to fedora wiki but because we `--setopt=install_weak_deps=False` this was not installed.

See: https://src.fedoraproject.org/rpms/python-wikitcms/blob/rawhide/f/python-wikitcms.spec#_30