### PR TITLE
.github/workflows: install httpx instead of aiohttp

### DIFF
--- a/.github/workflows/cleanup-tasks.yml
+++ b/.github/workflows/cleanup-tasks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-aiohttp
+          sudo apt-get install -y python3-httpx
 
       - name: Set up token
         run: |


### PR DESCRIPTION
The bots switched over a long time ago and this workflow has been failing since.