### PR TITLE
container: Add fedora-distro-aliases

### DIFF
--- a/tasks/container/Containerfile
+++ b/tasks/container/Containerfile
@@ -40,6 +40,7 @@ RUN dnf -y update && \
         python3-aiohttp+speedups \
         python3-aioresponses \
         python3-build \
+        python3-fedora-distro-aliases \
         python3-flake8 \
         python3-gssapi \
         python3-httpx+http2 python3-respx \


### PR DESCRIPTION
This Python module exposes the current active Fedora releases which we can then query in our bots scripts to automate Fedora image related updates.