### PR TITLE
webhook: stop handling issues events

### DIFF
--- a/tasks/container/webhook
+++ b/tasks/container/webhook
@@ -115,8 +115,6 @@ class CockpituousHandler(github_handler.GithubHandler):
             return self.handle_pull_request_event(event, request)
         elif event == 'status':
             return self.handle_status_event(event, request)
-        elif event == 'issues':
-            return self.handle_issues_event(event, request)
         return (501, 'unsupported event ' + event)
 
     def handle_pull_request_event(self, event, request):
@@ -131,7 +129,7 @@ class CockpituousHandler(github_handler.GithubHandler):
         if action == 'closed' and merged:
             logging.info("pull request was merged, ensuring cockpit checkout is latest main")
             ensure_bots_checkout()
-        elif action not in ['opened', 'synchronize', 'edited', 'labeled']:
+        elif action not in ['opened', 'synchronize', 'edited']:
             logging.info("action %s unknown, skipping pull request event", action)
             return None
 
@@ -149,15 +147,6 @@ class CockpituousHandler(github_handler.GithubHandler):
         logging.info('repo: %s; sha: %s; state: %s; description: %s', repo, sha, state, description)
         if not description.rstrip().endswith('(direct trigger)'):
             logging.info("Status description doesn't end with '(direct trigger)', skipping testing")
-            return None
-
-        publish_to_queue('webhook', event, request)
-        return None
-
-    def handle_issues_event(self, event, request):
-        action = request['action']
-        if event == 'issues' and action not in ['edited', 'labeled']:
-            logging.info("action %s unknown, skipping issues event", action)
             return None
 
         publish_to_queue('webhook', event, request)


### PR DESCRIPTION
Now that we no longer drive issue-scan nothing will look at this on the run-queue side.