### PR TITLE
tasks: Bump Docker deps

### DIFF
--- a/.github/workflows/build-tasks.yml
+++ b/.github/workflows/build-tasks.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Log in to container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: ${{ env.tmptag }}-${{ matrix.build.label }}


### PR DESCRIPTION
They will be EOL soon and stop working, updating to latest version
should work.

Fixes: https://github.com/cockpit-project/cockpituous/issues/691
Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
