### PR TITLE
aws: add a bucket-wide policy on cockpit-ci-images

### DIFF
--- a/ansible/aws/setup-s3-buckets.yml
+++ b/ansible/aws/setup-s3-buckets.yml
@@ -17,14 +17,21 @@
         state: present
         region: "{{ aws_region }}"
         profile: "{{ aws_profile }}"
-        # Enable per-file ACLs: non-RHEL images get public-read, RHEL images get private
-        object_ownership: ObjectWriter
+        # Use bucket policy for public read access (except RHEL images)
+        object_ownership: BucketOwnerEnforced
         public_access:
-          # Allow per-file public ACLs, but prevent bucket-wide public policies
-          block_public_acls: false
-          ignore_public_acls: false
-          block_public_policy: true
-          restrict_public_buckets: true
+          block_public_acls: true
+          ignore_public_acls: true
+          block_public_policy: false
+          restrict_public_buckets: false
+        policy:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: PublicReadNonRhel
+              Effect: Allow
+              Principal: '*'
+              Action: 's3:GetObject'
+              NotResource: 'arn:aws:s3:::{{ aws_s3_images_bucket }}/rhel*'
         tags:
           app-code: ARR-001
           cost-center: 700


### PR DESCRIPTION
Instead of having to worry about setting ACLs on upload, let's make this dirt simple and add a bucket policy to allow unauthenticated downloads only if the filename doesn't start with "rhel".  Otherwise (ie: in order to download RHEL images) you need access to an AWS token which access to read everything.

We only did the ACL stuff with Linode because it's the only tool we had at our disposal.  AWS is a lot more flexible here so let's use it to simplify things.