### PR TITLE
tasks: add vhost-device-vsock to the container

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -65,6 +65,7 @@ RUN dnf -y update && \
         valgrind \
         vim-enhanced \
         virt-install \
+        vhost-device-vsock \
         && \
     curl -o /tmp/cockpit.spec -s https://raw.githubusercontent.com/cockpit-project/cockpit/main/tools/cockpit.spec && \
     dnf -y builddep --setopt=install_weak_deps=False /tmp/cockpit.spec && \


### PR DESCRIPTION
test.thing wants to depend on this to avoid using vsock on the host machine, avoiding all kids of problems.