### PR TITLE
Anubis proxy for our cockpit-logs S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ These directories define our CI infrastructure.
 
  * [ansible](./ansible/): playbooks for deploying our CI to various clouds
  * [local-s3](./local-s3/): local S3 container for per-cluster image caching
+ * [logs-proxy](./logs-proxy/): web proxy for S3 log access (running on OpenShift)
  * [metrics](./metrics/): Prometheus, Grafana, and CI weather (running on OpenShift)
  * [tasks](./tasks/): tasks container and related setup scripts for integration tests or image rebuilds

--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -88,6 +88,8 @@
       # bots lib/stores.py LOG_STORE
       url = 'https://cockpit-logs.us-east-1.linodeobjects.com/'
       key = [{file="/run/secrets/s3-keys/cockpit-logs.us-east-1.linodeobjects.com"}]
+      proxy_url = 'https://logs-cockpit.apps.ocp.cloud.ci.centos.org/'
+      acl = 'authenticated-read'
 
       [container]
       command = ['podman-remote', '--url=unix:///podman.sock']

--- a/logs-proxy/README.md
+++ b/logs-proxy/README.md
@@ -1,0 +1,32 @@
+# Cockpit S3 logs proxy
+
+This service implements an [Anubis](https://anubis.techaro.lol/) log proxy for
+our `cockpit-logs` S3 bucket. This will soon be changed from `public` to
+`authenticated-read` to prevent unrestricted access to the logs, in particular
+to fend off aggressive AI scrapers.
+
+This re-uses our [bots S3 signing algorithm](https://github.com/cockpit-project/bots/blob/main/lib/s3.py).
+S3 signing is hard with nginx/lua, but we don't care about performance here, so
+Python will be fine.
+
+# Deployment
+
+The proxy runs on Kubernetes, in particular our CentOS CI OpenShift. That's
+much less efficient than running it on Linode, but maintaining an instance with
+a domain name and valid TLS certificate requires a lot more effort and
+overhead. Given how rarely humans look at logs, the extra traffic shouldn't
+hurt much.
+
+The proxy requires an S3 token with read access, which is stored in the
+`cockpit-s3-log-read-secrets` Kubernetes secret. Run
+
+```
+ansible-playbook -i inventory -f20 maintenance/sync-secrets.yml
+```
+
+first to create/update the secret. Then deploy the proxy with
+
+```
+oc create configmap logs-proxy-app --from-file logs-proxy/s3-proxy.py
+oc apply -f logs-proxy/proxy.yaml
+```

--- a/logs-proxy/proxy.yaml
+++ b/logs-proxy/proxy.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logs-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      infra: logs-proxy
+  template:
+    metadata:
+      name: logs-proxy
+      labels:
+        infra: logs-proxy
+    spec:
+      containers:
+      - name: app
+        image: docker.io/library/python:3-alpine
+        command: ["python3", "/app/s3-proxy.py", "https://cockpit-logs.us-east-1.linodeobjects.com", "10080"]
+        volumeMounts:
+        - name: logs-proxy-app
+          mountPath: /app/
+          readOnly: true
+        - name: s3-credentials
+          mountPath: /s3
+          readOnly: true
+
+      - name: anubis
+        image: ghcr.io/techarohq/anubis:latest
+        ports:
+          - containerPort: 8080
+            protocol: TCP
+            name: anubis-port
+        env:
+          # https://anubis.techaro.lol/docs/admin/installation/
+          - name: BIND
+            value: ":8080"
+          - name: METRICS_BIND
+            value: ":9099"
+          - name: SERVE_ROBOTS_TXT
+            value: "true"
+          - name: TARGET
+            # app container listens on port 10080
+            value: "http://localhost:10080/"
+          - name: DIFFICULTY
+            value: "6"
+          - name: COOKIE_EXPIRATION_TIME
+            value: "24h"
+
+      volumes:
+      - name: logs-proxy-app
+        configMap:
+          name: logs-proxy-app
+          defaultMode: 0755
+      - name: s3-credentials
+        secret:
+          secretName: cockpit-s3-log-read-secrets
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: logs-http
+spec:
+  clusterIP: None
+  selector:
+    infra: logs-proxy
+  ports:
+  # we use edge termination, so talk to plain http
+  - targetPort: anubis-port
+    port: 8080
+    protocol: TCP
+    name: anubis-port
+
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: logs
+spec:
+  to:
+    kind: Service
+    name: logs-http
+  port:
+    targetPort: anubis-port
+  tls:
+    termination: edge

--- a/logs-proxy/s3-proxy.py
+++ b/logs-proxy/s3-proxy.py
@@ -1,0 +1,135 @@
+import hashlib
+import hmac
+import http.server
+import socketserver
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+class S3ProxyHandler(http.server.BaseHTTPRequestHandler):
+    def sign_request(self,
+                     url: urllib.parse.ParseResult,
+                     method: str,
+                     headers: dict[str, str],
+                     checksum: str) -> dict[str, str]:
+        """Signs an AWS request using the AWS4-HMAC-SHA256 algorithm
+
+        Taken from https://github.com/cockpit-project/bots/blob/main/lib/s3.py
+        """
+
+        # Read S3 credentials
+        with open('/s3/access-key', 'r') as f:
+            access_key = f.read().strip()
+        with open('/s3/secret', 'r') as f:
+            secret_key = f.read().strip()
+
+        amzdate = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
+
+        # Header canonicalisation demands all header names in lowercase
+        headers = {key.lower(): value for key, value in headers.items()}
+        assert url.hostname
+        headers.update({'host': url.hostname, 'x-amz-content-sha256': checksum, 'x-amz-date': amzdate})
+        headers_str = ''.join(f'{k}:{v}\n' for k, v in sorted(headers.items()))
+        headers_list = ';'.join(sorted(headers))
+
+        credential_scope = f'{amzdate[:8]}/any/s3/aws4_request'
+        signing_key = f'AWS4{secret_key}'.encode('ascii')
+        for item in credential_scope.split('/'):
+            signing_key = hmac.new(signing_key, item.encode('ascii'), hashlib.sha256).digest()
+
+        algorithm = 'AWS4-HMAC-SHA256'
+        canonical_request = f'{method}\n{url.path}\n{url.query}\n{headers_str}\n{headers_list}\n{checksum}'
+        request_hash = hashlib.sha256(canonical_request.encode('ascii')).hexdigest()
+        string_to_sign = f'{algorithm}\n{amzdate}\n{credential_scope}\n{request_hash}'
+        signature = hmac.new(signing_key, string_to_sign.encode('ascii'), hashlib.sha256).hexdigest()
+        headers['Authorization'] = (
+            f'{algorithm} Credential={access_key}/{credential_scope},SignedHeaders={headers_list},Signature={signature}'
+        )
+
+        return headers
+
+    def proxy_request(self, method: str):
+        """Proxy the request to S3 with authentication"""
+        if self.path == '/health':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'healthy\n')
+            return
+
+        # disallow directory listing
+        if self.path == '/':
+            self.send_response(403)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'Forbidden: directory listing is not allowed\n')
+            return
+
+        s3_url = urllib.parse.urlparse(f'{S3_BUCKET_URL}{self.path}')
+        headers = self.sign_request(s3_url, method, {}, hashlib.sha256(b'').hexdigest())
+        request = urllib.request.Request(s3_url.geturl(), headers=headers, method=method)
+
+        try:
+            with urllib.request.urlopen(request) as response:
+                # forward response
+                self.send_response(response.getcode())
+                # forward headers
+                for header, value in response.headers.items():
+                    if header.lower() not in ['connection', 'transfer-encoding']:
+                        self.send_header(header, value)
+                self.end_headers()
+                # forward body
+                self.wfile.write(response.read())
+
+        except urllib.error.HTTPError as e:
+            # forward HTTP errors
+            self.send_response(e.code)
+            for header, value in e.headers.items():
+                if header.lower() not in ['connection', 'transfer-encoding']:
+                    self.send_header(header, value)
+            self.end_headers()
+            self.wfile.write(e.read())
+
+        except Exception as e:
+            # Internal server error
+            self.send_response(500)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'Proxy error, see pod log\n')
+            sys.stderr.write(f'Error while proxying request: {e}\n')
+
+    def do_GET(self):
+        self.proxy_request('GET')
+
+    def do_HEAD(self):
+        self.proxy_request('HEAD')
+
+    def log_request(self, code='-', size='-'):
+        """Log the request with X-Real-Ip and User-Agent headers"""
+        x_real_ip = self.headers.get('X-Real-Ip', '-')
+        user_agent = self.headers.get('User-Agent', '-')
+
+        sys.stdout.write(f'[{self.log_date_time_string()}] {x_real_ip} '
+                         f'"{self.requestline}" {code} {size} User-Agent="{user_agent}"\n')
+        sys.stdout.flush()
+
+    def log_message(self, format, *args):  # noqa: A002
+        # Log to stdout
+        sys.stderr.write(f"{self.address_string()} - - [{self.log_date_time_string()}] {format % args}\n")
+        sys.stderr.flush()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: s3-proxy.py <s3-bucket-url> <port>")
+        sys.exit(1)
+
+    S3_BUCKET_URL = sys.argv[1]
+    port = int(sys.argv[2])
+
+    with socketserver.TCPServer(("", port), S3ProxyHandler) as httpd:
+        print(f"S3 proxy server running on port {port} for bucket {S3_BUCKET_URL}")
+        httpd.serve_forever()

