### PR TITLE
local-s3: Switch to Hummingbird minio containers

### DIFF
--- a/local-s3/install-s3-service
+++ b/local-s3/install-s3-service
@@ -14,7 +14,7 @@ systemctl stop cockpit-s3.service || true
 
 if [ -z "${DISABLE_TLS:-}" ]; then
 
-    CERT_VOLS="-v $SECRETS/s3-server/s3-server.key:/root/.minio/certs/private.key:ro -v $SECRETS/s3-server/s3-server.pem:/root/.minio/certs/public.crt:ro"
+    CERT_VOLS="-v $SECRETS/s3-server/s3-server.key:/.minio/certs/private.key:ro,z -v $SECRETS/s3-server/s3-server.pem:/.minio/certs/public.crt:ro,z"
     PORT=443
     PROTOCOL=https
 else
@@ -32,7 +32,7 @@ Restart=always
 RestartSec=60
 ExecStartPre=-$RUNC rm -f cockpit-s3
 ExecStartPre=/bin/sh -c 'dd if=/dev/urandom bs=12 count=1 status=none | base64 > /run/cockpit-s3.rootpassword.txt'
-ExecStart=/bin/sh -xc "$RUNC run --name=cockpit-s3 --publish=$PORT:9000 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=\$(cat /run/cockpit-s3.rootpassword.txt) $CERT_VOLS -v images-minio-data:/data:rw quay.io/minio/minio server /data"
+ExecStart=/bin/sh -xc "$RUNC run --name=cockpit-s3 --publish=$PORT:9000 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=\$(cat /run/cockpit-s3.rootpassword.txt) $CERT_VOLS -v images-minio-data:/data:U,rw quay.io/hummingbird/minio server /data"
 ExecStartPost=/usr/local/lib/setup-s3.sh
 ExecStartPost=/bin/rm -f /run/cockpit-s3.rootpassword.txt
 ExecStop=$RUNC rm -f cockpit-s3
@@ -52,7 +52,7 @@ mkdir -p "$MC_CONFIG/certs/CAs"
 cp "$SECRETS/webhook/ca.pem" "$MC_CONFIG/certs/CAs/ca.crt"
 
 run_mc() {
-    $RUNC run --rm --network=host -v "$MC_CONFIG:/root/.mc:z" quay.io/minio/mc "\$@"
+    $RUNC run --rm --network=host -v "$MC_CONFIG:/mc/.mc:U,z" quay.io/hummingbird/minio-client "\$@"
 }
 
 # Wait for S3 to be ready by retrying alias set

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -133,8 +133,8 @@ class PodData:
         """Run mc command in minio mc container"""
         subprocess.run(
             ['podman', 'run', '--rm', '-i', f'--pod={self.pod}',
-             '-v', f'{self.mc_dir}:/root/.mc:z',
-             'quay.io/minio/mc',
+             '-v', f'{self.mc_dir}:/mc/.mc:U,z',
+             'quay.io/hummingbird/minio-client',
              *argv],
             check=True,
             timeout=30,  # avoid hanging tests
@@ -169,11 +169,11 @@ def pod(config: Config, pytestconfig) -> Iterator[PodData]:
     # minio S3 store
     data.s3 = f'cockpituous-s3-{test_instance}'
     subprocess.run(['podman', 'run', '-d', '--name', data.s3, f'--pod={data.pod}', *launch_args,
-                    '-v', f'{config.s3_server}/s3-server.key:/root/.minio/certs/private.key:ro',
-                    '-v', f'{config.s3_server}/s3-server.pem:/root/.minio/certs/public.crt:ro',
+                    '-v', f'{config.s3_server}/s3-server.key:/.minio/certs/private.key:ro',
+                    '-v', f'{config.s3_server}/s3-server.pem:/.minio/certs/public.crt:ro',
                     '-e', 'MINIO_ROOT_USER=minioadmin',
                     '-e', 'MINIO_ROOT_PASSWORD=minioadmin',
-                    'quay.io/minio/minio', 'server', '/data', '--console-address', ':9001'],
+                    'quay.io/hummingbird/minio', 'server', '/data', '--console-address', ':9001'],
                    check=True)
 
     proc = subprocess.run(['podman', 'port', data.s3, '9000'], capture_output=True, text=True, check=True)


### PR DESCRIPTION
The official image is deprecated and not updated any more [1][2], so we need to
switch to a maintained image. Project Hummingbird just got a new one [3], so
switch to that.

This requires some adjustments to volume paths, as the Hummingbird image runs
as non-root user and thus does not have `HOME=/root`.

Related: https://issues.redhat.com/browse/HUM-167

[1] https://github.com/minio/minio/commit/9e49d5e7a648f00e
[2] https://github.com/minio/minio/issues/21647
[3] https://quay.io/repository/hummingbird/minio

----

Goes on top of #676. I rolled this out and verified on rhos-01-2 with `sudo podman exec -it -w /work/bots cockpit-tasks-1 python3 -m lib.s3 ls http://10.0.203.212/images/`.