### PR TITLE
ansible: add Codeberg token

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -84,6 +84,10 @@
       [forge.github]
       token = [{file="/run/secrets/webhook/.config--github-token"}]
 
+      [forge.codeberg]
+      token = [{file="/run/secrets/webhook/.config--codeberg-token"}]
+      post = true
+
       [logs.s3]
       # bots lib/stores.py LOG_STORE
       url = 'https://cockpit-logs.us-east-1.linodeobjects.com/'


### PR DESCRIPTION
ci-secrets now contains a token for repository:write on the Codeberg account "cockpit-ci".  Add that to our job-runner config.