### PR TITLE
Move S3 log store to our AWS account

### DIFF
--- a/ansible/aws/README.md
+++ b/ansible/aws/README.md
@@ -1,23 +1,57 @@
 Resources for setting up CI in AWS
 ==================================
 
-Initial URLs
-------------
+AWS user management console
+---------------------------
 
- * Sign in [with your kerberos ticket](https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/saml/clients/itaws); this needs to be set up first for new users, ask Dominik Perpeet or Miroslav Vadkerti about it
- * The [User management console](https://console.aws.amazon.com/iam/home?#/users) shows the available users and their Access Keys. The Cockpit team CI uses the [arr-cockpit](https://console.aws.amazon.com/iam/home?#/users/arr-cockpit) user. Contact Miroslav Vadkerti about creating a new access key for you.
+ * Sign in [with your kerberos ticket](https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/saml/clients/itaws); this needs to be set up first for new users, ask Miroslav Vadkerti about it
+ * The [User management console](https://console.aws.amazon.com/iam/home?#/users) shows the available users and their Access Keys. The Cockpit team CI uses the [arr-cockpit](https://console.aws.amazon.com/iam/home?#/users/arr-cockpit) user for CI runtime, and the [arr-cockpit-bootstrap](https://us-east-1.console.aws.amazon.com/iam/home#/users/details/arr-cockpit-bootstrap?section=permissions) user for deploying the S3 buckets/credentials.
+
+Contact Miroslav Vadkerti about maintaining these users, privileges, and access keys.
 
 Credentials configuration
 -------------------------
-For interacting with AWS with these Ansible playbooks or with the [AWS CLI](https://docs.aws.amazon.com/cli/index.html), put your access key into `~/.config/aws/credentials`, either with calling `aws configure`, or creating the file manually:
+For interacting with AWS with these Ansible playbooks or with the [AWS CLI](https://docs.aws.amazon.com/cli/index.html), configure multiple profiles in `~/.config/aws/credentials`:
 
 ```ini
+# arr-cockpit
 [default]
-aws_access_key_id = AKIA...
-aws_secret_access_key = yoursecret
+aws_access_key_id = AKIA...arr-cockpit...
+aws_secret_access_key = ...arr-cockpit-secret...
+
+# arr-cockpit-bootstrap
+[bootstrap]
+aws_access_key_id = AKIA...arr-cockpit-bootstrap...
+aws_secret_access_key = ...arr-cockpit-bootstrap-secret...
 ```
 
+The `[default]` profile (arr-cockpit user) is for runtime operations: EC2 instances, S3 uploads.
+The `[bootstrap]` profile (arr-cockpit-bootstrap user) is for infrastructure setup: creating/configuring S3 buckets.
+
+These keys are stored in the Cockpit team's Bitwarden (cockpit-infra-accounts).
+
 Note: On some systems, the AWS CLI and Ansible may use the old `~/.aws/credentials` location. Both locations are supported.
+
+S3 buckets
+----------
+
+We use two S3 buckets in the `us-east-1` region:
+
+ * **cockpit-ci-images** - Test images (qcow2 files)
+   - Console: https://us-east-1.console.aws.amazon.com/s3/buckets/cockpit-ci-images
+   - URL: `https://cockpit-ci-images.s3.us-east-1.amazonaws.com/`
+   - Uses per-file ACLs: non-RHEL images are `public-read`, RHEL images are `private`
+   - No lifecycle policy (obsolete images pruned explicitly by tooling)
+
+ * **cockpit-ci-logs** - CI test logs, artifacts, and Prometheus metrics
+   - Console: https://us-east-1.console.aws.amazon.com/s3/buckets/cockpit-ci-logs
+   - URL: `https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/`
+   - Public read via bucket policy (no per-file ACLs needed)
+   - 90-day lifecycle policy for automatic cleanup
+
+Create or update both buckets with:
+
+    ansible-playbook aws/setup-s3-buckets.yml
 
 SSH key
 -------

--- a/ansible/aws/aws_defaults.yml
+++ b/ansible/aws/aws_defaults.yml
@@ -10,6 +10,10 @@ aws_coreos_owner: "125523088429"
 aws_coreos_filter: "Fedora CoreOS stable *"
 aws_coreos_defaultuser: "core"
 
+# S3 buckets for CI
+aws_s3_images_bucket: cockpit-ci-images
+aws_s3_logs_bucket: cockpit-ci-logs
+
 # CI secrets repository
 ci_secrets_repo: git@gitlab.cee.redhat.com:front-door-ci-wranglers/ci-secrets.git
 # use a directory which is guaranteed to be on tmpfs

--- a/ansible/aws/aws_defaults.yml
+++ b/ansible/aws/aws_defaults.yml
@@ -9,3 +9,8 @@ aws_rhel_ami: ami-03a454637e4aa453d
 aws_coreos_owner: "125523088429"
 aws_coreos_filter: "Fedora CoreOS stable *"
 aws_coreos_defaultuser: "core"
+
+# CI secrets repository
+ci_secrets_repo: git@gitlab.cee.redhat.com:front-door-ci-wranglers/ci-secrets.git
+# use a directory which is guaranteed to be on tmpfs
+ci_secrets_dir: "{{ lookup('env', 'XDG_RUNTIME_DIR') }}/ci-secrets"

--- a/ansible/aws/setup-s3-buckets.yml
+++ b/ansible/aws/setup-s3-buckets.yml
@@ -1,0 +1,80 @@
+---
+- name: Setup S3 buckets for Cockpit CI
+  hosts: localhost
+  gather_facts: false
+  vars_files: aws_defaults.yml
+
+  # Use arr-cockpit-bootstrap credentials for bucket creation/configuration
+  # Override with: ansible-playbook -e aws_profile=default
+  vars:
+    aws_profile: bootstrap
+
+  tasks:
+    # https://us-east-1.console.aws.amazon.com/s3/buckets/cockpit-ci-images?region=us-east-1
+    - name: Create and configure images bucket
+      amazon.aws.s3_bucket:
+        name: "{{ aws_s3_images_bucket }}"
+        state: present
+        region: "{{ aws_region }}"
+        profile: "{{ aws_profile }}"
+        # Enable per-file ACLs: non-RHEL images get public-read, RHEL images get private
+        object_ownership: ObjectWriter
+        public_access:
+          # Allow per-file public ACLs, but prevent bucket-wide public policies
+          block_public_acls: false
+          ignore_public_acls: false
+          block_public_policy: true
+          restrict_public_buckets: true
+        tags:
+          app-code: ARR-001
+          cost-center: 700
+          service-owner: cockpit
+          service-phase: prod
+
+    #https://us-east-1.console.aws.amazon.com/s3/buckets/cockpit-ci-logs?region=us-east-1
+    - name: Create and configure logs bucket
+      amazon.aws.s3_bucket:
+        name: "{{ aws_s3_logs_bucket }}"
+        state: present
+        region: "{{ aws_region }}"
+        profile: "{{ aws_profile }}"
+        # Use bucket policy for public-read GET, authenticated PUT/DELETE
+        object_ownership: BucketOwnerEnforced
+        public_access:
+          # Allow bucket policy for public read access
+          block_public_acls: true
+          ignore_public_acls: true
+          block_public_policy: false
+          restrict_public_buckets: false
+        policy:
+          # Policy language version (magic constant)
+          # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html
+          Version: '2012-10-17'
+          Statement:
+            # Allow public read access to all objects
+            - Sid: PublicReadGetObject
+              Effect: Allow
+              Principal: '*'
+              Action: 's3:GetObject'
+              Resource: 'arn:aws:s3:::{{ aws_s3_logs_bucket }}/*'
+        tags:
+          app-code: ARR-001
+          cost-center: 700
+          service-owner: cockpit
+          service-phase: prod
+
+    - name: Set lifecycle policy on logs bucket (90-day expiration)
+      community.aws.s3_lifecycle:
+        name: "{{ aws_s3_logs_bucket }}"
+        state: present
+        region: "{{ aws_region }}"
+        profile: "{{ aws_profile }}"
+        rule_id: expire-after-90-days
+        status: enabled
+        expiration_days: 90
+
+    - name: Display bucket URLs
+      debug:
+        msg:
+          - "Images bucket: https://{{ aws_s3_images_bucket }}.s3.{{ aws_region }}.amazonaws.com/"
+          - "Logs bucket: https://{{ aws_s3_logs_bucket }}.s3.{{ aws_region }}.amazonaws.com/"

--- a/ansible/roles/local-secrets-archive/tasks/main.yml
+++ b/ansible/roles/local-secrets-archive/tasks/main.yml
@@ -1,12 +1,14 @@
 ---
+ - name: Include AWS defaults
+   include_vars: "{{ role_path }}/../../aws/aws_defaults.yml"
+
  - name: Clone secrets repository
    delegate_to: localhost
    run_once: yes
    become: false
    git:
-     repo: git@gitlab.cee.redhat.com:front-door-ci-wranglers/ci-secrets.git
-     # use a directory which is guaranteed to be on tmpfs
-     dest: "{{ lookup('env', 'XDG_RUNTIME_DIR') }}/ci-secrets"
+     repo: "{{ ci_secrets_repo }}"
+     dest: "{{ ci_secrets_dir }}"
      depth: 1
 
  # copy module is waaaay to slow for recursive directory copy; only upload one tarball
@@ -17,4 +19,4 @@
    become: false
    run_once: yes
    shell: |
-     tar -C $XDG_RUNTIME_DIR/ci-secrets  -hz --hard-dereference -c webhook s3-keys s3-server tasks > $XDG_RUNTIME_DIR/ci-secrets.tar.gz
+     tar -C {{ ci_secrets_dir }}  -hz --hard-dereference -c webhook s3-keys s3-server tasks > $XDG_RUNTIME_DIR/ci-secrets.tar.gz

--- a/ansible/roles/tasks-systemd/tasks/main.yml
+++ b/ansible/roles/tasks-systemd/tasks/main.yml
@@ -91,10 +91,9 @@
 
       [logs.s3]
       # bots lib/stores.py LOG_STORE
-      url = 'https://cockpit-logs.us-east-1.linodeobjects.com/'
-      key = [{file="/run/secrets/s3-keys/cockpit-logs.us-east-1.linodeobjects.com"}]
-      proxy_url = 'https://logs-cockpit.apps.ocp.cloud.ci.centos.org/'
-      acl = 'authenticated-read'
+      url = 'https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/'
+      key = [{file="/run/secrets/s3-keys/s3.us-east-1.amazonaws.com"}]
+      acl = ''  # BucketOwnerEnforced - bucket policy handles public access, ACLs disabled
 
       [container]
       command = ['podman-remote', '--url=unix:///podman.sock']

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,6 +1,6 @@
 # Cockpit CI metrics
 
-Our CI system regularly [builds](https://github.com/cockpit-project/bots/blob/main/prometheus-stats) a [metrics file](https://prometheus.io/docs/instrumenting/exposition_formats/) which is stored on our log S3 bucket]: https://cockpit-logs.us-east-1.linodeobjects.com/prometheus
+Our CI system regularly [builds](https://github.com/cockpit-project/bots/blob/main/prometheus-stats) a [metrics file](https://prometheus.io/docs/instrumenting/exposition_formats/) which is stored on our [logs S3 bucket](https://cockpit-ci-logs.s3.us-east-1.amazonaws.com/prometheus).
 
 These kubernetes resources deploy [Prometheus](https://prometheus.io/) to
 regularly read these metrics and store them in a database, and [Grafana](https://grafana.com/) to visualize these metrics as graphs.

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -100,7 +100,7 @@ data:
       metrics_path: /prometheus
       scheme: https
       static_configs:
-      - targets: ['cockpit-logs.us-east-1.linodeobjects.com']
+      - targets: ['cockpit-ci-logs.s3.us-east-1.amazonaws.com']
 
 ---
 kind: ConfigMap


### PR DESCRIPTION
Part of https://github.com/cockpit-project/bots/issues/9003 and https://redhat.atlassian.net/browse/COCKPIT-1833

I already ran the new bucket deployment playbook. @jelly, @allisonkarlitskaya you (and everyone else with Cockpit Bitwarden access) should already be able to do that. These are the same credentials as for the `aws` CLI (Fedora package `awscli2`), which allows you to do everything the web UI can. Access to the latter still has to be set up at least for @jelle, not sure about @allisonkarlitskaya

I did *not* yet deploy the actual switch-over from the topmost commit. That goes together with https://github.com/cockpit-project/bots/pull/9013 and both should be reviewed/approved first. Then the landing and deployment need to happen in lockstep. I'm fine to do that, if either of you wants to do that, even better of course.

See https://github.com/cockpit-project/bots/issues/9003 for the master plan and details how I tested this.

 - [x] Deploy S3 secrets
 - [x] Deploy `setup-s3-buckets.yml`
 - [x] Land after https://github.com/cockpit-project/bots/pull/9013
 - [x] Deploy new tasks and metrics config
   - [x] tasks
   - [x] metrics
