### PR TITLE
.github/workflows: install yarl

### DIFF
--- a/.github/workflows/cleanup-tasks.yml
+++ b/.github/workflows/cleanup-tasks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-httpx
+          sudo apt-get install -y python3-httpx python3-yarl
 
       - name: Set up token
         run: |


### PR DESCRIPTION
Fixup from c1b1e9cbba5fbe822154, bots switched from aiohttp to httpx/yarl.