--- a/tasks/build-secrets
+++ b/tasks/build-secrets
@@ -36,6 +36,20 @@ for f in $(find -maxdepth 1 -type f -o -type l); do
     printf '  %s: %s\n' "${f#./}" "$(base64 --wrap=0 $f)"
 done
 
+# S3 log read-only token
+cat <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cockpit-s3-log-read-secrets
+data:
+EOF
+cd "$BASE/s3-log-read"
+for f in $(find -maxdepth 1 -type f -o -type l); do
+    printf '  %s: %s\n' "${f#./}" "$(base64 --wrap=0 $f)"
+done
+
 # local S3 image cache server secrets
 cat <<EOF
 ---

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -305,7 +305,7 @@ def mock_github(pod: PodData, bots_sha: str) -> Iterator[str]:
 
     yield f'export GITHUB_API={GHAPI_URL_POD}; SHA={bots_sha}'
 
-    mock_github.kill()
+    exec_c_out(pod.tasks, 'pkill -f mock-github')
     mock_github.wait()
 
 


### PR DESCRIPTION
We will make our S3 logs bucket private, and only allow reading logs through an Anubis proxy. This hopefully resolves the ridiculous traffic that we've been getting on our S3 buckets due to AI scrapers.

https://issues.redhat.com/browse/COCKPIT-1288.

