### PR TITLE
ansible: set `post = true` in job-runner.toml

### DIFF
--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -83,6 +83,7 @@
 
       [forge.github]
       token = [{file="/run/secrets/webhook/.config--github-token"}]
+      post = true
 
       [forge.codeberg]
       token = [{file="/run/secrets/webhook/.config--codeberg-token"}]

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -328,6 +328,7 @@ def generate_config(config: Config, forge_opts: str, s3_opts: str, run_args: str
 
         [forge.github]
         token = [{{file="/run/secrets/webhook/.config--github-token"}}]
+        post = true
         {forge_opts}
 
         [logs.s3]


### PR DESCRIPTION
We're about to change the default of this to `false` to enable more of the job-runner internals to be used from other scripts.