### PR TITLE
.github: Introduce dependabot to update workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 3
+    labels:
+      - "bot"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
In all other projects we keep our workflow actions up to date with dependabot, use it here as well.

---

We have several old actions such as:

.github/workflows/build-tasks.yml:        uses: actions/checkout@v5