See individual commits for details.

I deployed this. For testing I made a [single file private](https://cockpit-logs.us-east-1.linodeobjects.com/pull-2175-60c819be-20250703-052724-arch/log) (you'll get AccessDenied), but it's accessible through the proxy: https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-2175-60c819be-20250703-052724-arch/log

 - [x] Update bots to adjust the statuses URL to the OpenShift route: https://github.com/cockpit-project/bots/pull/7980
 - [x] Add integration test for `proxy_url` config
 - [x] Update job-runner config to add the proxy
 - [x] ~Configure Anubis to *actually* block bot traffic: https://github.com/TecharoHQ/anubis/discussions/809~ works as intended (User-Agent policy); we can tighten the policy to all agents if necessary, but then need to e.g. fix `test/common/pixel-tests fetch`
 - [x] Update documentation
 - [x] Change log ACLs to `authenticated-read`
 - [x] Deploy new job runner config
 - [x] Run a starter-kit test to validate GitHub statuses point to the proxy and they are readable: https://github.com/cockpit-project/starter-kit/pull/1197
 - [x] Temporarily reduce lifecycle: `s3cmd expire --expiry-days=7 s3://cockpit-logs`, changing 0.5M files takes far too long
 - [x] Wait until the above lifecycle becomes active, should be 2025-07-15 around 04:00 UTC according to [lifecycle docs](https://techdocs.akamai.com/cloud-computing/docs/lifecycle-policies)
 - [x] Revert lifecycle to 90 days
 - [x] Make the whole logs bucket private: `s3cmd setacl -v s3://cockpit-logs --acl-private --recursive`
