### PR TITLE
test: add an empty `test-download` secret

### DIFF
--- a/test/test_deployment.py
+++ b/test/test_deployment.py
@@ -381,6 +381,9 @@ def generate_config(config: Config, forge_opts: str, s3_opts: str, run_args: str
 
         [container.secrets]
         # these are *host* paths, this is podman-remote
+        image-download=[
+            # no RHEL images are tested here
+        ]
         image-upload=[
             '--volume={config.s3_keys}:/run/secrets/s3-keys:ro',
             '--env=COCKPIT_S3_KEY_DIR=/run/secrets/s3-keys',


### PR DESCRIPTION
job-runner currently silently ignores unknown secrets when expanding the podman commandline but it will soon complain about them.  We don't configure an `image-download` secret in test_deployment.py, but `tests-scan` generates jobs with those secrets.

Soon we'll make a change to job-runner which turns this missing secret into a hard error.

Add it.