### PR TITLE
ansible: Set up S3 image cache secret in image-cache playbook

### DIFF
--- a/ansible/psi/image-cache.yml
+++ b/ansible/psi/image-cache.yml
@@ -22,3 +22,9 @@
 
     - name: Tell tasks containers to drain and restart
       command: pkill -ex cockpit-tasks
+
+- name: Set up S3 image cache secret
+  hosts: openstack_tasks
+  gather_facts: false
+  roles:
+    - local-s3-alias


### PR DESCRIPTION
When running the psi/image-cache.yml playbook after launch-tasks.yml, as described in psi/README.md, the S3 key for our local image cache wasn't set up.

---

See https://github.com/cockpit-project/bots/issues/8145 and all the failed image refreshes today.