### PR TITLE
tasks: add python3-gssapi

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -41,6 +41,7 @@ RUN dnf -y update && \
         python3-aioresponses \
         python3-build \
         python3-flake8 \
+        python3-gssapi \
         python3-httpx+http2 python3-respx \
         python3-mypy \
         python3-mwclient \


### PR DESCRIPTION
gssapi is already installed in the container so this just brings a very thin wrapper for it.

This is basically just for type checking: the gssapi import is lazy and won't run in CI but mypy gets unhappy about it.  We could ignore it, but it produces different errors about unused ignores (due to a workaround for another issue).

See https://github.com/cockpit-project/bots/pull/9071 and https://github.com/pythongssapi/python-gssapi/pull/338

 - [x] https://github.com/cockpit-project/cockpituous/actions/runs/26443833073