### PR TITLE
tasks: Remove unnecessary packages

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -10,20 +10,15 @@ RUN dnf -y update && \
         chromium \
         curl \
         dbus-daemon \
-        dbus-glib \
         diffstat \
-        expect \
         firefox \
         fpaste \
-        gcc-c++ \
         genisoimage \
-        git \
-        gnupg \
+        git-core \
         google-noto-cjk-fonts-common \
         intltool \
         jq \
         lcov \
-        libXt \
         libappstream-glib \
         libvirt-client \
         libvirt-daemon-driver-qemu \


### PR DESCRIPTION
 - dbus-glib and libXt were added in commit 23afb2d197f0e9 for firefox nightly builds. But we've switched back to the Fedora package long ago which explicitly depends on these.

 - expect hasn't been used by our image build scripts any more for ages.

 - gcc-c++ and gnupg aren't used by any current project.

 - git-core is enough, we don't need the documentation and extra modules.
