### PR TITLE
workflows: Clean up unused tasks containers (dry mode)

### DIFF
--- a/.github/workflows/cleanup-tasks.yml
+++ b/.github/workflows/cleanup-tasks.yml
@@ -1,0 +1,51 @@
+name: cleanup-tasks
+on:
+  workflow_dispatch:
+  # Run this before build-tasks
+  schedule:
+    - cron: '2 00 * * 6'
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      packages: read
+      # enable this once removing dry mode
+      # packages: write
+
+    steps:
+      - name: Check out bots
+        uses: actions/checkout@v4
+        with:
+          repository: cockpit-project/bots
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-aiohttp
+
+      - name: Set up token
+        run: |
+          mkdir -p ~/.config/cockpit-dev
+          echo "${{ secrets.GITHUB_TOKEN }}" > ~/.config/cockpit-dev/github-token
+
+      - name: Get used images
+        id: get_used_tags
+        run: |
+          used=$(./used-tasks-tags)
+          echo "Used tags: $used"
+          echo "used=$used" >> $GITHUB_OUTPUT
+
+      # https://github.com/marketplace/actions/ghcr-io-cleanup-action
+      - name: Clean up unused images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          packages: tasks,tasks-tmp
+          keep-n-tagged: 6
+          delete-untagged: true
+          delete-partial-images: true
+          delete-orphaned-images: true
+          # start with dry mode
+          dry-run: true
+          validate: true
+          exclude-tags: ${{ steps.get_used_tags.outputs.used }}


### PR DESCRIPTION
We've accrued tons of outdated and unsupported tasks images, plus the tasks-tmp intermediate one. Clean up our registry regularly using [1].

Use our new `used-tasks-tags` script [2] to determine which tags are currently in use. Also keep the most recent six tags, in case we need to investigate some flakes.

Start with dry-mode, to establish the workflow on main and allow us to run it manually from a branch.

[1] https://github.com/marketplace/actions/ghcr-io-cleanup-action
[2] https://github.com/cockpit-project/bots/pull/7944

----

I did a [first run](https://github.com/cockpit-project/cockpituous/actions/runs/16068048767/job/45346272265) with attaching this to the existing "build-tasks" workflow, as we can't run a workflow from a branch that doesn't exist on main. Its output looks very promising, e.g. it [finds the broken partial image](https://github.com/cockpit-project/cockpituous/actions/runs/16068048767/job/45346272265#step:6:205)

> sha256:dbcbe0be25fdb20c45e51a46f3c04740e19a6d18a6e8c52043e48deffe2dd0be 2024-03-16

which broke cockpit's rhel8 branch (see https://github.com/cockpit-project/cockpit/pull/22161).

The [tags to delete](https://github.com/cockpit-project/cockpituous/actions/runs/16068048767/job/45346272265#step:6:211) list looks correct. It keeps the recent ones from June and late May, and keeps the old used ones (2024-03-18, 2024-04-25, 2024-08-19).

 - [x] Land https://github.com/cockpit-project/bots/pull/7944
 - [x] Update the workflow to check out bots main branch
 - [x] Move the code to its own new workflow
 - [x] https://github.com/cockpit-project/bots/pull/7961
 - [ ] Follow-up after landing this: Remove dry-run and allow "write" permission for packages, and run it for real on the branch
