### PR TITLE
webhook: Create durable AMQP queue; update to RabbitMQ 4.3

### DIFF
--- a/ansible/roles/webhook/cockpituous-webhook.service
+++ b/ansible/roles/webhook/cockpituous-webhook.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/podman run \
     --tmpfs /var/lib/rabbitmq \
     -v /etc/rabbitmq:/etc/rabbitmq:ro,z \
     -v /var/lib/cockpit-secrets/webhook:/run/secrets/webhook:ro,z \
-    docker.io/rabbitmq:4.2.6
+    docker.io/rabbitmq
 
 ExecStart=/usr/bin/podman run \
     --cgroups=no-conmon \

--- a/tasks/container/webhook
+++ b/tasks/container/webhook
@@ -70,7 +70,7 @@ def distributed_queue(amqp_server):
         credentials=pika.credentials.ExternalCredentials()))
     channel = connection.channel()
 
-    channel.queue_declare(queue='webhook', auto_delete=False)
+    channel.queue_declare(queue='webhook', durable=True, auto_delete=False)
     yield channel
     connection.close()
 

--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -163,7 +163,7 @@ def pod(config: Config, pytestconfig) -> Iterator[PodData]:
                     '--publish', '9000',
                     '-v', f'{config.rabbitmq}:/etc/rabbitmq:ro',
                     '-v', f'{config.webhook}:/run/secrets/webhook:ro',
-                    'docker.io/rabbitmq:4.2.6'],
+                    'docker.io/rabbitmq'],
                    check=True)
 
     # minio S3 store


### PR DESCRIPTION
And revert "Temporarily pin rabbitmq to 4.2.6". See https://github.com/cockpit-project/cockpituous/pull/695#discussion_r3205932750 .

~This will still fail until https://github.com/cockpit-project/bots/pull/9007 lands.~ Landed