### PR TITLE
ansible: Add maintenance playbook for updating users

### DIFF
--- a/ansible/maintenance/sync-secrets.yml
+++ b/ansible/maintenance/sync-secrets.yml
@@ -8,7 +8,7 @@
     - install-secrets-openshift
 
 - name: Deploy secrets to cloud instances
-  hosts: tag_ServiceName_FrontDoorCI openstack_tasks
+  hosts: tag_service_owner_cockpit openstack_tasks
   gather_facts: false
   roles:
     - install-secrets-dir

--- a/ansible/maintenance/update-users.yml
+++ b/ansible/maintenance/update-users.yml
@@ -1,0 +1,19 @@
+# Update SSH authorized keys on all cloud instances
+---
+- name: Update users on AWS instances
+  hosts: tag_service_owner_cockpit
+  gather_facts: false
+  vars_files: ../aws/aws_defaults.yml
+  roles:
+    - role: users
+      vars:
+        user: "{{ aws_coreos_defaultuser }}"
+
+- name: Update users on OpenStack instances
+  hosts: openstack_tasks
+  gather_facts: false
+  vars_files: ../psi/psi_defaults.yml
+  roles:
+    - role: users
+      vars:
+        user: "{{ psi_user }}"


### PR DESCRIPTION
For rolling out changes to ssh-keys. I previously did some ad-hoc `ansible -m include_role` commands for this, but this is easier and more robust.

---

I tested this with #700 and it worked fine.