### PR TITLE
test: relax <html> check in log.html

### DIFF
--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -673,7 +673,7 @@ def test_real_pr(config: Config, request, pod: PodData, bots_sha: str, real_runn
     print(f'----- PR unit-tests log -----\n{log}\n-----------------')
     assert re.search(r'Running on:\s+cockpituous', log)
     assert 'Job ran successfully' in log
-    assert '<html>' in get_s3(config, pod, f'logs/{log_name}.html')
+    assert '<html' in get_s3(config, pod, f'logs/{log_name}.html')
 
     # validate test attachment if we ran cockpituous' own tests
     if pr_repo.endswith('/cockpituous'):


### PR DESCRIPTION
The test currently checks for `<html>` but this is a problem because we have a PR in bots which wants to change it to `<html lang="en">` on the advice of biome.

Relax the check.