### PR TITLE
doc: Update for asciidoctor

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -4,6 +4,8 @@ LABEL maintainer='cockpit-devel@lists.fedorahosted.org'
 RUN dnf -y update && \
     dnf -y install --disablerepo=fedora-cisco-openh264 --setopt=install_weak_deps=False \
         'dnf-command(builddep)' \
+        # TEMP: Need asciidoctor to be able to run unit tests for asciidoc PR, once merged cockpit.spec takes care of this
+        asciidoctor \
         adobe-source-code-pro-fonts \
         byobu \
         chromedriver \


### PR DESCRIPTION
We need asciidoctor for unit tests to run within the asciidoc PR. When
that PR is merged we can remove this as we will then install it from the
`cockpit.spec` file.

Related-to: https://issues.redhat.com/browse/COCKPIT-1340
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
