### PR TITLE
.github/workflows: ensure PRs are proposed from origin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,9 @@ jobs:
       statuses: write
     timeout-minutes: 30
     steps:
+      - name: Ensure branch was proposed from origin
+        run: test "${{ github.event.pull_request.head.repo.url }}" = "${{ github.event.pull_request.base.repo.url }}"
+
       - name: Clone repository
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Our integration testing tries to write a status to real-life GitHub (and has `permissions: statuses: write` to do it) but the permission is only granted if the branch is proposed from origin.

We just scratched our heads for a bit about why a recent PR was failing before realising this.  Add an explicit check (copied from the same test in the bots repo, and for the same reason).