### PR TITLE
workflows: Enable cleanup-tasks

### DIFF
--- a/.github/workflows/cleanup-tasks.yml
+++ b/.github/workflows/cleanup-tasks.yml
@@ -9,9 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      packages: read
-      # enable this once removing dry mode
-      # packages: write
+      packages: write
 
     steps:
       - name: Check out bots
@@ -45,7 +43,5 @@ jobs:
           delete-untagged: true
           delete-partial-images: true
           delete-orphaned-images: true
-          # start with dry mode
-          dry-run: true
           validate: true
           exclude-tags: ${{ steps.get_used_tags.outputs.used }}


### PR DESCRIPTION
Follow-up after #659 . Now that the workflow is on main, we can run it from a branch.

 * [Run of main](https://github.com/cockpit-project/cockpituous/actions/runs/16118266784/job/45477218333) in dry-run mode, shows the correct tags/images to clean up.
 * Current status quo: [tasks](https://github.com/cockpit-project/cockpituous/pkgs/container/tasks/versions) has 50 tagged, 110 untagged images; [tasks-tmp](https://github.com/cockpit-project/cockpituous/pkgs/container/tasks-tmp/versions) has 111 tagged, 0 untagged versions.
 * [Run of this PR's workflow](https://github.com/cockpit-project/cockpituous/actions/runs/16118358745/job/45477525027) cleaned up lots of images. Now tasks is down to "11 tagged, 22 untagged" and tasks-tmp down to "6 tagged, 0 untagged" (exactly corresponding to `keep-n-tagged`).