### PR TITLE
ansible: Add fedora-wiki tasks secret

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -145,6 +145,10 @@
           '--volume=/var/lib/cockpit-secrets/webhook/.config--github-token:/run/secrets/github-token:ro',
           '--env=COCKPIT_GITHUB_TOKEN_FILE=/run/secrets/github-token',
       ]
+      fedora-wiki=[
+          '--volume=/var/lib/cockpit-secrets/tasks/fedora-wiki.json:/run/secrets/fedora-wiki.json:ro',
+          '--env=COCKPIT_FEDORA_WIKI_TOKEN=/run/secrets/fedora-wiki.json',
+      ]
 
 - name: Create janitor service
   copy:


### PR DESCRIPTION
For posting Anaconda nightly compose test results.

---

I already committed the new secret to the private git and rolled it out to the host. After that we still need to teach bots to actually use the new secret.

Also see https://github.com/rhinstaller/anaconda-webui/pull/641