### PR TITLE
workflows: Build ARM tasks image on GitHub runner

### DIFF
--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -22,13 +22,12 @@ jobs:
           - label: amd64
             runner: ubuntu-24.04
           - label: arm64
-            runner: buildjet-2vcpu-ubuntu-2204-arm
+            runner: ubuntu-22.04-arm
 
     runs-on: ${{ matrix.build.runner }}
     timeout-minutes: 10
 
     steps:
-      # NB: no podman on buildjet arm runners
       - name: Log in to container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Commit a4c513ac49 moved the workflow to checkout@v5. The buildjet runners don't get along with this, apparently they don't have a new enough nodejs installed yet:

> Error: System.ArgumentOutOfRangeException:
> Specified argument was out of the range of valid values.
> (Parameter ''using: node24' is not supported, use 'docker', 'node12', 'node16' or 'node20' instead.')

Move to a GitHub ARM runner instead.

 - [X] [container build](https://github.com/cockpit-project/cockpituous/actions/runs/17367343524)
 - [x] https://github.com/cockpit-project/cockpit/pull/22385
 - [x] https://github.com/cockpit-project/cockpit-files/pull/1176