### PR TITLE
aws: Update tags according to current policy

### DIFF
--- a/ansible/aws/README.md
+++ b/ansible/aws/README.md
@@ -9,13 +9,15 @@ Initial URLs
 
 Credentials configuration
 -------------------------
-For interacting with AWS with these Ansible playbooks or with the [AWS CLI](https://docs.aws.amazon.com/cli/index.html), put your access key into ~/.aws/credentials, either with calling `aws configure`, or creating the file manually:
+For interacting with AWS with these Ansible playbooks or with the [AWS CLI](https://docs.aws.amazon.com/cli/index.html), put your access key into `~/.config/aws/credentials`, either with calling `aws configure`, or creating the file manually:
 
 ```ini
 [default]
 aws_access_key_id = AKIA...
 aws_secret_access_key = yoursecret
 ```
+
+Note: On some systems, the AWS CLI and Ansible may use the old `~/.aws/credentials` location. Both locations are supported.
 
 SSH key
 -------

--- a/ansible/aws/launch-demo.yml
+++ b/ansible/aws/launch-demo.yml
@@ -17,11 +17,10 @@
         assign_public_ip: yes
         group: public-all
         instance_tags:
-          Name: cockpit-demo
-          ServiceOwner: FrontDoorSST
-          ServiceComponent: Demo
-          ServicePhase: Temporary
-          AppCode: ARR-001
+          app-code: ARR-001
+          cost-center: 700
+          service-owner: cockpit
+          service-phase: lab
       register: ec2
 
     - name: Add new instance to host group

--- a/ansible/aws/tasks/launch-coreos.yml
+++ b/ansible/aws/tasks/launch-coreos.yml
@@ -35,12 +35,10 @@
     vpc_subnet_id: "{{ vpc_subnet_id | default(omit) }}"
     volumes: "{{ volumes | default(omit) }}"
     tags:
-      Name: "{{ tag_name }}"
-      ServiceOwner: FrontDoorSST
-      ServiceName: FrontDoorCI
-      ServiceComponent: "{{ tag_service_component }}"
-      ServicePhase: Prod
-      AppCode: ARR-001
+      app-code: ARR-001
+      cost-center: 700
+      service-owner: cockpit
+      service-phase: prod
   register: ec2
 
 - name: Add new instance to host group

--- a/ansible/inventory/aws_ec2.yml
+++ b/ansible/inventory/aws_ec2.yml
@@ -10,6 +10,6 @@ hostnames:
   - dns-name
   - private-ip-address
 filters:
-  tag:ServiceOwner: FrontDoorSST
+  tag:service-owner: cockpit
 compose:
   ansible_become: true


### PR DESCRIPTION
See https://source.redhat.com/departments/strategy_and_operations/it/datacenter_infrastructure/itcloudservices/itpubliccloudpage/cloud/itpc_annoucements/updated_it_public_cloud_tagging_policy

Thanks to @thrix for pointing this out!